### PR TITLE
Remove "reset" script from module

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,9 +60,9 @@ There are also docker integration tests that actually run the git commands; run:
 
     docker build .
 
-Note that, due to the use of `Import-Module`, PowerShell caches scripts in the local environment. This won't affect users when updating, since each git alias launches a new `pwsh` scope. However, for developers, you can use the following commands to pick up changes in any `.psm1` files within this project:
+Note that, due to the use of `Import-Module`, PowerShell caches scripts in the local environment. This won't affect users when updating, since each git alias launches a new `pwsh` scope. However, for developers, you can use the following command to pick up changes in any `.psm1` files within this project:
 
-    import-module ./reset.psm1 -Force; Reset-GitModules
+    ./reset.ps1
 
 ### Demo
 

--- a/reset.ps1
+++ b/reset.ps1
@@ -1,0 +1,6 @@
+# Useful for development to reset all of our modules
+
+Get-Module -All | Where-Object { $_.Path.StartSwith($PSScriptRoot) } | ForEach-Object {
+    Write-Host "Unloading $($_.Name)..."
+    Remove-Module $_.Name -Force
+}

--- a/reset.psm1
+++ b/reset.psm1
@@ -1,8 +1,0 @@
-# Useful for development to reset all of our modules
-
-function Reset-GitModules() {
-    Get-Module -All | Where-Object { $_.Path.StartSwith($PSScriptRoot) } | ForEach-Object {
-        Write-Host "Unloading $($_.Name)..."
-        Remove-Module $_.Name -Force
-    }
-}


### PR DESCRIPTION
As noted in the readme, PS modules get cached; having the reset script in a module itself needlessly complicates testing.