### PR TITLE
Auto-fix spacing issues for aliases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /repos/
 FROM base AS demo-local
 RUN /git-tools/demos/demo-local.ps1
 
+FROM base AS demo-local-with-space
+RUN /git-tools/demos/demo-local-with-space.ps1
+
 FROM base AS demo-remote
 RUN /git-tools/demos/demo-remote.ps1
 
@@ -32,6 +35,7 @@ FROM base as final
 
 WORKDIR /results/
 COPY --from=demo-local /repos/report.txt demo-local-report.txt
+COPY --from=demo-local-with-space /repos/report.txt demo-local-with-space-report.txt
 COPY --from=demo-remote /repos/report.txt demo-remote-report.txt
 COPY --from=demo-remote-without-config /repos/report.txt demo-remote-report-without-config.txt
 COPY --from=demo-remote-release /repos/report.txt demo-remote-report-release.txt

--- a/demos/demo-local-with-space.ps1
+++ b/demos/demo-local-with-space.ps1
@@ -1,0 +1,38 @@
+#!/usr/bin/env pwsh
+
+function ThrowOnNativeFalure {
+    if ($LASTEXITCODE -ne 0) {
+        throw "Native Falure - exit code $LASTEXITCODE"
+    }
+}
+
+& $PSScriptRoot/_setup-existing.ps1
+
+mv /git-tools "/git` tools"
+
+ln -s origin local
+cd local
+. "/git` tools/init.ps1"
+
+git new feature/PS-1
+ThrowOnNativeFalure
+
+if ((git rev-parse main) -ne (git rev-parse HEAD)) {
+    throw 'HEAD does not point to the same commit as main';
+}
+
+if ((git branch --show-current) -ne 'feature/PS-1') {
+    throw 'Branch name did not match expected';
+}
+
+git rc rc/test -branches feature/add-item-1,feature/add-item-2
+ThrowOnNativeFalure
+
+if ((git branch --show-current) -ne 'feature/PS-1') {
+    throw 'Branch name should not have changed';
+}
+
+git verify-updated rc/test
+ThrowOnNativeFalure
+
+git branch > ../report.txt

--- a/init.ps1
+++ b/init.ps1
@@ -1,6 +1,6 @@
 #!/usr/bin/env pwsh
 
-$dir = $PSScriptRoot -replace '\\','/'
+$dir = $PSScriptRoot -replace '\\','/' -replace ' ', '\ '
 
 # Updates self
 git config alias.tool-update "!$dir/init.ps1"


### PR DESCRIPTION
So, `-replaces` can be stacked, so we can use that to have the aliases handle spaces correctly without having users have to edit their `.git/config`