### PR TITLE
Fix bugs

### DIFF
--- a/config/git/Assert-BranchPushed.mocks.psm1
+++ b/config/git/Assert-BranchPushed.mocks.psm1
@@ -11,7 +11,7 @@ function Initialize-BranchPushed([String] $branchName) {
     $remoteBranch = "$remote/$branchName"
 
     Invoke-MockGit "show-ref --verify --quiet refs/heads/$($branchName)"
-    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name refs/heads/$($branchName)@{u}" -MockWith $remoteBranch
+    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name $($branchName)@{u}" -MockWith $remoteBranch
     Invoke-MockGit "rev-list --count ^$remoteBranch $branchName" -MockWith 0
 }
 
@@ -20,18 +20,18 @@ function Initialize-BranchNotPushed([String] $branchName) {
     $remoteBranch = "$remote/$branchName"
 
     Invoke-MockGit "show-ref --verify --quiet refs/heads/$($branchName)"
-    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name refs/heads/$($branchName)@{u}" -MockWith $remoteBranch
+    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name $($branchName)@{u}" -MockWith $remoteBranch
     Invoke-MockGit "rev-list --count ^$remoteBranch $branchName" -MockWith 1
 }
 
 function Initialize-BranchNoUpstream([String] $branchName) {
     Invoke-MockGit "show-ref --verify --quiet refs/heads/$($branchName)"
-    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name refs/heads/$($branchName)@{u}" -MockWith $nil
+    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name $($branchName)@{u}" -MockWith $nil
 }
 
 function Initialize-BranchDoesNotExist([String] $branchName) {
     Invoke-MockGit "show-ref --verify --quiet refs/heads/$($branchName)" -MockWith { $Global:LASTEXITCODE = 1 }
-    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name refs/heads/$($branchName)@{u}" -MockWith $nil
+    Invoke-MockGit "rev-parse --abbrev-ref --symbolic-full-name $($branchName)@{u}" -MockWith $nil
 }
 
 Export-ModuleMember -Function Initialize-BranchPushed, Initialize-BranchNotPushed, Initialize-BranchNoUpstream, Initialize-BranchDoesNotExist

--- a/config/git/Assert-BranchPushed.psm1
+++ b/config/git/Assert-BranchPushed.psm1
@@ -14,7 +14,7 @@ function Assert-BranchPushed([Parameter(Mandatory)][String] $branchName, [Switch
         }
 
         # Get the diff with the remote branch
-        $remoteBranch = git rev-parse --abbrev-ref --symbolic-full-name "refs/heads/$($branchName)@{u}" 2> $nil
+        $remoteBranch = git rev-parse --abbrev-ref --symbolic-full-name "$($branchName)@{u}" 2> $nil
         if ($remoteBranch -ne $nil) {
             $diff = git rev-list --count ^$remoteBranch $branchName # Number of commits in branch excluding those already pushed
             if ($diff -ne 0) {

--- a/demos/demo-remote.ps1
+++ b/demos/demo-remote.ps1
@@ -36,6 +36,9 @@ if ((git branch --show-current) -ne 'feature/PS-1') {
     throw 'Branch name should not have changed';
 }
 
+git pull-upstream rc/test
+ThrowOnNativeFalure
+
 git verify-updated rc/test
 ThrowOnNativeFalure
 

--- a/git-pull-upstream.ps1
+++ b/git-pull-upstream.ps1
@@ -11,6 +11,7 @@ Import-Module -Scope Local "$PSScriptRoot/config/git/Select-UpstreamBranches.psm
 Import-Module -Scope Local "$PSScriptRoot/config/git/Assert-CleanWorkingDirectory.psm1"
 Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-MergeBranches.psm1";
 Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-CheckoutBranch.psm1"
+Import-Module -Scope Local "$PSScriptRoot/config/git/Invoke-PreserveBranch.psm1"
 
 $config = Get-Configuration
 


### PR DESCRIPTION
- Corrects the rev-parse command (`@{u}` gets the remote tracking branch, but cannot allow `refs/heads/` in front, since that part is always assumed for remote tracking branches)
- Adds import for `Restore-GitHead` used within `pull-upstream`

Resolves #42 