### PR TITLE
Ensures diagnostics shows hidden process logs

### DIFF
--- a/utils/framework/diagnostic-framework.psm1
+++ b/utils/framework/diagnostic-framework.psm1
@@ -1,3 +1,4 @@
+Import-Module -Scope Local "$PSScriptRoot/processlog-framework.psm1"
 
 function New-Diagnostics {
     [OutputType([System.Collections.ArrayList])]
@@ -22,10 +23,11 @@ function Add-Diagnostic(
     [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [Parameter(Mandatory)][psobject] $diagnostic
 ) {
-    if ($nil -ne $diagnostics) {
+    if ($null -ne $diagnostics) {
         $diagnostics.Add($diagnostic) *> $null
     } else {
         if ($diagnostic.level -eq 'error') {
+            Show-ProcessLogs
             throw $diagnostic.message
         }
     }
@@ -38,6 +40,13 @@ function Add-ErrorDiagnostic(
     Add-Diagnostic $diagnostics (New-ErrorDiagnostic $message)
 }
 
+function Add-ErrorException(
+    [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
+    [Parameter(Mandatory)][System.Management.Automation.ErrorRecord] $exception
+) {
+    Add-Diagnostic $diagnostics (New-ErrorDiagnostic "$($exception.Exception.Message)`n$($exception.ScriptStackTrace)")
+}
+
 function Add-WarningDiagnostic(
     [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [Parameter(Mandatory)][string] $message
@@ -45,16 +54,25 @@ function Add-WarningDiagnostic(
     Add-Diagnostic $diagnostics (New-WarningDiagnostic $message)
 }
 
+function Get-HasErrorDiagnostic(
+    [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+) {
+    return ($diagnostics | Where-Object { $_.level -eq 'error' }).Count -gt 0
+}
+
 function Assert-Diagnostics(
     [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
 ) {
-    if ($diagnostics -ne $nil) {
-        $shouldExit = $false
+    if ($null -ne $diagnostics) {
+        $shouldExit = Get-HasErrorDiagnostic $diagnostics
+        if ($shouldExit) {
+            Show-ProcessLogs
+            Clear-ProcessLogs
+        }
         foreach ($diagnostic in $diagnostics) {
             switch ($diagnostic.level) {
                 'error' {
                     Write-Host 'ERR:  ' -ForegroundColor Red -BackgroundColor Black -NoNewline
-                    $shouldExit = $true
                 }
                 'warning' {
                     Write-Host 'WARN: ' -ForegroundColor Yellow -BackgroundColor Black -NoNewline
@@ -74,4 +92,4 @@ function Exit-DueToAssert {
     exit 1
 }
 
-Export-ModuleMember -Function New-Diagnostics, Add-ErrorDiagnostic, Add-WarningDiagnostic, Assert-Diagnostics
+Export-ModuleMember -Function New-Diagnostics, Add-ErrorDiagnostic, Add-ErrorException, Add-WarningDiagnostic, Assert-Diagnostics, Get-HasErrorDiagnostic

--- a/utils/framework/diagnostic-framework.tests.ps1
+++ b/utils/framework/diagnostic-framework.tests.ps1
@@ -17,6 +17,36 @@ Describe 'diagnostic-framework' {
             $output | Should -Contain 'WARN: Warning 2'
             $output | Should -Contain 'ERR:  Error 1'
         }
+        
+        It 'allows detection of no errors' {
+            $diag = New-Diagnostics
+            Add-WarningDiagnostic $diag 'Warning 1'
+            Add-WarningDiagnostic $diag 'Warning 2'
+
+            Get-HasErrorDiagnostic $diag | Should -Be $false
+        }
+        
+        It 'allows detection of errors' {
+            $diag = New-Diagnostics
+            Add-WarningDiagnostic $diag 'Warning 1'
+            Add-ErrorDiagnostic $diag 'Error 1'
+            Add-WarningDiagnostic $diag 'Warning 2'
+
+            Get-HasErrorDiagnostic $diag | Should -Be $true
+        }
+        
+        It 'throws for errors but reports all diagnostics' {
+            $diag = New-Diagnostics
+            Add-WarningDiagnostic $diag 'Warning 1'
+            Add-ErrorDiagnostic $diag 'Error 1'
+            Add-WarningDiagnostic $diag 'Warning 2'
+            $output = Register-Diagnostics -throwInsteadOfExit
+            { Assert-Diagnostics $diag } | Should -Throw
+
+            $output | Should -Contain 'WARN: Warning 1'
+            $output | Should -Contain 'WARN: Warning 2'
+            $output | Should -Contain 'ERR:  Error 1'
+        }
 
         It 'does not throw if there are no errors' {
             $diag = New-Diagnostics

--- a/utils/framework/processlog-framework.psm1
+++ b/utils/framework/processlog-framework.psm1
@@ -5,7 +5,7 @@ function Write-ProcessLogs {
     [OutputType([string])]
     Param (
         [Parameter(Mandatory)][string]$processDescription,
-        [Parameter(Mandatory, ValueFromPipeline = $true)][object]$inputLog,
+        [Parameter(Mandatory, ValueFromPipeline = $true)][AllowNull()][object]$inputLog,
         [Switch] $allowSuccessOutput,
         [Switch] $quiet
     )


### PR DESCRIPTION
Currently, if an error occurs in one of the modules that uses process logs, the logs will be removed with no way to retrieve them. This is especially problematic when an error occurs, as @AverageJosh encountered this morning.

This resolves that on main. (This is part of the larger PR at #70.)