### PR TITLE
Ensure branch is pushed before updating

### DIFF
--- a/config/git/Assert-BranchPushed.mocks.psm1
+++ b/config/git/Assert-BranchPushed.mocks.psm1
@@ -1,0 +1,37 @@
+Import-Module -Scope Local "$PSScriptRoot/Get-Configuration.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../testing/Invoke-MockGitModule.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Assert-BranchPushed.psm1"
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Assert-BranchPushed' @PSBoundParameters
+}
+
+function Initialize-BranchPushed([String] $branchName) {
+    $remote = $(Get-Configuration).remote
+    $remoteBranch = "$remote/$branchName"
+
+    Invoke-MockGit "show-ref --verify --quiet refs/heads/$($branchName)"
+    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name refs/heads/$($branchName)@{u}" -MockWith $remoteBranch
+    Invoke-MockGit "rev-list --count ^$remoteBranch $branchName" -MockWith 0
+}
+
+function Initialize-BranchNotPushed([String] $branchName) {
+    $remote = $(Get-Configuration).remote
+    $remoteBranch = "$remote/$branchName"
+
+    Invoke-MockGit "show-ref --verify --quiet refs/heads/$($branchName)"
+    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name refs/heads/$($branchName)@{u}" -MockWith $remoteBranch
+    Invoke-MockGit "rev-list --count ^$remoteBranch $branchName" -MockWith 1
+}
+
+function Initialize-BranchNoUpstream([String] $branchName) {
+    Invoke-MockGit "show-ref --verify --quiet refs/heads/$($branchName)"
+    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name refs/heads/$($branchName)@{u}" -MockWith $nil
+}
+
+function Initialize-BranchDoesNotExist([String] $branchName) {
+    Invoke-MockGit "show-ref --verify --quiet refs/heads/$($branchName)" -MockWith { $Global:LASTEXITCODE = 1 }
+    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name refs/heads/$($branchName)@{u}" -MockWith $nil
+}
+
+Export-ModuleMember -Function Initialize-BranchPushed, Initialize-BranchNotPushed, Initialize-BranchNoUpstream, Initialize-BranchDoesNotExist

--- a/config/git/Assert-BranchPushed.psm1
+++ b/config/git/Assert-BranchPushed.psm1
@@ -1,0 +1,29 @@
+Import-Module -Scope Local "$PSScriptRoot/Get-Configuration.psm1"
+
+function Assert-BranchPushed([Parameter(Mandatory)][String] $branchName, [Switch] $failIfNoBranch, [Switch] $failIfNoUpstream, [Parameter()][String][Alias('m')] $message) {
+    $config = Get-Configuration
+    if ($config.remote -ne $nil) {
+        # Ensure the branch exists locally
+        git show-ref --verify --quiet refs/heads/$branchName
+        if ($Global:LASTEXITCODE -ne 0) {
+            if ($failIfNoBranch) {
+                throw "Branch $branchName does not exist locally. $message"
+            } else {
+                return
+            }
+        }
+
+        # Get the diff with the remote branch
+        $remoteBranch = git rev-parse --abbrev-ref --symbolic-full-name "refs/heads/$($branchName)@{u}" 2> $nil
+        if ($remoteBranch -ne $nil) {
+            $diff = git rev-list --count ^$remoteBranch $branchName # Number of commits in branch excluding those already pushed
+            if ($diff -ne 0) {
+                throw "Branch $branchName has changes not pushed to $remoteBranch. $message"
+            }
+        } elseif ($failIfNoUpstream) {
+            throw "Branch $branchName does not have a remote tracking branch. $message"
+        }
+    }
+}
+
+Export-ModuleMember -Function Assert-BranchPushed

--- a/config/git/Assert-BranchPushed.tests.ps1
+++ b/config/git/Assert-BranchPushed.tests.ps1
@@ -1,0 +1,81 @@
+BeforeAll {
+    . "$PSScriptRoot/../testing/Lock-Git.mocks.ps1"
+    Import-Module -Scope Local "$PSScriptRoot/Get-Configuration.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Assert-BranchPushed.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Assert-BranchPushed.mocks.psm1"
+}
+
+Describe 'Assert-BranchPushed' {
+    $noLocalBranch = 'Branch my-branch does not exist locally. '
+    $noUpstreamError = 'Branch my-branch does not have a remote tracking branch. '
+    $notPushedError = 'Branch my-branch has changes not pushed to origin/my-branch. '
+    $extraMessage = 'Please try again.'
+
+    # TODO - these are not correct
+    It 'does nothing if no remote is set' {
+        Initialize-ToolConfiguration -noRemote
+        Assert-BranchPushed my-branch
+    }
+
+    It 'does nothing when no remote tracking is set by default' {
+        Initialize-ToolConfiguration
+        Initialize-BranchNoUpstream my-branch
+        Assert-BranchPushed my-branch
+    }
+
+    It 'fails when a remote tracking is not set if requested' {
+        Initialize-ToolConfiguration
+        Initialize-BranchNoUpstream my-branch
+        { Assert-BranchPushed my-branch -failIfNoUpstream } | Should -Throw $noUpstreamError -Because 'no remote tracking branch was set'
+    }
+
+    It 'does nothing when the remote tracking is up-to-date with the local branch' {
+        Initialize-ToolConfiguration
+        Initialize-BranchPushed my-branch
+        Assert-BranchPushed my-branch
+    }
+
+    It 'ignores -failIfNoUpstream if there is an upstream' {
+        Initialize-ToolConfiguration
+        Initialize-BranchPushed my-branch
+        Assert-BranchPushed my-branch -failIfNoUpstream
+    }
+
+    It 'fails when the remote tracking is not up-to-date with the local branch' {
+        Initialize-ToolConfiguration
+        Initialize-BranchNotPushed my-branch
+        { Assert-BranchPushed my-branch } | Should -Throw $notPushedError -Because 'the remote tracking branch was not up-to-date'
+    }
+
+    It 'includes the message for no-upstream' {
+        Initialize-ToolConfiguration
+        Initialize-BranchNoUpstream my-branch
+        { Assert-BranchPushed my-branch -failIfNoUpstream -message $extraMessage }
+            | Should -Throw "$noUpstreamError$extraMessage" -Because 'no remote tracking branch was set'
+    }
+
+    It 'includes the message for not-pushed' {
+        Initialize-ToolConfiguration
+        Initialize-BranchNotPushed my-branch
+        { Assert-BranchPushed my-branch -message $extraMessage }
+            | Should -Throw "$notPushedError$extraMessage" -Because 'the remote tracking branch was not up-to-date'
+    }
+
+    It 'does nothing if the local branch does not exist' {
+        Initialize-ToolConfiguration
+        Initialize-BranchDoesNotExist my-branch
+        Assert-BranchPushed my-branch
+    }
+
+    It 'fails if the local branch does not exist and requested' {
+        Initialize-BranchDoesNotExist my-branch
+        { Assert-BranchPushed my-branch -failIfNoBranch }
+            | Should -Throw "$noLocalBranch" -Because "local branch was required"
+    }
+
+    It 'fails with message if the local branch does not exist and requested' {
+        Initialize-BranchDoesNotExist my-branch
+        { Assert-BranchPushed my-branch -failIfNoBranch -m $extraMessage }
+            | Should -Throw "$noLocalBranch$extraMessage" -Because "local branch was required"
+    }
+}

--- a/config/git/Set-RemoteTracking.mocks.psm1
+++ b/config/git/Set-RemoteTracking.mocks.psm1
@@ -1,0 +1,13 @@
+Import-Module -Scope Local "$PSScriptRoot/../testing/Invoke-MockGitModule.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Get-Configuration.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Set-RemoteTracking.psm1"
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Set-RemoteTracking' @PSBoundParameters
+}
+
+function Initialize-SetRemoteTracking($branchName) {
+    $remote = $(Get-Configuration).remote
+    return Invoke-MockGit "branch --set-upstream-to=refs/heads/$($remote)/$($branchName) $($branchName)"
+}
+Export-ModuleMember -Function Initialize-SetRemoteTracking

--- a/config/git/Set-RemoteTracking.mocks.psm1
+++ b/config/git/Set-RemoteTracking.mocks.psm1
@@ -8,6 +8,6 @@ function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
 
 function Initialize-SetRemoteTracking($branchName) {
     $remote = $(Get-Configuration).remote
-    return Invoke-MockGit "branch --set-upstream-to=refs/heads/$($remote)/$($branchName) $($branchName)"
+    return Invoke-MockGit "branch --set-upstream-to=refs/remotes/$($remote)/$($branchName) $($branchName)"
 }
 Export-ModuleMember -Function Initialize-SetRemoteTracking

--- a/config/git/Set-RemoteTracking.psm1
+++ b/config/git/Set-RemoteTracking.psm1
@@ -1,0 +1,10 @@
+Import-Module -Scope Local "$PSScriptRoot/Get-Configuration.psm1"
+
+function Set-RemoteTracking([String]$branchName) {
+    $config = Get-Configuration
+    git branch --set-upstream-to="refs/heads/$($config.remote)/$($branchName)" $($branchName)
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not set  '$branchName' from '$($source)'"
+    }
+}
+Export-ModuleMember -Function Set-RemoteTracking

--- a/config/git/Set-RemoteTracking.psm1
+++ b/config/git/Set-RemoteTracking.psm1
@@ -2,7 +2,7 @@ Import-Module -Scope Local "$PSScriptRoot/Get-Configuration.psm1"
 
 function Set-RemoteTracking([String]$branchName) {
     $config = Get-Configuration
-    git branch --set-upstream-to="refs/heads/$($config.remote)/$($branchName)" $($branchName)
+    git branch --set-upstream-to="refs/remotes/$($config.remote)/$($branchName)" $($branchName)
     if ($LASTEXITCODE -ne 0) {
         throw "Could not set  '$branchName' from '$($source)'"
     }

--- a/config/git/Set-RemoteTracking.tests.ps1
+++ b/config/git/Set-RemoteTracking.tests.ps1
@@ -1,0 +1,19 @@
+BeforeAll {
+    . "$PSScriptRoot/../testing/Lock-Git.mocks.ps1"
+    Import-Module -Scope Local "$PSScriptRoot/Get-Configuration.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Set-RemoteTracking.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Set-RemoteTracking.psm1"
+    . $PSScriptRoot/../TestUtils.ps1
+}
+
+Describe 'Set-RemoteTracking' {
+    BeforeEach{
+        Initialize-ToolConfiguration
+    }
+
+    It 'tracks feature/FOO-123' {
+        $verifiable = Initialize-SetRemoteTracking 'feature/123'
+        Set-RemoteTracking 'feature/123'
+        Invoke-VerifyMock $verifiable -Times 1
+    }
+}

--- a/docs/pull-upstream.md
+++ b/docs/pull-upstream.md
@@ -1,13 +1,11 @@
 # `git pull-upstream`
 
-Merges all the "upstream" branches into the current branch. Note that this doesn't ensure those branches are up-to-date, only merges them into the current branch.
+Merges all the "upstream" branches into the current branch. Note that this doesn't ensure those branches are up-to-date, only merges them into the current branch. If working with a remote, pushes the merge to the remote.
 
 Usage:
 
-    git-pull-upstream.ps1 [-noFetch]
+    git-pull-upstream.ps1
 
 ## Parameters
 
-### `-noFetch` (Optional)
-
-If specified, do not fetch the latest from the remote (if any).
+`git pull-upstream` does not support parameters at this time.

--- a/git-add-upstream.ps1
+++ b/git-add-upstream.ps1
@@ -67,11 +67,8 @@ $result = Invoke-PreserveBranch {
 
     if (-not $dryRun) {
         if ($config.remote) {
-            if ($config.atomicPushEnabled) {
-				git push $config.remote --atomic "HEAD:$($branchName)" "$($upstreamCommitish):refs/heads/$($config.upstreamBranch)"
-			} else {
-				git push $config.remote "HEAD:$($branchName)" "$($upstreamCommitish):refs/heads/$($config.upstreamBranch)"
-			}
+            $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
+            git push $config.remote @atomicPart "HEAD:$($branchName)" "$($upstreamCommitish):refs/heads/$($config.upstreamBranch)"
         } else {
             git branch -f $config.upstreamBranch $upstreamCommitish
         }

--- a/git-add-upstream.tests.ps1
+++ b/git-add-upstream.tests.ps1
@@ -198,10 +198,10 @@ Describe 'git-add-upstream' {
         Initialize-CleanWorkingDirectory
         Initialize-CurrentBranch 'my-branch'
         Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
-        Initialize-BranchNotPushed 'rc/2022-07-14'
+        Initialize-BranchNoUpstream 'rc/2022-07-14'
 
         { & ./git-add-upstream.ps1 @('feature/FOO-76') -branchName 'rc/2022-07-14' -m "" }
-            | Should -Throw "Branch rc/2022-07-14 has changes not pushed to origin/rc/2022-07-14. Please ensure changes are pushed (or reset) and try again."
+            | Should -Throw "Branch rc/2022-07-14 does not have a remote tracking branch. Please ensure changes are pushed (or reset) and try again."
     }
 
 }

--- a/git-add-upstream.tests.ps1
+++ b/git-add-upstream.tests.ps1
@@ -18,7 +18,6 @@ Describe 'git-add-upstream' {
         Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-MergeBranches.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/config/testing/Invoke-VerifyMock.psm1"
         Import-Module -Scope Local "$PSScriptRoot/config/git/Select-UpstreamBranches.mocks.psm1"
-        Import-Module -Scope Local "$PSScriptRoot/config/git/Get-UpstreamBranch.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-CheckoutBranch.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-PreserveBranch.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/config/git/Update-Git.mocks.psm1"
@@ -120,7 +119,6 @@ Describe 'git-add-upstream' {
     It 'works with a remote' {
         Initialize-ToolConfiguration
         Initialize-UpdateGit
-        Initialize-FetchUpstreamBranch
         Initialize-CleanWorkingDirectory
         Initialize-CurrentBranch 'my-branch'
         Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
@@ -143,7 +141,6 @@ Describe 'git-add-upstream' {
     It 'works with a remote when the target branch doesn''t exist locally' {
         Initialize-ToolConfiguration
         Initialize-UpdateGit
-        Initialize-FetchUpstreamBranch
         Initialize-CleanWorkingDirectory
         Initialize-CurrentBranch 'my-branch'
         Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
@@ -186,7 +183,6 @@ Describe 'git-add-upstream' {
     It 'ensures the remote is up-to-date' {
         Initialize-ToolConfiguration
         Initialize-UpdateGit
-        Initialize-FetchUpstreamBranch
         Initialize-CleanWorkingDirectory
         Initialize-CurrentBranch 'my-branch'
         Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
@@ -199,7 +195,6 @@ Describe 'git-add-upstream' {
     It 'ensures the remote is tracked' {
         Initialize-ToolConfiguration
         Initialize-UpdateGit
-        Initialize-FetchUpstreamBranch
         Initialize-CleanWorkingDirectory
         Initialize-CurrentBranch 'my-branch'
         Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }

--- a/git-new.ps1
+++ b/git-new.ps1
@@ -51,11 +51,8 @@ Invoke-PreserveBranch {
     $(Invoke-MergeBranches ($parentBranches | select -skip 1)).ThrowIfInvalid()
 
     if ($config.remote -ne $nil) {
-		if ($config.atomicPushEnabled) {
-        	git push $config.remote --atomic "$($branchName):refs/heads/$($branchName)" "$($upstreamCommitish):refs/heads/$($config.upstreamBranch)"
-		} else {
-			git push $config.remote "$($branchName):refs/heads/$($branchName)" "$($upstreamCommitish):refs/heads/$($config.upstreamBranch)"
-		}
+        $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
+        git push $config.remote @atomicPart "$($branchName):refs/heads/$($branchName)" "$($upstreamCommitish):refs/heads/$($config.upstreamBranch)"
     } else {
         git branch -f $config.upstreamBranch $upstreamCommitish --quiet
     }

--- a/git-new.ps1
+++ b/git-new.ps1
@@ -19,6 +19,7 @@ Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-CreateBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-CheckoutBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-MergeBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-PreserveBranch.psm1"
+Import-Module -Scope Local "$PSScriptRoot/config/git/Set-RemoteTracking.psm1"
 . $PSScriptRoot/config/git/Set-GitFiles.ps1
 
 $config = Get-Configuration
@@ -48,11 +49,12 @@ Invoke-PreserveBranch {
     Invoke-CreateBranch $branchName $parentBranches[0]
     Invoke-CheckoutBranch $branchName
     Assert-CleanWorkingDirectory # checkouts can change ignored files; reassert clean
-    $(Invoke-MergeBranches ($parentBranches | select -skip 1)).ThrowIfInvalid()
+    $(Invoke-MergeBranches ($parentBranches | Select-Object -skip 1)).ThrowIfInvalid()
 
     if ($config.remote -ne $nil) {
         $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
         git push $config.remote @atomicPart "$($branchName):refs/heads/$($branchName)" "$($upstreamCommitish):refs/heads/$($config.upstreamBranch)"
+        Set-RemoteTracking $branchName
     } else {
         git branch -f $config.upstreamBranch $upstreamCommitish --quiet
     }

--- a/git-new.tests.ps1
+++ b/git-new.tests.ps1
@@ -27,6 +27,7 @@ Describe 'git-new' {
         Import-Module -Scope Local "$PSScriptRoot/config/git/Assert-CleanWorkingDirectory.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-CheckoutBranch.mocks.psm1";
         Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-CreateBranch.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/config/git/Set-RemoteTracking.mocks.psm1"
         Initialize-QuietMergeBranches
     }
 
@@ -88,9 +89,11 @@ Describe 'git-new' {
         Initialize-CleanWorkingDirectory
         Initialize-CreateBranch -branchName 'feature/PS-100-some-work' -source 'origin/main'
         Initialize-CheckoutBranch 'feature/PS-100-some-work'
+        $verifySetRemoteTracking = Initialize-SetRemoteTracking 'feature/PS-100-some-work'
         Mock git -ParameterFilter { ($args -join ' ') -eq 'push origin --atomic feature/PS-100-some-work:refs/heads/feature/PS-100-some-work new-commit:refs/heads/_upstream' } { $Global:LASTEXITCODE = 0 }
 
         & $PSScriptRoot/git-new.ps1 feature/PS-100-some-work -m 'some work'
+        Invoke-VerifyMock $verifySetRemoteTracking -Times 1
     }
 
     It 'creates a remote branch when a remote is configured and an upstream branch is provided' {
@@ -102,9 +105,11 @@ Describe 'git-new' {
         Initialize-CleanWorkingDirectory
         Initialize-CreateBranch -branchName 'feature/PS-100-some-work' -source 'origin/infra/foo'
         Initialize-CheckoutBranch 'feature/PS-100-some-work'
+        $verifySetRemoteTracking = Initialize-SetRemoteTracking 'feature/PS-100-some-work'
         Mock git -ParameterFilter { ($args -join ' ') -eq 'push origin --atomic feature/PS-100-some-work:refs/heads/feature/PS-100-some-work new-commit:refs/heads/_upstream' } { $Global:LASTEXITCODE = 0 }
 
         & $PSScriptRoot/git-new.ps1 feature/PS-100-some-work -from 'infra/foo' -m 'some work'
+        Invoke-VerifyMock $verifySetRemoteTracking -Times 1
     }
 
 }

--- a/git-pull-upstream.ps1
+++ b/git-pull-upstream.ps1
@@ -1,7 +1,6 @@
 #!/usr/bin/env pwsh
 
 Param(
-    [Switch] $noFetch
 )
 
 Import-Module -Scope Local "$PSScriptRoot/config/git/Get-Configuration.psm1"
@@ -11,15 +10,21 @@ Import-Module -Scope Local "$PSScriptRoot/config/git/Select-UpstreamBranches.psm
 Import-Module -Scope Local "$PSScriptRoot/config/git/Assert-CleanWorkingDirectory.psm1"
 Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-MergeBranches.psm1";
 
-if (-not $noFetch) {
-    Update-Git
-}
+$config = Get-Configuration
+
+Update-Git
 $branchName = Get-CurrentBranch
 if ($branchName -eq $nil) {
     throw 'Must have a branch checked out'
 }
+# TODO - check to see if current branch is pulled, too?
+Assert-BranchPushed $branchName -m 'Please ensure changes are pushed (or reset) and try again.' -failIfNoUpstream
 $parentBranches = [String[]](Select-UpstreamBranches $branchName -includeRemote -config $config)
 
 Assert-CleanWorkingDirectory
 $(Invoke-MergeBranches ($parentBranches) -noAbort).ThrowIfInvalid()
 # TODO: If conflicts are detected, recommend an integration branch
+
+if ($config.remote) {
+    git push $config.remote "HEAD:$($branchName)"
+}

--- a/git-pull-upstream.tests.ps1
+++ b/git-pull-upstream.tests.ps1
@@ -1,0 +1,85 @@
+BeforeAll {
+    . "$PSScriptRoot/config/testing/Lock-Git.mocks.ps1"
+
+    # User-interface commands are a bit noisy; TODO: add quiet option and test it by making this throw
+    Mock -CommandName Write-Host {}
+}
+
+Describe 'git-pull-upstream' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/config/git/Assert-CleanWorkingDirectory.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/config/git/Get-Configuration.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/config/git/Get-CurrentBranch.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-MergeBranches.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/config/git/Select-UpstreamBranches.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/config/git/Update-Git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/config/git/Assert-BranchPushed.mocks.psm1"
+        Initialize-QuietMergeBranches
+    }
+
+    It 'works on the current branch' {
+        Initialize-ToolConfiguration -noRemote
+
+        Initialize-CleanWorkingDirectory
+        Initialize-CurrentBranch 'feature/FOO-76'
+        Initialize-BranchPushed 'feature/FOO-76'
+        Initialize-UpstreamBranches @{ 'feature/FOO-76' = @("feature/FOO-123","feature/XYZ-1-services") }
+
+        Initialize-InvokeMergeSuccess 'feature/FOO-123'
+        Initialize-InvokeMergeSuccess 'feature/XYZ-1-services'
+
+        & ./git-pull-upstream.ps1
+    }
+
+    It 'works on the current branch and leaves conflicts' {
+        Initialize-ToolConfiguration -noRemote
+
+        Initialize-CleanWorkingDirectory
+        Initialize-CurrentBranch 'feature/FOO-76'
+        Initialize-BranchPushed 'feature/FOO-76'
+        Initialize-UpstreamBranches @{ 'feature/FOO-76' = @("feature/FOO-123","feature/XYZ-1-services") }
+
+        Initialize-InvokeMergeFailure 'feature/FOO-123'
+
+        { & ./git-pull-upstream.ps1 }
+            | Should -Throw "Could not complete the merge."
+    }
+
+    It 'works with a remote' {
+        Initialize-ToolConfiguration
+        Initialize-UpdateGit
+        Initialize-CleanWorkingDirectory
+        Initialize-CurrentBranch 'feature/FOO-76'
+        Initialize-BranchPushed 'feature/FOO-76'
+        Initialize-UpstreamBranches @{ 'feature/FOO-76' = @("feature/FOO-123","feature/XYZ-1-services") }
+
+        Initialize-InvokeMergeSuccess 'origin/feature/FOO-123'
+        Initialize-InvokeMergeSuccess 'origin/feature/XYZ-1-services'
+
+        Mock git -ParameterFilter { ($args -join ' ') -eq 'push origin HEAD:feature/FOO-76' } { $Global:LASTEXITCODE = 0 }
+
+        & ./git-pull-upstream.ps1
+    }
+
+    It 'ensures the remote is up-to-date' {
+        Initialize-ToolConfiguration
+        Initialize-UpdateGit
+        Initialize-CleanWorkingDirectory
+        Initialize-CurrentBranch 'feature/FOO-76'
+        Initialize-BranchNotPushed 'feature/FOO-76'
+
+        { & ./git-pull-upstream.ps1 }
+            | Should -Throw "Branch feature/FOO-76 has changes not pushed to origin/feature/FOO-76. Please ensure changes are pushed (or reset) and try again."
+    }
+
+    It 'ensures the remote is tracked' {
+        Initialize-ToolConfiguration
+        Initialize-UpdateGit
+        Initialize-CleanWorkingDirectory
+        Initialize-CurrentBranch 'feature/FOO-76'
+        Initialize-BranchNoUpstream 'feature/FOO-76'
+
+        { & ./git-pull-upstream.ps1 }
+            | Should -Throw "Branch feature/FOO-76 does not have a remote tracking branch. Please ensure changes are pushed (or reset) and try again."
+    }
+}

--- a/git-verify-updated.ps1
+++ b/git-verify-updated.ps1
@@ -19,6 +19,8 @@ if (-not $noFetch) {
 
 $noneSpecified = ($branchName -eq $nil -OR $branchName -eq '')
 $branchName = $noneSpecified ? (Get-CurrentBranch) : $branchName
+Assert-BranchPushed $branchName -m 'Please ensure changes are pushed (or reset) and try again.' -failIfNoUpstream
+
 $fullBranchName = $noneSpecified -OR $config.remote -eq $nil ? $branchName
     : "$($config.remote)/$($branchName)"
 if ($fullBranchName -eq $nil) {

--- a/reset.psm1
+++ b/reset.psm1
@@ -1,8 +1,9 @@
 # Useful for development to reset all of our modules
 
 function Reset-GitModules() {
-    Get-ChildItem -Path "$PSScriptRoot" -Include "*.psm1" -Recurse | ForEach-Object {
-        Write-Host "Loading $($_.FullName)"
-        Import-Module -Scope Local $_.FullName -Force
+    $localModules = ((Get-ChildItem -Path "." -Include "*.psm1" -Recurse) | ForEach-Object { $_.FullName })
+    Get-Module -All | Where-Object { $localModules -contains $_.Path } | ForEach-Object {
+        Write-Host "Unloading $($_.Name)..."
+        Remove-Module $_.Name -Force
     }
 }


### PR DESCRIPTION
Adds to `pull-upstream`, `add-upstream`, and `verify-updated` a check to make sure the branch in question, if local, has all commits pushed to the remote.

This also includes some code cleanliness work.

Resolves #35 