### PR TITLE
Convert `Set-GitFiles` into a module

### DIFF
--- a/config/git/Set-MultipleUpstreamBranches.psm1
+++ b/config/git/Set-MultipleUpstreamBranches.psm1
@@ -1,5 +1,5 @@
 Import-Module -Scope Local "$PSScriptRoot/../../utils/query-state/Get-UpstreamBranch.psm1"
-. $PSScriptRoot/../../utils/git/Set-GitFiles.ps1
+Import-Module -Scope Local "$PSScriptRoot/../../utils/git/Set-GitFiles.psm1"
 . $PSScriptRoot/../core/ArrayToHash.ps1
 
 function Set-MultipleUpstreamBranches(
@@ -8,7 +8,7 @@ function Set-MultipleUpstreamBranches(
 ) {
     $upstreamBranch = Get-UpstreamBranch -fetch
     $contents = $upstreamBanchesByBranchName.Keys | ArrayToHash -getValue { $upstreamBanchesByBranchName[$_] -eq $nil ? $nil : "$($upstreamBanchesByBranchName[$_] -join "`n")`n" }
-    $commitish = Set-GitFiles $contents -m $commitMessage -branchName $upstreamBranch -dryRun
+    $commitish = Set-GitFiles $contents -m $commitMessage -branchName $upstreamBranch
     if ($commitish -eq $nil -OR $commitish -eq '') {
         throw "Failed to create commit"
     }

--- a/config/git/Set-MultipleUpstreamBranches.tests.ps1
+++ b/config/git/Set-MultipleUpstreamBranches.tests.ps1
@@ -22,17 +22,17 @@ Describe 'Set-MultipleUpstreamBranches' {
         It 'sets the git file' {
             Initialize-FetchUpstreamBranch
 
-            Mock git -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify github/my-upstream -q' } { 'upstream-HEAD' }
-            Mock git -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify github/my-upstream^{tree} -q' } { 'upstream-TREE' }
-            Mock git -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter { ($args -join ' ') -eq 'ls-tree upstream-TREE' } {
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify github/my-upstream -q' } { 'upstream-HEAD' }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify github/my-upstream^{tree} -q' } { 'upstream-TREE' }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'ls-tree upstream-TREE' } {
                 "100644 blob 2adfafd75a2c423627081bb19f06dca28d09cd8e`t.dockerignore"
             }
             Initialize-WriteBlob ([Text.Encoding]::UTF8.GetBytes("baz`nbarbaz`n")) 'new-FILE'
-            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries -contains "100644 blob 2adfafd75a2c423627081bb19f06dca28d09cd8e`t.dockerignore" `
                     -AND $treeEntries -contains "100644 blob new-FILE`tfoobar"
             } { return 'new-TREE' }
-            Mock git  -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter { ($args -join ' ') -eq 'commit-tree new-TREE -m Add barbaz to foobar -p upstream-HEAD' } {
+            Mock git  -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'commit-tree new-TREE -m Add barbaz to foobar -p upstream-HEAD' } {
                 'new-COMMIT'
             }
 
@@ -73,9 +73,9 @@ Describe 'Set-MultipleUpstreamBranches' {
         It 'sets the git file' {
             Initialize-FetchUpstreamBranch
 
-            Mock git -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify my-upstream -q' } { 'upstream-HEAD' }
-            Mock git -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify my-upstream^{tree} -q' } { 'upstream-TREE' }
-            Mock git -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter { ($args -join ' ') -eq 'ls-tree upstream-TREE' } {
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify my-upstream -q' } { 'upstream-HEAD' }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify my-upstream^{tree} -q' } { 'upstream-TREE' }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'ls-tree upstream-TREE' } {
                 "100644 blob 2adfafd75a2c423627081bb19f06dca28d09cd8e`t.dockerignore"
             }
             Initialize-WriteBlob ([Text.Encoding]::UTF8.GetBytes("baz`nbarbaz`n")) 'new-FILE'
@@ -83,7 +83,7 @@ Describe 'Set-MultipleUpstreamBranches' {
                 "100644 blob 2adfafd75a2c423627081bb19f06dca28d09cd8e`t.dockerignore",
                 "100644 blob new-FILE`tfoobar"
             ) 'new-TREE'
-            Mock git  -ModuleName 'Set-MultipleUpstreamBranches' -ParameterFilter { ($args -join ' ') -eq 'commit-tree new-TREE -m Add barbaz to foobar -p upstream-HEAD' } {
+            Mock git  -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'commit-tree new-TREE -m Add barbaz to foobar -p upstream-HEAD' } {
                 'new-COMMIT'
             }
 

--- a/utils/git/Set-GitFiles.tests.ps1
+++ b/utils/git/Set-GitFiles.tests.ps1
@@ -1,5 +1,5 @@
 BeforeAll {
-    . $PSScriptRoot/Set-GitFiles.ps1
+    Import-Module -Scope Local "$PSScriptRoot/Set-GitFiles.psm1"
     Import-Module -Scope Local "$PSScriptRoot/../framework.mocks.psm1"
 }
 
@@ -15,7 +15,7 @@ Describe 'Set-GitFiles' {
             } -Verifiable
 
             {
-                Set-GitFiles @{ 'foo' = 'something'; 'foo/bar' = 'something else' } -m 'Test' -branchName 'target' -remote 'origin'
+                Set-GitFiles @{ 'foo' = 'something'; 'foo/bar' = 'something else' } -m 'Test' -branchName 'origin/target'
             } | Should -Throw
 
             Should -Invoke -CommandName git -Times 0
@@ -23,105 +23,90 @@ Describe 'Set-GitFiles' {
     }
     Context 'For new branch' {
         BeforeEach{
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/target -q' } { $global:LASTEXITCODE = 128 }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/target^{tree} -q' } { $global:LASTEXITCODE = 128 }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/target -q' } { $global:LASTEXITCODE = 128 }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/target^{tree} -q' } { $global:LASTEXITCODE = 128 }
         }
 
         It 'adds a single file at the root' {
             Initialize-WriteBlob ([Text.Encoding]::UTF8.GetBytes('something')) 'some-hash'
-            Mock -CommandName Invoke-WriteTree -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries -contains "100644 blob some-hash`tfoo"
             } { return 'root-TREE' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test' } { 'new-commit-hash' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } { $global:LASTEXITCODE = 0 }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test' } { 'new-commit-hash' }
 
-            Set-GitFiles @{ 'foo' = 'something' } -m 'Test' -branchName 'target' -remote 'origin'
-
-            Should -Invoke git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } -Times 1
+            Set-GitFiles @{ 'foo' = 'something' } -m 'Test' -branchName 'origin/target'
         }
         It 'adds a single file' {
             Initialize-WriteBlob ([Text.Encoding]::UTF8.GetBytes('something')) 'some-hash'
-            Mock -CommandName Invoke-WriteTree -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries -contains "100644 blob some-hash`tbar"
             } { return 'foo-TREE' }
-            Mock -CommandName Invoke-WriteTree -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries -contains "040000 tree foo-TREE`tfoo"
             } { return 'root-TREE' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test' } { 'new-commit-hash' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } { $global:LASTEXITCODE = 0 }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test' } { 'new-commit-hash' }
 
-            Set-GitFiles @{ 'foo/bar' = 'something' } -m 'Test' -branchName 'target' -remote 'origin'
-
-            Should -Invoke git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } -Times 1
+            Set-GitFiles @{ 'foo/bar' = 'something' } -m 'Test' -branchName 'origin/target'
         }
         # TODO: looks like Pester's Mock doesn't support testing stdin, which this would really need for a proper test
         # It 'adds multiple files' {
-        #     Set-GitFiles @{ 'foo/bar' = 'something'; 'foo/baz' = 'something else' } -m 'Test' -branchName 'target' -remote 'origin'
+        #     Set-GitFiles @{ 'foo/bar' = 'something'; 'foo/baz' = 'something else' } -m 'Test' -branchName 'origin/target'
         # }
     }
     Context 'For an existing new branch' {
         BeforeEach{
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/target -q' } { 'prev-commit-hash' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/target^{tree} -q' } { 'prev-tree' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'ls-tree prev-tree' } { "100644 blob existing-hash`texisting" }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/target -q' } { 'prev-commit-hash' }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/target^{tree} -q' } { 'prev-tree' }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'ls-tree prev-tree' } { "100644 blob existing-hash`texisting" }
         }
 
         It 'adds a single file' {
             Initialize-WriteBlob ([Text.Encoding]::UTF8.GetBytes('something')) 'some-hash'
-            Mock -CommandName Invoke-WriteTree -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries -contains "100644 blob some-hash`tbar"
             } { return 'foo-TREE' }
-            Mock -CommandName Invoke-WriteTree -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries -contains "040000 tree foo-TREE`tfoo" `
                 -AND $treeEntries -contains "100644 blob existing-hash`texisting"
             } { return 'root-TREE' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test -p prev-commit-hash' } { 'new-commit-hash' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } { $global:LASTEXITCODE = 0 }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test -p prev-commit-hash' } { 'new-commit-hash' }
 
-            Set-GitFiles @{ 'foo/bar' = 'something' } -m 'Test' -branchName 'target' -remote 'origin'
-
-            Should -Invoke git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } -Times 1
+            Set-GitFiles @{ 'foo/bar' = 'something' } -m 'Test' -branchName 'origin/target'
         }
         # TODO: looks like Pester's Mock doesn't support testing stdin, which this would really need for a proper test
         # It 'adds multiple files' {
-        #     Set-GitFiles @{ 'foo/bar' = 'something'; 'foo/baz' = 'something else' } -m 'Test' -branchName 'target' -remote 'origin'
+        #     Set-GitFiles @{ 'foo/bar' = 'something'; 'foo/baz' = 'something else' } -m 'Test' -branchName 'origin/target'
         # }
         It 'replaces a file' {
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'ls-tree prev-tree' } { "100644 blob existing-foo-hash`tfoo" }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'ls-tree existing-foo-hash' } { "100644 blob old-baz-hash`tbaz" }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'ls-tree prev-tree' } { "100644 blob existing-foo-hash`tfoo" }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'ls-tree existing-foo-hash' } { "100644 blob old-baz-hash`tbaz" }
             Initialize-WriteBlob ([Text.Encoding]::UTF8.GetBytes('something new')) 'some-hash'
-            Mock -CommandName Invoke-WriteTree -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries -contains "100644 blob some-hash`tbaz" `
                     -AND $treeEntries.length -eq 1
             } { return 'foo-TREE' }
-            Mock -CommandName Invoke-WriteTree -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries -contains "040000 tree foo-TREE`tfoo" `
                     -AND $treeEntries.length -eq 1
             } { return 'root-TREE' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test -p prev-commit-hash' } { 'new-commit-hash' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } { $global:LASTEXITCODE = 0 }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test -p prev-commit-hash' } { 'new-commit-hash' }
 
-            Set-GitFiles @{ 'foo/baz' = 'something new' } -m 'Test' -branchName 'target' -remote 'origin'
-
-            Should -Invoke git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } -Times 1
+            Set-GitFiles @{ 'foo/baz' = 'something new' } -m 'Test' -branchName 'origin/target'
         }
         # TODO: looks like Pester's Mock doesn't support testing stdin, which this would really need for a proper test
         # It 'replaces a file and adds a file' {
-        #     Set-GitFiles @{ 'foo/bar' = 'something new'; 'foo/baz' = 'something blue' } -m 'Test' -branchName 'target' -remote 'origin'
+        #     Set-GitFiles @{ 'foo/bar' = 'something new'; 'foo/baz' = 'something blue' } -m 'Test' -branchName 'origin/target'
         # }
         It 'removes a file' {
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'ls-tree prev-tree' } { "100644 blob existing-foo-hash`tfoo" }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'ls-tree existing-foo-hash' } { "100644 blob old-baz-hash`tbaz" }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'ls-tree prev-tree' } { "100644 blob existing-foo-hash`tfoo" }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'ls-tree existing-foo-hash' } { "100644 blob old-baz-hash`tbaz" }
             Initialize-WriteBlob ([Text.Encoding]::UTF8.GetBytes('something')) 'some-hash'
-            Mock -CommandName Invoke-WriteTree -ParameterFilter {
+            Mock -CommandName Invoke-WriteTree -ModuleName 'Set-GitFiles' -ParameterFilter {
                 $treeEntries.length -eq 0
             } { return 'root-TREE' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test -p prev-commit-hash' } { 'new-commit-hash' }
-            Mock git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } { $global:LASTEXITCODE = 0 }
+            Mock git -ModuleName 'Set-GitFiles' -ParameterFilter { ($args -join ' ') -eq 'commit-tree root-TREE -m Test -p prev-commit-hash' } { 'new-commit-hash' }
 
-            Set-GitFiles @{ 'foo/baz' = $nil } -m 'Test' -branchName 'target' -remote 'origin'
-
-            Should -Invoke git -ParameterFilter { ($args -join ' ') -eq 'push origin new-commit-hash:target' } -Times 1
+            Set-GitFiles @{ 'foo/baz' = $nil } -m 'Test' -branchName 'origin/target'
         }
     }
 }


### PR DESCRIPTION
- Removes `git push` from `Set-GitFiles` since it was always used in `-dryRun` mode
- Converts `Set-GitFiles` to a powershell module