### PR TITLE
Add tests (and correct) parameterizing from JSON

### DIFF
--- a/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
@@ -21,9 +21,12 @@ function ConvertFrom-ParameterizedAnything(
     } elseif ($script -is [array]) {
         $result = ConvertFrom-ParameterizedArray @PSBoundParameters -convertFromParameterized ${function:ConvertFrom-ParameterizedAnything}
         return $result
-    } elseif ($script -is [PSObject]) {
+    } elseif ($script -is [PSObject] -or $script -is [PSCustomObject] -or $script -is [Hashtable]) {
         $result = ConvertFrom-ParameterizedObject @PSBoundParameters -convertFromParameterized ${function:ConvertFrom-ParameterizedAnything}
         return $result
+    } else {
+        Add-ErrorDiagnostic $diagnostics "Unknown type $($script.GetType().FullName) when parameterizing"
+        return @{ result = $null; fail = $true }
     }
 }
 

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
@@ -9,8 +9,9 @@ Describe 'ConvertFrom-ParameterizedAnything' {
     }
 
     It 'can evaluate parameters in objects nested in arrays' {
+        $target = @('foo', @{ '$($params.foo)' = '$($params.baz)' })
         $params = @{ foo = 'bar'; baz = 'woot' }
-        $result = ConvertFrom-ParameterizedAnything @('foo', @{ '$($params.foo)' = '$($params.baz)' }) -params $params -actions @{} -failOnError
+        $result = ConvertFrom-ParameterizedAnything $target -params $params -actions @{} -failOnError
         $result.result.Count | Should -Be 2
         $result.result[0] | Should -Be 'foo'
         $result.result[1] | Assert-ShouldBeObject @{ 'bar'= 'woot' }
@@ -18,6 +19,25 @@ Describe 'ConvertFrom-ParameterizedAnything' {
 
     It 'can evaluate parameters in arrays nested in objects' {
         $target = @{ 'foo' = @('$($params.foo -join ",")', '$($params.banter)'); 'baz' = '$($params.banter)' }
+        $params = @{ foo = @('bar', 'baz'); banter = @('woot') }
+        $result = ConvertFrom-ParameterizedAnything $target -params $params -actions @{} -failOnError
+        $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }
+    }
+    
+    
+    It 'can evaluate parameters in objects nested in arrays when converting from json' {
+        $target = @('foo', @{ '$($params.foo)' = '$($params.baz)' })
+        $target = $target | ConvertTo-Json | ConvertFrom-Json
+        $params = @{ foo = 'bar'; baz = 'woot' }
+        $result = ConvertFrom-ParameterizedAnything $target -params $params -actions @{} -failOnError
+        $result.result.Count | Should -Be 2
+        $result.result[0] | Should -Be 'foo'
+        $result.result[1] | Assert-ShouldBeObject @{ 'bar'= 'woot' }
+    }
+
+    It 'can evaluate parameters in arrays nested in objects' {
+        $target = @{ 'foo' = @('$($params.foo -join ",")', '$($params.banter)'); 'baz' = '$($params.banter)' }
+        $target = $target | ConvertTo-Json | ConvertFrom-Json
         $params = @{ foo = @('bar', 'baz'); banter = @('woot') }
         $result = ConvertFrom-ParameterizedAnything $target -params $params -actions @{} -failOnError
         $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }

--- a/utils/scripting/ConvertFrom-ParameterizedObject.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedObject.tests.ps1
@@ -23,16 +23,24 @@ Describe 'ConvertFrom-ParameterizedObject' {
     }
 
     It 'can evaluate key parameters' {
-        $target = @{ 'foo' = 'bar baz'; 'baz' = '$($params.banter)' }
-        $params = @{ banter = @('woot') }
+        $target = @{ 'foo' = 'bar baz'; '$($params.banter)' = 'woot' }
+        $params = @{ banter = 'baz' }
         $result = ConvertFrom-ParameterizedObject $target -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Assert-ShouldBeObject @{ 'foo' = 'bar baz'; 'baz' = 'woot' }
         $result.fail | Should -Be $false
     }
 
     It 'can evaluate key and value parameters' {
-        $target = @{ 'foo' = '$($params.foo)'; 'baz' = '$($params.banter)' }
-        $params = @{ foo = @('bar', 'baz'); banter = @('woot') }
+        $target = @{ 'foo' = '$($params.foo)'; '$($params.banter)' = 'woot' }
+        $params = @{ foo = @('bar', 'baz'); banter = 'baz' }
+        $result = ConvertFrom-ParameterizedObject $target -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $result.result | Assert-ShouldBeObject @{ 'foo' = 'bar baz'; 'baz' = 'woot' }
+        $result.fail | Should -Be $false
+    }
+
+    It 'can evaluate key and value parameters when loaded from JSON' {
+        $target = @{ 'foo' = '$($params.foo)'; '$($params.banter)' = 'woot' } | ConvertTo-Json | ConvertFrom-Json
+        $params = @{ foo = @('bar', 'baz'); banter = 'baz' }
         $result = ConvertFrom-ParameterizedObject $target -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Assert-ShouldBeObject @{ 'foo' = 'bar baz'; 'baz' = 'woot' }
         $result.fail | Should -Be $false


### PR DESCRIPTION
The parameterization scripts didn't support what was deserialized from JSON; this corrects that.