### PR TITLE
Improve parameterization

### DIFF
--- a/git-new.json
+++ b/git-new.json
@@ -5,7 +5,7 @@
             "type": "set-upstream",
             "parameters": {
                 "upstreamBranches": {
-                    "$($params.branchName)": ["$($params.upstreamBranches -join ',')"]
+                    "$params.branchName": ["$params.upstreamBranches"]
                 },
                 "message": "Add branch $($params.branchName)$($params.comment -eq '' ? '' : \" for $($params.comment)\")"
             }
@@ -14,8 +14,8 @@
             "id": "create-branch",
             "type": "create-branch",
             "parameters": {
-                "target": "$($params.branchName)",
-                "upstreamBranches": ["$($params.upstreamBranches -join ',')"]
+                "target": "$params.branchName",
+                "upstreamBranches": ["$params.upstreamBranches"]
             }
         }
     ],
@@ -24,15 +24,15 @@
             "type": "set-branches",
             "parameters": {
                 "branches": {
-                    "$($config.upstreamBranch)": "$($actions['set-upstream'].outputs['commit'])",
-                    "$($params.branchName)": "$($actions['create-branch'].outputs['commit'])"
+                    "$config.upstreamBranch": "$actions['set-upstream'].outputs['commit']",
+                    "$params.branchName": "$actions['create-branch'].outputs['commit']"
                 }
             }
         },
         {
             "type": "checkout",
             "parameters": {
-                "HEAD": "$($params.branchName)"
+                "HEAD": "$params.branchName"
             }
         }
     ],

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
@@ -17,6 +17,15 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $result.result[1] | Assert-ShouldBeObject @{ 'bar'= 'woot' }
     }
 
+    It 'can evaluate parameters in objects nested in arrays without extra syntax' {
+        $target = @('foo', @{ '$params.foo' = '$params.baz' })
+        $params = @{ foo = 'bar'; baz = 'woot' }
+        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $result.result.Count | Should -Be 2
+        $result.result[0] | Should -Be 'foo'
+        $result.result[1] | Assert-ShouldBeObject @{ 'bar'= 'woot' }
+    }
+
     It 'can evaluate parameters in arrays nested in objects' {
         $target = @{ 'foo' = @('$($params.foo -join ",")', '$($params.banter)'); 'baz' = '$($params.banter)' }
         $params = @{ foo = @('bar', 'baz'); banter = @('woot') }
@@ -24,6 +33,35 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }
     }
     
+    It 'can evaluate parameters in arrays nested in objects without extra syntax' {
+        $target = @{ 'foo' = @('$params.foo', '$params.banter'); 'baz' = '$params.banter' }
+        $params = @{ foo = @('bar', 'baz'); banter = @('woot') }
+        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }
+    }
+    
+    It 'can evaluate complex strings' {
+        $target = '$($params.foo) and $($params.baz)'
+        $target = $target | ConvertTo-Json | ConvertFrom-Json
+        $params = @{ foo = 'bar'; baz = 'woot' }
+        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $result.result | Should -Be 'bar and woot'
+    }
+    
+    It 'blocks poorly formatted strings' {
+        $target = '$params.foo and $params.baz'
+        $target = $target | ConvertTo-Json | ConvertFrom-Json
+        $params = @{ foo = 'bar'; baz = 'woot' }
+        { ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError } | Should -Throw
+    }
+    
+    It 'can evaluate basic strings' {
+        $target = '$params.foo'
+        $target = $target | ConvertTo-Json | ConvertFrom-Json
+        $params = @{ foo = 'bar'; baz = 'woot' }
+        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $result.result | Should -Be 'bar'
+    }
     
     It 'can evaluate parameters in objects nested in arrays when converting from json' {
         $target = @('foo', @{ '$($params.foo)' = '$($params.baz)' })
@@ -35,7 +73,7 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $result.result[1] | Assert-ShouldBeObject @{ 'bar'= 'woot' }
     }
 
-    It 'can evaluate parameters in arrays nested in objects' {
+    It 'can evaluate parameters in arrays nested in objects when converting from json' {
         $target = @{ 'foo' = @('$($params.foo -join ",")', '$($params.banter)'); 'baz' = '$($params.banter)' }
         $target = $target | ConvertTo-Json | ConvertFrom-Json
         $params = @{ foo = @('bar', 'baz'); banter = @('woot') }

--- a/utils/scripting/ConvertFrom-ParameterizedArray.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedArray.psm1
@@ -18,7 +18,11 @@ function ConvertFrom-ParameterizedArray(
         } else {
             $entry = & $convertFromParameterized -script $_ -config $config -params $params -actions $actions -diagnostics $diagnostics -failOnError:$failOnError
             $fail = $fail -or $entry.fail
-            if ($entry.result -is [string]) {
+            if ($entry.result -is [array]) {
+                foreach ($item in $entry.result) {
+                    $converted.Add($item) *> $null
+                }
+            } elseif ($entry.result -is [string]) {
                 $expanded = Expand-StringArray $entry.result
                 foreach ($item in $expanded) {
                     $converted.Add($item) *> $null

--- a/utils/scripting/ConvertFrom-ParameterizedObject.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedObject.psm1
@@ -22,7 +22,11 @@ function ConvertFrom-ParameterizedObject(
         $fail = $fail -or $entry.fail
         return $entry.result
     } -getKey {
-        $entry = ConvertFrom-ParameterizedString -script $_ -config $config -params $params -actions $actions -diagnostics $diagnostics -failOnError:$failOnError
+        $entry = & $convertFromParameterized -script $_ -config $config -params $params -actions $actions -diagnostics $diagnostics -failOnError:$failOnError
+        if ($entry.result -isnot [string]) {
+            $fail = $true
+            return $null
+        }
         $fail = $fail -or $entry.fail
         return $entry.result
     }


### PR DESCRIPTION
Removes need for always doing `$($params.foo)` for cases where we want to reference the variable without doing string interpolation.

This simplifies `git-new.json` (as shown) and will hopefully reduce total number of mistakes in the scripting.