### PR TITLE
Expand scripting for git-new

### DIFF
--- a/docs/new.md
+++ b/docs/new.md
@@ -5,7 +5,7 @@ Creates a new branch and checks it out from the specified branches
 Usage:
 
     git-new.ps1 [-branchName] <string> [-comment <string>] `
-        [-upstreamBranches <string[]>]
+        [-upstreamBranches <string[]>] [-dryRun]
 
 ## Parameters:
 
@@ -24,3 +24,7 @@ Specifies a comment as part of the commit message for the upstream branch.
 _Aliases: -u, -upstream, -upstreams_
 
 A comma-delimited list of branches (without the remote, if applicable). If not specified, assumes the default service line (see [tool-config](./tool-config.md).)
+
+### `-dryRun` (Optional)
+
+If specified, only test merging, do not push the updates.

--- a/git-new.json
+++ b/git-new.json
@@ -1,11 +1,18 @@
 {
     "local": [
         {
+            "id": "simplify-upstream",
+            "type": "simplify-upstream",
+            "parameters": {
+                "upstreamBranches": ["$params.upstreamBranches"]
+            }
+        },
+        {
             "id": "set-upstream",
             "type": "set-upstream",
             "parameters": {
                 "upstreamBranches": {
-                    "$params.branchName": ["$params.upstreamBranches"]
+                    "$params.branchName": ["$actions['simplify-upstream'].outputs"]
                 },
                 "message": "Add branch $($params.branchName)$($params.comment -eq '' ? '' : \" for $($params.comment)\")"
             }
@@ -15,7 +22,7 @@
             "type": "create-branch",
             "parameters": {
                 "target": "$params.branchName",
-                "upstreamBranches": ["$params.upstreamBranches"]
+                "upstreamBranches": ["$actions['simplify-upstream'].outputs"]
             }
         }
     ],

--- a/git-new.json
+++ b/git-new.json
@@ -45,6 +45,6 @@
         }
     ],
     "output": [
-        "$($params.branchName) is now checked out."
+        "Switched to branch '$($params.branchName)'"
     ]
 }

--- a/git-new.json
+++ b/git-new.json
@@ -21,8 +21,8 @@
             "id": "create-branch",
             "type": "create-branch",
             "parameters": {
-                "target": "$params.branchName",
-                "upstreamBranches": ["$actions['simplify-upstream'].outputs"]
+                "upstreamBranches": ["$actions['simplify-upstream'].outputs"],
+                "mergeMessageTemplate": "Merge '{}' for creation of $($params.branchName)"
             }
         }
     ],
@@ -33,7 +33,8 @@
                 "branches": {
                     "$config.upstreamBranch": "$actions['set-upstream'].outputs['commit']",
                     "$params.branchName": "$actions['create-branch'].outputs['commit']"
-                }
+                },
+                "track": ["$params.branchName"]
             }
         },
         {

--- a/git-new.ps1
+++ b/git-new.ps1
@@ -9,28 +9,19 @@ Param(
 
 Import-Module -Scope Local "$PSScriptRoot/utils/framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/input.psm1"
-$upstreamBranches = Expand-StringArray $upstreamBranches
 
 $diagnostics = New-Diagnostics
 Assert-ValidBranchName $branchName -diagnostics $diagnostics
-$upstreamBranches | Assert-ValidBranchName -diagnostics $diagnostics
 Assert-Diagnostics $diagnostics
 
 Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/git.psm1"
 
-$config = Get-Configuration
 Update-GitRemote
-# default to service line if none provided and config has a service line
-$upstreamBranches = $upstreamBranches.Count -eq 0 ? @( $config.defaultServiceLine ) : $upstreamBranches
-if ($upstreamBranches.length -eq 0) {
-    Add-ErrorDiagnostic $diagnostics 'At least one upstream branch must be specified or the default service line must be set'
-}
-$upstreamBranches = Compress-UpstreamBranches $upstreamBranches -diagnostics $diagnostics
 
 $params = @{
     branchName = $branchName;
-    upstreamBranches = $upstreamBranches;
+    upstreamBranches = Expand-StringArray $upstreamBranches;
     comment = $comment ?? '';
 }
 

--- a/git-new.ps1
+++ b/git-new.ps1
@@ -25,24 +25,22 @@ Param(
 
 Import-Module -Scope Local "$PSScriptRoot/utils/framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/input.psm1"
-
-$diagnostics = New-Diagnostics
-Assert-ValidBranchName $branchName -diagnostics $diagnostics
-Assert-Diagnostics $diagnostics
-
 Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/git.psm1"
-
-Update-GitRemote
+Import-Module -Scope Local "$PSScriptRoot/utils/scripting.psm1"
 
 $params = @{
     branchName = $branchName;
     upstreamBranches = Expand-StringArray $upstreamBranches;
     comment = $comment ?? '';
 }
+$scriptPath = "$PSScriptRoot/git-new.json"
 
-$instructions = Get-Content "$PSScriptRoot/git-new.json" | ConvertFrom-Json
+$diagnostics = New-Diagnostics
+# TODO: move this into a JSON task
+Assert-ValidBranchName $branchName -diagnostics $diagnostics
+Assert-Diagnostics $diagnostics
 
-Import-Module -Scope Local "$PSScriptRoot/utils/scripting.psm1"
-
+Update-GitRemote
+$instructions = Get-Content $scriptPath | ConvertFrom-Json
 Invoke-Script $instructions -params $params -diagnostics $diagnostics -dryRun:$dryRun

--- a/git-new.ps1
+++ b/git-new.ps1
@@ -1,5 +1,21 @@
 #!/usr/bin/env pwsh
 
+<#
+.SYNOPSIS
+    Creates a new branch and checks it out from the specified branches
+
+.PARAMETER branchName
+    Specifies the name of the branch.
+
+.PARAMETER comment
+    Specifies a comment as part of the commit message for the upstream branch.
+
+.PARAMETER upstreamBranches
+    A comma-delimited list of branches (without the remote, if applicable). If not specified, assumes the default service line (see [tool-config](./tool-config.md).)
+
+.PARAMETER dryRun
+    If specified, only test merging, do not push the updates.
+#>
 Param(
     [Parameter(Mandatory)][String] $branchName,
     [Parameter()][Alias('m')][Alias('message')][ValidateLength(1,25)][String] $comment,

--- a/git-new.tests.ps1
+++ b/git-new.tests.ps1
@@ -6,9 +6,6 @@ BeforeAll {
     Import-Module -Scope Local "$PSScriptRoot/utils/git.mocks.psm1"
     Import-Module -Scope Local "$PSScriptRoot/utils/actions.mocks.psm1"
     Initialize-QuietMergeBranches
-
-    # User-interface commands are a bit noisy; TODO: add quiet option and test it by making this throw
-    # Mock -CommandName Write-Host {}
 }
 
 Describe 'git-new' {
@@ -23,9 +20,6 @@ Describe 'git-new' {
             Lock-LocalActionSetUpstream
 
             Initialize-AnyUpstreamBranches
-            Initialize-UpstreamBranches @{
-                'feature/homepage-redesign' = @('infra/upgrade-dependencies')
-            }
         }
 
         It 'halts if the working directory is not clean' {

--- a/git-new.tests.ps1
+++ b/git-new.tests.ps1
@@ -22,17 +22,17 @@ Describe 'git-new' {
             Initialize-AnyUpstreamBranches
         }
 
-        It 'halts if the working directory is not clean' {
-            Initialize-DirtyWorkingDirectory
+        # It 'halts if the working directory is not clean' {
+        #     Initialize-DirtyWorkingDirectory
 
-            Initialize-AssertValidBranchName 'feature/PS-100-some-work'
-            Initialize-LocalActionSetUpstream @{
-                'feature/PS-100-some-work' = 'main'
-            } -commitish 'new-commit'
+        #     Initialize-AssertValidBranchName 'feature/PS-100-some-work'
+        #     Initialize-LocalActionSetUpstream @{
+        #         'feature/PS-100-some-work' = 'main'
+        #     } -commitish 'new-commit'
             
-            { & $PSScriptRoot/git-new.ps1 feature/PS-100-some-work -m 'some work' } | Should -Throw 'ERR:  Git working directory is not clean.'
-            $fw.assertDiagnosticOutput | Should -Contain 'ERR:  Git working directory is not clean.'
-        }
+        #     { & $PSScriptRoot/git-new.ps1 feature/PS-100-some-work -m 'some work' } | Should -Throw 'ERR:  Git working directory is not clean.'
+        #     $fw.assertDiagnosticOutput | Should -Contain 'ERR:  Git working directory is not clean.'
+        # }
 
         It 'handles standard functionality' {
             Initialize-AssertValidBranchName 'feature/PS-100-some-work'
@@ -41,8 +41,9 @@ Describe 'git-new' {
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'main'
                 } -commitish 'new-commit'
-                Initialize-LocalActionCreateBranchSuccess 'feature/PS-100-some-work' `
-                    @('main') 'latest-main'
+                Initialize-LocalActionCreateBranchSuccess `
+                    @('main') 'latest-main' `
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-100-some-work"
                 Initialize-FinalizeActionSetBranches @{
                     _upstream = 'new-commit'
                     'feature/PS-100-some-work' = 'latest-main'
@@ -62,8 +63,9 @@ Describe 'git-new' {
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'main'
                 } -commitish 'new-commit'
-                Initialize-LocalActionCreateBranchSuccess 'feature/PS-100-some-work' `
-                    @('main') 'latest-main'
+                Initialize-LocalActionCreateBranchSuccess `
+                    @('main') 'latest-main' `
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-100-some-work"
                 Initialize-FinalizeActionSetBranches @{
                     _upstream = 'new-commit'
                     'feature/PS-100-some-work' = 'latest-main'
@@ -84,8 +86,9 @@ Describe 'git-new' {
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-600-some-work' = 'infra/foo'
                 } -commitish 'new-commit'
-                Initialize-LocalActionCreateBranchSuccess 'feature/PS-600-some-work' `
-                    @('infra/foo') 'latest-foo'
+                Initialize-LocalActionCreateBranchSuccess `
+                    @('infra/foo') 'latest-foo' `
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-600-some-work"
                 Initialize-FinalizeActionSetBranches @{
                     _upstream = 'new-commit'
                     'feature/PS-600-some-work' = 'latest-foo'
@@ -130,12 +133,13 @@ Describe 'git-new' {
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'main'
                 } -commitish 'new-commit'
-                Initialize-LocalActionCreateBranchSuccess 'feature/PS-100-some-work' `
-                    @('main') 'latest-main'
+                Initialize-LocalActionCreateBranchSuccess `
+                    @('main') 'latest-main' `
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-100-some-work"
                 Initialize-FinalizeActionSetBranches @{
                     _upstream = 'new-commit'
                     'feature/PS-100-some-work' = 'latest-main'
-                }
+                } -track @('feature/PS-100-some-work')
                 Initialize-FinalizeActionCheckout 'feature/PS-100-some-work'
             )
 
@@ -152,12 +156,13 @@ Describe 'git-new' {
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'infra/foo'
                 } -commitish 'new-commit'
-                Initialize-LocalActionCreateBranchSuccess 'feature/PS-100-some-work' `
-                    @('infra/foo') 'latest-foo'
+                Initialize-LocalActionCreateBranchSuccess `
+                    @('infra/foo') 'latest-foo' `
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-100-some-work"
                 Initialize-FinalizeActionSetBranches @{
                     _upstream = 'new-commit'
                     'feature/PS-100-some-work' = 'latest-foo'
-                }
+                } -track @('feature/PS-100-some-work')
                 Initialize-FinalizeActionCheckout 'feature/PS-100-some-work'
             )
 
@@ -176,12 +181,13 @@ Describe 'git-new' {
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = @('feature/homepage-redesign')
                 } -commitish 'new-commit'
-                Initialize-LocalActionCreateBranchSuccess 'feature/PS-100-some-work' `
-                    @('feature/homepage-redesign') 'latest-redesign'
+                Initialize-LocalActionCreateBranchSuccess `
+                    @('feature/homepage-redesign') 'latest-redesign' `
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-100-some-work"
                 Initialize-FinalizeActionSetBranches @{
                     _upstream = 'new-commit'
                     'feature/PS-100-some-work' = 'latest-redesign'
-                }
+                } -track @('feature/PS-100-some-work')
                 Initialize-FinalizeActionCheckout 'feature/PS-100-some-work'
             )
 
@@ -204,12 +210,13 @@ Describe 'git-new' {
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = @('feature/homepage-redesign', 'infra/update-dependencies')
                 } -commitish 'new-commit'
-                Initialize-LocalActionCreateBranchSuccess 'feature/PS-100-some-work' `
-                    @('feature/homepage-redesign', 'infra/update-dependencies') 'merge-result'
+                Initialize-LocalActionCreateBranchSuccess `
+                    @('feature/homepage-redesign', 'infra/update-dependencies') 'merge-result' `
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-100-some-work"
                 Initialize-FinalizeActionSetBranches @{
                     _upstream = 'new-commit'
                     'feature/PS-100-some-work' = 'merge-result'
-                }
+                } -track @('feature/PS-100-some-work')
                 Initialize-FinalizeActionCheckout 'feature/PS-100-some-work'
             )
 
@@ -221,7 +228,7 @@ Describe 'git-new' {
             )
         }
 
-        It 'reports failed merges and does not push' {
+        It 'reports failed merges and does not push if all fail' {
             Initialize-AssertValidBranchName 'feature/PS-100-some-work'
             Initialize-AssertValidBranchName 'feature/homepage-redesign'
             Initialize-AssertValidBranchName 'infra/update-dependencies'
@@ -230,13 +237,39 @@ Describe 'git-new' {
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = @('feature/homepage-redesign', 'infra/update-dependencies')
                 } -commitish 'new-commit'
-                Initialize-LocalActionCreateBranchSuccess 'feature/PS-100-some-work' `
+                Initialize-LocalActionCreateBranchSuccess `
                     @('feature/homepage-redesign', 'infra/update-dependencies') 'merge-result' `
-                    -failAtMerge 1
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-100-some-work" `
+                    -failAtMerge 0
             )
 
-            { & $PSScriptRoot/git-new.ps1 feature/PS-100-some-work -u 'feature/homepage-redesign,infra/update-dependencies' -m 'some work' } | Should -Throw 'ERR:  Failed to merge all branches'
-            $fw.assertDiagnosticOutput | Should -Contain 'ERR:  Failed to merge all branches'
+            { & $PSScriptRoot/git-new.ps1 feature/PS-100-some-work -u 'feature/homepage-redesign,infra/update-dependencies' -m 'some work' } | Should -Throw
+            $fw.assertDiagnosticOutput | Should -Contain 'ERR:  No branches could be resolved to merge'
+            Invoke-VerifyMock $mocks -Times 1
+        }
+
+        It 'reports failed merges but pushes anyway' {
+            Initialize-AssertValidBranchName 'feature/PS-100-some-work'
+            Initialize-AssertValidBranchName 'feature/homepage-redesign'
+            Initialize-AssertValidBranchName 'infra/update-dependencies'
+            
+            $mocks = @(
+                Initialize-LocalActionSetUpstream @{
+                    'feature/PS-100-some-work' = @('feature/homepage-redesign', 'infra/update-dependencies')
+                } -commitish 'new-commit'
+                Initialize-LocalActionCreateBranchSuccess `
+                    @('feature/homepage-redesign', 'infra/update-dependencies') 'merge-result' `
+                    -failAtMerge 1 `
+                    -mergeMessageTemplate "Merge '{}' for creation of feature/PS-100-some-work"
+                Initialize-FinalizeActionSetBranches @{
+                    _upstream = 'new-commit'
+                    'feature/PS-100-some-work' = 'merge-result'
+                } -track @('feature/PS-100-some-work')
+                Initialize-FinalizeActionCheckout 'feature/PS-100-some-work'
+            )
+
+            { & $PSScriptRoot/git-new.ps1 feature/PS-100-some-work -u 'feature/homepage-redesign,infra/update-dependencies' -m 'some work' } | Should -Not -Throw
+            $fw.assertDiagnosticOutput | Should -Contain 'WARN: Could not merge the following branches: origin/infra/update-dependencies'
             Invoke-VerifyMock $mocks -Times 1
         }
     }

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -4,6 +4,9 @@ Export-ModuleMember -Function Lock-LocalActionSetUpstream, Initialize-LocalActio
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionCreateBranch.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionCreateBranchSuccess
 
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionSimplifyUpstreamBranches.mocks.psm1"
+Export-ModuleMember -Function Initialize-LocalActionSimplifyUpstreamBranchesSuccess
+
 Import-Module -Scope Local "$PSScriptRoot/actions/finalize/Register-FinalizeActionCheckout.mocks.psm1"
 Export-ModuleMember -Function Initialize-FinalizeActionCheckout
 

--- a/utils/actions/Invoke-FinalizeAction.psm1
+++ b/utils/actions/Invoke-FinalizeAction.psm1
@@ -19,12 +19,11 @@ function Invoke-FinalizeAction(
     }
 
     # run
-    $displayName = $actionDefinition.displayName ?? $actionDefinition.id ?? "task of type $($actionDefinition.type)"
     $parameters = ConvertTo-Hashtable $actionDefinition.parameters
     try {
         $outputs = & $targetAction @parameters -diagnostics $diagnostics
     } catch {
-        Add-ErrorDiagnostic $diagnostics "Unhandled exception occurred while running '$displayName':"
+        Add-ErrorDiagnostic $diagnostics "Unhandled exception occurred while running '$(ConvertTo-Json $actionDefinition -Depth 10)':"
         Add-ErrorException $diagnostics $_
     }
 

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -25,6 +25,7 @@ function Invoke-LocalAction(
     try {
         $outputs = & $targetAction @parameters -diagnostics $diagnostics
     } catch {
+        Write-Host "ex: $_"
         Add-ErrorDiagnostic $diagnostics "Unhandled exception occurred while running $(ConvertTo-Json $actionDefinition -Depth 10):"
         Add-ErrorException $diagnostics $_
     }

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -2,10 +2,12 @@ Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSetUpstream.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionCreateBranch.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSimplifyUpstreamBranches.psm1"
 
 $localActions = @{}
 Register-LocalActionSetUpstream $localActions
 Register-LocalActionCreateBranch $localActions
+Register-LocalActionSimplifyUpstreamBranches $localActions
 
 function Invoke-LocalAction(
     [PSObject] $actionDefinition,
@@ -19,12 +21,11 @@ function Invoke-LocalAction(
     }
 
     # run
-    $displayName = $actionDefinition.displayName ?? $actionDefinition.id ?? "task of type $($actionDefinition.type)"
     $parameters = ConvertTo-Hashtable $actionDefinition.parameters
     try {
         $outputs = & $targetAction @parameters -diagnostics $diagnostics
     } catch {
-        Add-ErrorDiagnostic $diagnostics "Unhandled exception occurred while running '$displayName':"
+        Add-ErrorDiagnostic $diagnostics "Unhandled exception occurred while running $(ConvertTo-Json $actionDefinition -Depth 10):"
         Add-ErrorException $diagnostics $_
     }
 

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.mocks.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.mocks.psm1
@@ -1,7 +1,9 @@
 Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
 
 function Initialize-FinalizeActionCheckout([string] $HEAD, [switch] $fail) {
+    Initialize-CleanWorkingDirectory
     if (-not $fail) {
         Initialize-CheckoutBranch $HEAD
     } else {

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
@@ -10,7 +10,10 @@ function Register-FinalizeActionCheckout([PSObject] $finalizeActions) {
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
-        Invoke-CheckoutBranch $HEAD -diagnostics $diagnostics
+        Assert-CleanWorkingDirectory -diagnostics $diagnostics
+        if (-not (Get-HasErrorDiagnostic $diagnostics)) {
+            Invoke-CheckoutBranch $HEAD -diagnostics $diagnostics
+        }
     }
 }
 

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.tests.ps1
@@ -14,8 +14,6 @@ Describe 'finalize action "checkout"' {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $diag = $fw.diagnostics
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $output = $fw.assertDiagnosticOutput
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $standardScript = ('{ 
             "type": "checkout", 
             "parameters": {
@@ -27,19 +25,32 @@ Describe 'finalize action "checkout"' {
 
     It 'handles standard functionality' {
         $mocks = @(
+            Initialize-CleanWorkingDirectory
             Invoke-MockGitModule -ModuleName 'Invoke-CheckoutBranch' `
                 -gitCli "checkout new-branch"
         )
         
         Invoke-FinalizeAction $standardScript -diagnostics $diag
-        $diag | Should -Be $null
+        $diag | Should -BeNullOrEmpty
+        Invoke-VerifyMock $mocks -Times 1
+    }
+
+    It 'fails if the working directory is not clean' {
+        $mocks = @(
+            Initialize-DirtyWorkingDirectory
+        )
+        
+        Invoke-FinalizeAction $standardScript -diagnostics $diag
+        { Assert-Diagnostics $diag } | Should -Throw
+        Get-HasErrorDiagnostic $diag | Should -BeTrue
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  Git working directory is not clean.'
         Invoke-VerifyMock $mocks -Times 1
     }
 
     It 'handles standard functionality using mocks' {
         $mocks = Initialize-FinalizeActionCheckout 'new-branch'
         Invoke-FinalizeAction $standardScript -diagnostics $diag
-        $diag | Should -Be $null
+        $diag | Should -BeNullOrEmpty
         Invoke-VerifyMock $mocks -Times 1
     }
 

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.tests.ps1
@@ -9,12 +9,12 @@ Describe 'finalize action "checkout"' {
     }
     
     BeforeEach {
-        Register-Framework
+        $fw = Register-Framework
 
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $diag = New-Diagnostics
+        $diag = $fw.diagnostics
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $output = Register-Diagnostics -throwInsteadOfExit
+        $output = $fw.assertDiagnosticOutput
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $standardScript = ('{ 
             "type": "checkout", 

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1
@@ -2,18 +2,25 @@ Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Register-FinalizeActionSetBranches.psm1"
 
-function Initialize-FinalizeActionSetBranches([Hashtable] $branches, [switch] $fail) {
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' @PSBoundParameters
+}
+
+function Initialize-FinalizeActionSetBranches([Hashtable] $branches, [string[]] $track, [switch] $fail) {
     $config = Get-Configuration
     
     if ($null -ne $config.remote) {
         $atomicPart = $config.atomicPushEnabled ? "--atomic " : ''
         $branchList = ConvertTo-PushBranchList $branches
-        Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' `
-            -gitCli "push $($config.remote) $atomicPart$branchList" `
+        Invoke-MockGit -gitCli "push $($config.remote) $atomicPart$branchList" `
             -MockWith $($fail ? { $Global:LASTEXITCODE = 1 } : {})
+
+        foreach ($branch in $track) {
+            Invoke-MockGit -gitCli "branch $branch --set-upstream-to $($config.remote)/$branch"
+        }
     } else {
         foreach ($key in $branches.Keys) {
-            Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' `
+            Invoke-MockGit `
                 -gitCli "branch $($key) $($branches[$key]) -f" `
                 -MockWith $($fail ? { $Global:LASTEXITCODE = 1 } : {})
         }

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1
@@ -16,6 +16,9 @@ function Initialize-FinalizeActionSetBranches([Hashtable] $branches, [string[]] 
             -MockWith $($fail ? { $Global:LASTEXITCODE = 1 } : {})
 
         foreach ($branch in $track) {
+            Invoke-MockGit `
+                -gitCli "branch $($branch) $($branches[$branch]) -f" `
+                -MockWith $($fail ? { $Global:LASTEXITCODE = 1 } : {})
             Invoke-MockGit -gitCli "branch $branch --set-upstream-to $($config.remote)/$branch"
         }
     } else {

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1
@@ -1,4 +1,5 @@
 Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../input.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Register-FinalizeActionSetBranches.psm1"
 
@@ -9,6 +10,10 @@ function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
 function Initialize-FinalizeActionSetBranches([Hashtable] $branches, [string[]] $track, [switch] $fail) {
     $config = Get-Configuration
     
+    foreach ($branch in $branches.Keys) {
+        Initialize-AssertValidBranchName $branch
+    }
+
     if ($null -ne $config.remote) {
         $atomicPart = $config.atomicPushEnabled ? "--atomic " : ''
         $branchList = ConvertTo-PushBranchList $branches

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -17,6 +17,7 @@ function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
     $finalizeActions['set-branches'] = {
         param(
             [Parameter()] $branches,
+            [Parameter()][AllowEmptyCollection()][string[]] $track,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
@@ -32,7 +33,13 @@ function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
             if ($global:LASTEXITCODE -ne 0) {
                 Add-ErrorDiagnostic $diagnostics "Unable to push updates to $($config.remote)"
             }
-            # TODO: set upstream? We don't even know what the local branches would push to
+            
+
+            foreach ($key in $track) {
+                Invoke-ProcessLogs "git branch $key --set-upstream-to $($config.remote)/$key" {
+                    git branch $key --set-upstream-to "$($config.remote)/$key"
+                }
+            }
         } else {
             foreach ($key in $branches.Keys) {
                 Invoke-ProcessLogs "git branch $key $($branches[$key])" {

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -1,5 +1,6 @@
 Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
@@ -23,6 +24,8 @@ function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
 
         $branches = ConvertTo-Hashtable $branches
         $config = Get-Configuration
+
+        $branches.Keys | Assert-ValidBranchName -diagnostics $diagnostics
 
         if ($null -ne $config.remote) {
             $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -36,6 +36,9 @@ function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
             
 
             foreach ($key in $track) {
+                Invoke-ProcessLogs "git branch $key $($branches[$key])" {
+                    git branch $key $($branches[$key]) -f
+                }
                 Invoke-ProcessLogs "git branch $key --set-upstream-to $($config.remote)/$key" {
                     git branch $key --set-upstream-to "$($config.remote)/$key"
                 }

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
@@ -12,9 +12,9 @@ Describe 'finalize action "set-branches"' {
         $fw = Register-Framework -throwInsteadOfExit
 
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $diag = New-Diagnostics
+        $diag = $fw.diagnostics
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $output = $fw.diagnostics
+        $output = $fw.assertDiagnosticOutput
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $standardScript = ('{ 
             "type": "set-branches", 

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
@@ -2,6 +2,7 @@ Describe 'finalize action "set-branches"' {
     BeforeAll {
         Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../input.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/../Invoke-FinalizeAction.psm1"
         Import-Module -Scope Local "$PSScriptRoot/Register-FinalizeActionSetBranches.mocks.psm1"
@@ -41,6 +42,9 @@ Describe 'finalize action "set-branches"' {
 
         It 'handles standard functionality' {
             $mocks = @(
+                Initialize-AssertValidBranchName '_upstream'
+                Initialize-AssertValidBranchName 'other'
+                Initialize-AssertValidBranchName 'another'
                 Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' `
                     -gitCli "branch _upstream new-upstream-commitish -f"
                 Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' `
@@ -50,14 +54,14 @@ Describe 'finalize action "set-branches"' {
             )
             
             Invoke-FinalizeAction $standardScript -diagnostics $diag
-            $diag | Should -Be $null
+            $diag | Should -BeNullOrEmpty
             Invoke-VerifyMock $mocks -Times 1
         }
 
         It 'handles standard functionality using mocks' {
             $mocks = Initialize-FinalizeActionSetBranches $standardBranches
             Invoke-FinalizeAction $standardScript -diagnostics $diag
-            $diag | Should -Be $null
+            $diag | Should -BeNullOrEmpty
             Invoke-VerifyMock $mocks -Times 1
         }
 
@@ -75,6 +79,9 @@ Describe 'finalize action "set-branches"' {
 
         It 'handles standard functionality' {
             $mocks = @(
+                Initialize-AssertValidBranchName '_upstream'
+                Initialize-AssertValidBranchName 'other'
+                Initialize-AssertValidBranchName 'another'
                 Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' `
                     -gitCli "push origin --atomic new-upstream-commitish:refs/heads/_upstream another-commitish:refs/heads/another other-commitish:refs/heads/other"
             )
@@ -104,6 +111,9 @@ Describe 'finalize action "set-branches"' {
 
         It 'handles standard functionality' {
             $mocks = @(
+                Initialize-AssertValidBranchName '_upstream'
+                Initialize-AssertValidBranchName 'other'
+                Initialize-AssertValidBranchName 'another'
                 Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' `
                     -gitCli "push origin new-upstream-commitish:refs/heads/_upstream another-commitish:refs/heads/another other-commitish:refs/heads/other"
             )

--- a/utils/actions/local/Register-LocalActionCreateBranch.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionCreateBranch.mocks.psm1
@@ -4,34 +4,24 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionCreateBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
 
-
-
 function Initialize-LocalActionCreateBranchSuccess(
-    [Parameter(Mandatory)][string] $target, 
     [Parameter(Mandatory)][string[]] $upstreamBranches, 
     [Parameter(Mandatory)][string] $resultCommitish,
+    [Parameter(Mandatory)][string] $mergeMessageTemplate,
     [Parameter()][int] $failAtMerge = -1
 ) {
     $config = Get-Configuration
     if ($null -ne $config.remote) {
         $upstreamBranches = [string[]]$upstreamBranches | Foreach-Object { "$($config.remote)/$_" }
     }
-    Initialize-CleanWorkingDirectory
-    Initialize-NoCurrentBranch
-    Initialize-PreserveBranchCleanup -detachedHead 'baadf00d'
 
-    Initialize-CreateBranch $target $upstreamBranches[0]
-    Initialize-CheckoutBranch $target
+    $successfulBranches = $failAtMerge -eq -1 ? $upstreamBranches
+        : $failAtMerge -eq 0 ? @()
+        : ($upstreamBranches | Select-Object -First $failAtMerge)
 
-    for ($i = 1; $i -lt $upstreamBranches.Count; $i++) {
-        if ($i -eq $failAtMerge) {
-            Initialize-InvokeMergeFailure $upstreamBranches[$i]
-            return
-        }
-        Initialize-InvokeMergeSuccess $upstreamBranches[$i]
-    }
-
-    Invoke-MockGitModule -ModuleName Register-LocalActionCreateBranch "rev-parse $target" -MockWith $resultCommitish
+    Initialize-MergeTogether $upstreamBranches $successfulBranches `
+        -messageTemplate $mergeMessageTemplate `
+        -resultCommitish $resultCommitish
 }
 
 Export-ModuleMember -Function Initialize-LocalActionCreateBranchSuccess

--- a/utils/actions/local/Register-LocalActionCreateBranch.psm1
+++ b/utils/actions/local/Register-LocalActionCreateBranch.psm1
@@ -2,13 +2,12 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
-# TODO: this action has a side effect that creates the local branch.
 # TODO: this assumes all branches are remotes (if remote is specified)
 function Register-LocalActionCreateBranch([PSObject] $localActions) {
     $localActions['create-branch'] = {
         param(
-            [string] $target,
             [string[]] $upstreamBranches,
+            [string] $mergeMessageTemplate,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
@@ -16,29 +15,13 @@ function Register-LocalActionCreateBranch([PSObject] $localActions) {
         if ($null -ne $config.remote) {
             $upstreamBranches = [string[]]$upstreamBranches | Foreach-Object { "$($config.remote)/$_" }
         }
-        Assert-CleanWorkingDirectory $diagnostics
-        if (Get-HasErrorDiagnostic $diagnostics) { return $null }
 
-        # TODO: update these to use diagnostics
-        Invoke-PreserveBranch {
-            Invoke-CreateBranch $target $upstreamBranches[0]
-            Invoke-CheckoutBranch $target -diagnostics $diagnostics
-            Assert-CleanWorkingDirectory -diagnostics $diagnostics # checkouts can change ignored files; reassert clean
-            if (Get-HasErrorDiagnostic $diagnostics) { return }
-
-            try {
-                # TODO - use diagnostics and record output to processlog
-                $(Invoke-MergeBranches ($upstreamBranches | Select-Object -skip 1) -quiet).ThrowIfInvalid() *> $null
-            } catch {
-                Add-ErrorDiagnostic $diagnostics "Failed to merge all branches"
-            }
+        $mergeResult = Invoke-MergeTogether $upstreamBranches -messageTemplate $mergeMessageTemplate -diagnostics $diagnostics -asWarnings
+        $commit = $mergeResult.result
+        if ($null -eq $commit) {
+            Add-ErrorDiagnostic $diagnostics "No branches could be resolved to merge"
         }
-
-        if (Get-HasErrorDiagnostic $diagnostics) { return }
-
-        $commit = Invoke-ProcessLogs "git rev-parse $target" {
-            git rev-parse $target
-        } -allowSuccessOutput -quiet
+        # TODO - output successfully merged branches
         return @{ commit = $commit }
     }
 }

--- a/utils/actions/local/Register-LocalActionCreateBranch.tests.ps1
+++ b/utils/actions/local/Register-LocalActionCreateBranch.tests.ps1
@@ -17,51 +17,33 @@ Describe 'local action "create-branch"' {
     }
 
     function AddStandardTests() {
-        It 'halts if the working directory is not clean' {
-            Initialize-DirtyWorkingDirectory
-
-            $result = Invoke-LocalAction ('{ 
-                    "type": "create-branch", 
-                    "parameters": {
-                        "target": "foobar",
-                        "upstreamBranches": [
-                            "baz",
-                            "barbaz"
-                        ]
-                    }
-                }' | ConvertFrom-Json) -diagnostics $diag
-            $result | Should -Be $null
-            { Assert-Diagnostics $diag } | Should -Throw
-            $output | Should -Contain 'ERR:  Git working directory is not clean.'
-        }
-
         It 'creates from a single branch' {
-            Initialize-LocalActionCreateBranchSuccess 'foobar' @('baz') 'new-Commit'
+            Initialize-LocalActionCreateBranchSuccess @('baz') 'new-Commit' -mergeMessageTemplate "Merge {}"
 
             $result = Invoke-LocalAction ('{ 
                 "type": "create-branch", 
                 "parameters": {
-                    "target": "foobar",
                     "upstreamBranches": [
                         "baz"
-                    ]
+                    ],
+                    "mergeMessageTemplate": "Merge {}"
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
-            $diag | Should -Be $null
+            $diag | Should -BeNullOrEmpty
             $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
         }
 
         It 'handles standard functionality' {
-            $mocks = Initialize-LocalActionCreateBranchSuccess 'foobar' @('baz', 'barbaz') 'new-Commit'
+            $mocks = Initialize-LocalActionCreateBranchSuccess @('baz', 'barbaz') 'new-Commit' -mergeMessageTemplate "Merge {}"
 
             $result = Invoke-LocalAction ('{ 
                 "type": "create-branch", 
                 "parameters": {
-                    "target": "foobar",
                     "upstreamBranches": [
                         "baz",
                         "barbaz"
-                    ]
+                    ],
+                    "mergeMessageTemplate": "Merge {}"
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
             $diag | Should -Be $null
@@ -69,23 +51,24 @@ Describe 'local action "create-branch"' {
             Invoke-VerifyMock $mocks -Times 1
         }
 
-        It 'reports merge failures' {
-            $mocks = Initialize-LocalActionCreateBranchSuccess 'foobar' @('baz', 'barbaz') 'new-Commit' `
-                -failAtMerge 1
+        It 'fails if all branches could not be resolved' {
+            $mocks = Initialize-LocalActionCreateBranchSuccess @('baz', 'barbaz') 'new-Commit' `
+                -mergeMessageTemplate "Merge {}" `
+                -failAtMerge 0
 
             $result = Invoke-LocalAction ('{ 
                 "type": "create-branch", 
                 "parameters": {
-                    "target": "foobar",
                     "upstreamBranches": [
                         "baz",
                         "barbaz"
-                    ]
+                    ],
+                    "mergeMessageTemplate": "Merge {}"
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
             { Assert-Diagnostics $diag } | Should -Throw
-            $output | Should -contain 'ERR:  Failed to merge all branches'
-            $result | Should -Be $null
+            $output | Should -contain 'ERR:  No branches could be resolved to merge'
+            $result | Assert-ShouldBeObject @{ commit = $null }
             Invoke-VerifyMock $mocks -Times 1
         }
     }
@@ -101,6 +84,27 @@ Describe 'local action "create-branch"' {
         }
 
         AddStandardTests
+        
+        It 'reports merge failures' {
+            $mocks = Initialize-LocalActionCreateBranchSuccess @('baz', 'barbaz') 'new-Commit' `
+                -mergeMessageTemplate "Merge {}" `
+                -failAtMerge 1
+
+            $result = Invoke-LocalAction ('{ 
+                "type": "create-branch", 
+                "parameters": {
+                    "upstreamBranches": [
+                        "baz",
+                        "barbaz"
+                    ],
+                    "mergeMessageTemplate": "Merge {}"
+                }
+            }' | ConvertFrom-Json) -diagnostics $diag
+            { Assert-Diagnostics $diag } | Should -Not -Throw
+            $output | Should -contain 'WARN: Could not merge the following branches: barbaz'
+            $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
+            Invoke-VerifyMock $mocks -Times 1
+        }
     }
     
     Context 'with remote' {
@@ -114,5 +118,26 @@ Describe 'local action "create-branch"' {
         }
         
         AddStandardTests
+        
+        It 'reports merge failures' {
+            $mocks = Initialize-LocalActionCreateBranchSuccess @('baz', 'barbaz') 'new-Commit' `
+                -mergeMessageTemplate "Merge {}" `
+                -failAtMerge 1
+
+            $result = Invoke-LocalAction ('{ 
+                "type": "create-branch", 
+                "parameters": {
+                    "upstreamBranches": [
+                        "baz",
+                        "barbaz"
+                    ],
+                    "mergeMessageTemplate": "Merge {}"
+                }
+            }' | ConvertFrom-Json) -diagnostics $diag
+            { Assert-Diagnostics $diag } | Should -Not -Throw
+            $output | Should -contain 'WARN: Could not merge the following branches: origin/barbaz'
+            $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
+            Invoke-VerifyMock $mocks -Times 1
+        }
     }
 }

--- a/utils/actions/local/Register-LocalActionCreateBranch.tests.ps1
+++ b/utils/actions/local/Register-LocalActionCreateBranch.tests.ps1
@@ -12,6 +12,8 @@ Describe 'local action "create-branch"' {
         $fw = Register-Framework -throwInsteadOfExit
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $output = $fw.assertDiagnosticOutput
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = $fw.diagnostics
     }
 
     function AddStandardTests() {
@@ -96,8 +98,6 @@ Describe 'local action "create-branch"' {
             Initialize-UpstreamBranches @{
                 'feature/homepage-redesign' = @('infra/upgrade-dependencies')
             }
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-            $diag = New-Diagnostics
         }
 
         AddStandardTests
@@ -111,8 +111,6 @@ Describe 'local action "create-branch"' {
             Initialize-UpstreamBranches @{
                 'feature/homepage-redesign' = @('infra/upgrade-dependencies')
             }
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-            $diag = New-Diagnostics
         }
         
         AddStandardTests

--- a/utils/actions/local/Register-LocalActionCreateBranch.tests.ps1
+++ b/utils/actions/local/Register-LocalActionCreateBranch.tests.ps1
@@ -11,7 +11,7 @@ Describe 'local action "create-branch"' {
     BeforeEach {
         $fw = Register-Framework -throwInsteadOfExit
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $output = $fw.diagnostics
+        $output = $fw.assertDiagnosticOutput
     }
 
     function AddStandardTests() {

--- a/utils/actions/local/Register-LocalActionSetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.psm1
@@ -1,7 +1,7 @@
 Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
-Import-Module -Scope Local "$PSScriptRoot/../../git/Set-GitFiles.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 function Register-LocalActionSetUpstream([PSObject] $localActions) {
     $localActions['set-upstream'] = {

--- a/utils/actions/local/Register-LocalActionSetUpstream.tests.ps1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.tests.ps1
@@ -9,7 +9,9 @@ Describe 'local action "set-upstream"' {
     }
     
     BeforeEach {
-        Register-Framework
+        $fw = Register-Framework
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = $fw.diagnostics
     }
 
     Context 'with remote' {
@@ -32,8 +34,6 @@ Describe 'local action "set-upstream"' {
                 'new-COMMIT'
             }
 
-            $diag = New-Diagnostics
-            
             $result = Invoke-LocalAction @{
                 type = 'set-upstream'
                 parameters = @{
@@ -41,7 +41,6 @@ Describe 'local action "set-upstream"' {
                     message = 'Add barbaz to foobar'
                 }
             } -diagnostics $diag
-            Register-Diagnostics -throwInsteadOfExit
             { Assert-Diagnostics $diag } | Should -Not -Throw
             $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
         }
@@ -49,7 +48,6 @@ Describe 'local action "set-upstream"' {
         It 'provides mocks to do the same' {
             $mock = Initialize-LocalActionSetUpstream @{ 'foobar' = @('baz', 'barbaz') } -message 'Add barbaz to foobar' -commitish 'new-COMMIT'
 
-            $diag = New-Diagnostics
             $result = Invoke-LocalAction @{
                 type = 'set-upstream'
                 parameters = @{
@@ -57,7 +55,6 @@ Describe 'local action "set-upstream"' {
                     message = 'Add barbaz to foobar'
                 }
             } -diagnostics $diag
-            Register-Diagnostics -throwInsteadOfExit
             $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
             Invoke-VerifyMock $mock -Times 1
         }
@@ -65,7 +62,6 @@ Describe 'local action "set-upstream"' {
         It 'handles action deserialized from json' {
             $mock = Initialize-LocalActionSetUpstream @{ 'foobar' = @('baz', 'barbaz') } -message 'Add barbaz to foobar' -commitish 'new-COMMIT'
 
-            $diag = New-Diagnostics
             $result = Invoke-LocalAction ('{ 
                 "type": "set-upstream", 
                 "parameters": {
@@ -78,7 +74,6 @@ Describe 'local action "set-upstream"' {
                     }
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
-            Register-Diagnostics -throwInsteadOfExit
             $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
             Invoke-VerifyMock $mock -Times 1
         }
@@ -142,7 +137,6 @@ Describe 'local action "set-upstream"' {
                 'new-COMMIT'
             }
 
-            $diag = New-Diagnostics
             $result = Invoke-LocalAction @{
                 type = 'set-upstream'
                 parameters = @{
@@ -150,7 +144,6 @@ Describe 'local action "set-upstream"' {
                     message = 'Add barbaz to foobar'
                 }
             } -diagnostics $diag
-            Register-Diagnostics -throwInsteadOfExit
             { Assert-Diagnostics $diag } | Should -Not -Throw
             $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
         }

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.mocks.psm1
@@ -1,0 +1,38 @@
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../input.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionSimplifyUpstreamBranches.psm1"
+
+function Lock-LocalActionSimplifyUpstreamBranches() {
+    Mock -ModuleName 'Register-LocalActionSimplifyUpstreamBranches' -CommandName Compress-UpstreamBranches -MockWith {
+        throw "Register-LocalActionSimplifyUpstreamBranches was not set up for this test, $originalUpstream"
+    }
+}
+
+function Initialize-LocalActionSimplifyUpstreamBranchesSuccess(
+    [string[]] $from,
+    [string[]] $to
+) {
+    Lock-LocalActionSimplifyUpstreamBranches
+    foreach ($branch in $from) {
+        Initialize-AssertValidBranchName $branch
+    }
+
+    $contents = (@(
+         "`$originalUpstream.Count -eq $($from.Count)"
+        "(`$originalUpstream -join ',') -eq '$($from  -join ',')'"
+     ) | ForEach-Object { $_ } | Where-Object { $_ -ne $null }) -join ' -AND '
+
+    $result = New-VerifiableMock `
+        -CommandName Compress-UpstreamBranches `
+        -ModuleName 'Register-LocalActionSimplifyUpstreamBranches' `
+        -ParameterFilter $([scriptblock]::Create($contents))
+    Invoke-WrapMock $result -MockWith {
+            $global:LASTEXITCODE = 0
+            $to
+        }.GetNewClosure()
+    return $result
+}
+
+Export-ModuleMember -Function Initialize-LocalActionSimplifyUpstreamBranchesSuccess

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -11,6 +11,7 @@ function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) 
         )
         
         $upstreamBranches | Assert-ValidBranchName -diagnostics $diagnostics
+        if (Get-HasErrorDiagnostic $diagnostics) { return $null }
 
         if ($upstreamBranches.Count -eq 0) {
             $config = Get-Configuration

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -1,0 +1,29 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+
+function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) {
+    $localActions['simplify-upstream'] = {
+        param(
+            [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $upstreamBranches,
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+        
+        $upstreamBranches | Assert-ValidBranchName -diagnostics $diagnostics
+
+        if ($upstreamBranches.Count -eq 0) {
+            $config = Get-Configuration
+            if ($null -eq $config.defaultServiceLine) {
+                Add-ErrorDiagnostic $diagnostics 'At least one upstream branch must be specified or the default service line must be set'
+            }
+            # default to service line if none provided and config has a service line
+            return @( $config.defaultServiceLine )
+        }
+
+        $result = Compress-UpstreamBranches $upstreamBranches -diagnostics $diagnostics
+        return $result
+    }
+}
+
+Export-ModuleMember -Function Register-LocalActionSimplifyUpstreamBranches

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.tests.ps1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.tests.ps1
@@ -11,7 +11,7 @@ Describe 'local action "simplify-upstream"' {
     BeforeEach {
         $fw = Register-Framework -throwInsteadOfExit
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $output = $fw.diagnostics
+        $output = $fw.assertDiagnosticOutput
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $diag = New-Diagnostics
     }

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.tests.ps1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.tests.ps1
@@ -13,7 +13,7 @@ Describe 'local action "simplify-upstream"' {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $output = $fw.assertDiagnosticOutput
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $diag = New-Diagnostics
+        $diag = $fw.diagnostics
     }
 
     It 'allows fallback to the default service line' {

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.tests.ps1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.tests.ps1
@@ -1,0 +1,46 @@
+Describe 'local action "simplify-upstream"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionSimplifyUpstreamBranches.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        $fw = Register-Framework -throwInsteadOfExit
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $output = $fw.diagnostics
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = New-Diagnostics
+    }
+
+    It 'allows fallback to the default service line' {
+        Initialize-ToolConfiguration -defaultServiceLine 'line/1.0'
+
+        $result = Invoke-LocalAction @{
+            type = 'simplify-upstream'
+            parameters = @{
+                upstreamBranches = @()
+            }
+        } -diagnostics $diag
+        try { Assert-Diagnostics $diag } catch { }
+        $output | Should -BeNullOrEmpty
+        Should -ActualValue $result -Be @('line/1.0')
+    }
+
+    It 'allows mocked simplification' {
+        Initialize-LocalActionSimplifyUpstreamBranchesSuccess -from @('foo', 'bar') -to @('foo')
+
+        $result = Invoke-LocalAction @{
+            type = 'simplify-upstream'
+            parameters = @{
+                upstreamBranches = @('foo', 'bar')
+            }
+        } -diagnostics $diag
+        try { Assert-Diagnostics $diag } catch { }
+        $output | Should -BeNullOrEmpty
+        Should -ActualValue $result -Be @('foo')
+    }
+}

--- a/utils/actions/template/Register-LocalActionXxx.mocks.psm1
+++ b/utils/actions/template/Register-LocalActionXxx.mocks.psm1
@@ -1,0 +1,12 @@
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionXxx.psm1"
+
+function Initialize-LocalActionXxxSuccess(
+) {
+
+}
+
+Export-ModuleMember -Function Initialize-LocalActionXxxSuccess

--- a/utils/actions/template/Register-LocalActionXxx.psm1
+++ b/utils/actions/template/Register-LocalActionXxx.psm1
@@ -1,0 +1,16 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+
+function Register-LocalActionXxx([PSObject] $localActions) {
+    $localActions['xxx'] = {
+        param(
+            # TODO: add parameters
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+        
+        return @{}
+    }
+}
+
+Export-ModuleMember -Function Register-LocalActionXxx

--- a/utils/actions/template/Register-LocalActionXxx.tests.ps1
+++ b/utils/actions/template/Register-LocalActionXxx.tests.ps1
@@ -11,7 +11,7 @@ Describe 'local action "xxx"' {
     BeforeEach {
         $fw = Register-Framework
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $output = $fw.diagnostics
+        $output = $fw.assertDiagnosticOutput
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $diag = New-Diagnostics
     }

--- a/utils/actions/template/Register-LocalActionXxx.tests.ps1
+++ b/utils/actions/template/Register-LocalActionXxx.tests.ps1
@@ -13,7 +13,7 @@ Describe 'local action "xxx"' {
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $output = $fw.assertDiagnosticOutput
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $diag = New-Diagnostics
+        $diag = $fw.diagnostics
     }
 
     It 'will be implemented' -Pending {}

--- a/utils/actions/template/Register-LocalActionXxx.tests.ps1
+++ b/utils/actions/template/Register-LocalActionXxx.tests.ps1
@@ -1,0 +1,20 @@
+Describe 'local action "xxx"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionXxx.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        $fw = Register-Framework
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $output = $fw.diagnostics
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = New-Diagnostics
+    }
+
+    It 'will be implemented' -Pending {}
+}

--- a/utils/framework.mocks.psm1
+++ b/utils/framework.mocks.psm1
@@ -26,7 +26,7 @@ function Register-Framework {
     Lock-InvokeWriteTree
 }
 
-Export-ModuleMember -Function New-Diagnostics, Add-ErrorDiagnostic, Add-ErrorException, Add-WarningDiagnostic, Assert-Diagnostics `
+Export-ModuleMember -Function New-Diagnostics, Add-ErrorDiagnostic, Add-ErrorException, Add-WarningDiagnostic, Assert-Diagnostics, Get-HasErrorDiagnostic `
     , Invoke-ProcessLogs `
     , Register-Framework `
     , New-Diagnostics, Register-Diagnostics, Get-DiagnosticStrings `

--- a/utils/framework.mocks.psm1
+++ b/utils/framework.mocks.psm1
@@ -13,9 +13,13 @@ function Register-Framework {
     . "$PSScriptRoot/testing.ps1"
 
     Register-ProcessLog
-    $diagnostics = Register-Diagnostics -throwInsteadOfExit:$throwInsteadOfExit
+    $diag = New-Diagnostics
+    Mock -CommandName New-Diagnostics -MockWith { $diag }
+    
+    $diagnostics = Register-Diagnostics -throwInsteadOfExit
     return @{
-        diagnostics = $diagnostics
+        assertDiagnosticOutput = $diagnostics
+        diagnostics = $diag
     }
 
     Lock-InvokeWriteBlob

--- a/utils/framework/diagnostic-framework.mocks.psm1
+++ b/utils/framework/diagnostic-framework.mocks.psm1
@@ -13,7 +13,7 @@ function Register-Diagnostics {
     New-Variable -Name "mockDiagnosticResult" -Value $result -Scope "script" -Force
 
     if ($throwInsteadOfExit) {
-        Mock -ModuleName 'diagnostic-framework' -CommandName 'Exit-DueToAssert' { throw 'Fake Exit-DueToAssert' }
+        Mock -ModuleName 'diagnostic-framework' -CommandName 'Exit-DueToAssert' { throw ($result -join "`n") }.GetNewClosure()
     }
     Mock -ModuleName 'diagnostic-framework' Write-Host {
         if ($mockPrevNewLine) {

--- a/utils/framework/diagnostic-framework.psm1
+++ b/utils/framework/diagnostic-framework.psm1
@@ -70,6 +70,8 @@ function Assert-Diagnostics(
             Clear-ProcessLogs
         }
         foreach ($diagnostic in $diagnostics) {
+            if ($diagnostic.reported) { continue }
+            $diagnostic.reported = $true
             switch ($diagnostic.level) {
                 'error' {
                     Write-Host 'ERR:  ' -ForegroundColor Red -BackgroundColor Black -NoNewline

--- a/utils/framework/diagnostic-framework.tests.ps1
+++ b/utils/framework/diagnostic-framework.tests.ps1
@@ -2,6 +2,8 @@ Describe 'diagnostic-framework' {
     BeforeAll {
         Import-Module -Scope Local "$PSScriptRoot/diagnostic-framework.psm1"
         Import-Module -Scope Local "$PSScriptRoot/diagnostic-framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/processlog-framework.mocks.psm1"
+        Register-ProcessLog
     }
 
     Context 'when diagnostics are passed' {

--- a/utils/framework/processlog-framework.tests.ps1
+++ b/utils/framework/processlog-framework.tests.ps1
@@ -10,7 +10,7 @@ Describe 'processlog-framework' {
     }
 
     It 'can handle errors' {
-        # This is an unmocked command. Git explicitly allows `.lock` branch names
+        # This is an unmocked command. Git explicitly disallows `.lock` branch names
         Invoke-ProcessLogs 'check-ref-format with invalid branch' {
             git check-ref-format --branch "test.lock"
         }

--- a/utils/git.mocks.psm1
+++ b/utils/git.mocks.psm1
@@ -15,3 +15,6 @@ Export-ModuleMember -Function Lock-InvokeWriteBlob, Initialize-WriteBlob `
     , Initialize-InvokeMergeSuccess, Initialize-InvokeMergeFailure, Get-MergeAbortFilter, Initialize-QuietMergeBranches `
     , Initialize-SetGitFiles `
     , Initialize-SetRemoteTracking `
+
+Import-Module -Scope Local "$PSScriptRoot/git/Invoke-MergeTogether.mocks.psm1"
+Export-ModuleMember -Function Initialize-MergeTogetherAllFailed, Initialize-MergeTogether

--- a/utils/git.psm1
+++ b/utils/git.psm1
@@ -15,3 +15,6 @@ Export-ModuleMember -Function Invoke-WriteBlob `
     , Invoke-CreateBranch `
     , Invoke-MergeBranches `
     , Set-RemoteTracking
+
+Import-Module -Scope Local "$PSScriptRoot/git/Invoke-MergeTogether.psm1"
+Export-ModuleMember -Function Invoke-MergeTogether

--- a/utils/git/Invoke-CheckoutBranch.psm1
+++ b/utils/git/Invoke-CheckoutBranch.psm1
@@ -10,7 +10,7 @@ function Invoke-CheckoutBranch(
         git checkout $branchName
     } -quiet
     if ($LASTEXITCODE -ne 0) {
-        Add-ErrorDiagnostic $diagnostics "Could not checkout newly created branch '$branchName'"
+        Add-ErrorDiagnostic $diagnostics "Could not checkout '$branchName'"
     }
 
     if (-not $quiet -AND $null -eq $diagnostics) {

--- a/utils/git/Invoke-MergeTogether.mocks.psm1
+++ b/utils/git/Invoke-MergeTogether.mocks.psm1
@@ -1,0 +1,83 @@
+Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Invoke-MergeTogether.psm1"
+
+function Invoke-MockGitModuleStartsWith([string] $gitCli, [object] $MockWith) {
+    $result = New-VerifiableMock `
+        -ModuleName 'Invoke-MergeTogether' `
+        -CommandName git `
+        -ParameterFilter $([scriptblock]::Create("(`$args -join ' ').StartsWith('$gitCli')"))
+    Invoke-WrapMock $result -MockWith {
+            $global:LASTEXITCODE = 0
+            if ($MockWith -is [scriptblock]) {
+                & $MockWith
+            } elseif ($MockWith -ne $nil) {
+                $MockWith
+            }
+        }.GetNewClosure()
+    return $result
+}
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Invoke-MergeTogether' @PSBoundParameters
+}
+
+function Initialize-MergeTogetherAllFailed(
+    [AllowEmptyCollection()][string[]] $allBranches
+) {
+    foreach ($branch in $allBranches) {
+        Invoke-MockGit "rev-parse --verify $branch" -MockWith { $global:LASTEXITCODE = 1 }
+    }
+}
+
+function Initialize-MergeTogether(
+    [AllowEmptyCollection()][string[]] $allBranches,
+    [AllowEmptyCollection()][string[]] $successfulBranches,
+    [string] $messageTemplate = "Merge {}",
+    [string] $resultCommitish
+) {
+    $success = @()
+    $failed = @()
+    $initialSuccessfulBranch = $allBranches | Where-Object { $successfulBranches -contains $_ } | Select-Object -First 1
+
+    if ($null -ne $initialSuccessfulBranch) {
+        $lastBranch = ($allBranches | Where-Object { $successfulBranches -contains $_ } | Select-Object -Last 1)
+        $commitish = $successfulBranches | ConvertTo-HashMap -getValue { "$_-commitish" }
+        $commitish[$lastBranch] = $resultCommitish
+
+        $success += $initialSuccessfulBranch
+
+        $currentCommit = $commitish[$initialSuccessfulBranch]
+        Invoke-MockGit "rev-parse --verify $initialSuccessfulBranch" -MockWith { $commitish[$initialSuccessfulBranch] }.GetNewClosure()
+    }
+
+    for ($i = 0; $i -lt $allBranches.Count; $i++) {
+        $current = $allBranches[$i]
+        if ($successfulBranches -contains $current) {
+            $success += $current
+            if ($current -eq $initialSuccessfulBranch) { continue }
+
+            $treeish = "$current-tree"
+            $message = $messageTemplate.Replace('{}', $current)
+            Initialize-MergeTree $currentCommit $current $treeish
+            Invoke-MockGit "commit-tree $treeish -m $message -p $currentCommit" -MockWith "$($commitish[$current])"
+            $currentCommit = $commitish[$current]
+
+            foreach ($failedBranch in $failed) {
+                Initialize-MergeTree $currentCommit $failedBranch $treeish -fail
+            }
+        } else {
+            if ($success.Count -eq 0) {
+                Invoke-MockGit "rev-parse --verify $current" -MockWith { $global:LASTEXITCODE = 1 }
+            } else {
+                $treeish = "$current-tree"
+                Initialize-MergeTree $currentCommit $current $treeish -fail
+            }
+            $failed += $current
+        }
+    }
+}
+
+Export-ModuleMember -Function Initialize-MergeTogetherAllFailed, Initialize-MergeTogether

--- a/utils/git/Invoke-MergeTogether.mocks.psm1
+++ b/utils/git/Invoke-MergeTogether.mocks.psm1
@@ -58,11 +58,12 @@ function Initialize-MergeTogether(
         if ($successfulBranches -contains $current) {
             $success += $current
             if ($current -eq $initialSuccessfulBranch) { continue }
+            Invoke-MockGit "rev-parse --verify $current" -MockWith "$current-commitish"
 
             $treeish = "$current-tree"
             $message = $messageTemplate.Replace('{}', $current)
             Initialize-MergeTree $currentCommit $current $treeish
-            Invoke-MockGit "commit-tree $treeish -m $message -p $currentCommit" -MockWith "$($commitish[$current])"
+            Invoke-MockGit "commit-tree $treeish -m $message -p $currentCommit -p $current-commitish" -MockWith "$($commitish[$current])"
             $currentCommit = $commitish[$current]
 
             foreach ($failedBranch in $failed) {
@@ -72,6 +73,7 @@ function Initialize-MergeTogether(
             if ($success.Count -eq 0) {
                 Invoke-MockGit "rev-parse --verify $current" -MockWith { $global:LASTEXITCODE = 1 }
             } else {
+                Invoke-MockGit "rev-parse --verify $current" -MockWith "$current-commitish"
                 $treeish = "$current-tree"
                 Initialize-MergeTree $currentCommit $current $treeish -fail
             }

--- a/utils/git/Invoke-MergeTogether.psm1
+++ b/utils/git/Invoke-MergeTogether.psm1
@@ -1,0 +1,76 @@
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../query-state.psm1"
+
+function Invoke-MergeTogether(
+    [Parameter(Mandatory)][String[]] $commitishes, 
+    [Parameter()][string] $messageTemplate = "Merge {}",
+    [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
+    [switch] $asWarnings
+) {
+
+    [String[]]$remaining = $commitishes
+    [String[]]$failed = @()
+    [String[]]$successful = @()
+
+    $currentCommit = $null
+    while ($remaining.Count -gt 0) {
+        $target = $remaining[0]
+        if ($null -eq $currentCommit) {
+            $parsedCommitish = Invoke-ProcessLogs "git rev-parse --verify $target" {
+                git rev-parse --verify $target
+            } -allowSuccessOutput -quiet
+            if ($global:LASTEXITCODE -eq 0) {
+                $currentCommit = $parsedCommitish
+                $remaining = $remaining | Where-Object { $_ -ne $target }
+                $successful += $target
+            } else {
+                $remaining = $remaining | Where-Object { $_ -ne $target }
+                $failed += $target
+                if ($asWarnings) {
+                    Add-WarningDiagnostic $diagnostics "Could not resolve '$($target)'"
+                } else {
+                    Add-ErrorDiagnostic $diagnostics "Could not resolve '$($target)'"
+                }
+            }
+        } else {
+            $allFailed = $true
+            for ($i = 0; $i -lt $remaining.Count; $i++) {
+                $target = $remaining[$i]
+                $mergeTreeResult = Get-MergeTree $currentCommit $target
+                if (-not $mergeTreeResult.isSuccess) { continue }
+                $nextTree = $mergeTreeResult.treeish
+
+                $commitMessage = $messageTemplate.Replace('{}', $target)
+                $resultCommit = Invoke-ProcessLogs "git commit-tree $nextTree -m $commitMessage -p $currentCommit" {
+                    git commit-tree $nextTree -m $commitMessage -p $currentCommit
+                } -allowSuccessOutput
+                if ($global:LASTEXITCODE -ne 0) { continue }
+
+                $currentCommit = $resultCommit
+                $allFailed = $false
+                $i--
+                $remaining = $remaining | Where-Object { $_ -ne $target }
+                $successful += $target
+                break;
+            }
+            if ($allFailed) {
+                if ($asWarnings) {
+                    Add-WarningDiagnostic $diagnostics "Could not merge the following branches: $remaining"
+                } else {
+                    Add-ErrorDiagnostic $diagnostics "Could not merge the following branches: $remaining"
+                }
+
+                $failed += $remaining
+                $remaining = @()
+            }
+        }
+    }
+
+    return @{
+        result = $currentCommit
+        successful = $successful
+        failed = $failed
+    }
+}
+
+Export-ModuleMember -Function Invoke-MergeTogether

--- a/utils/git/Invoke-MergeTogether.tests.ps1
+++ b/utils/git/Invoke-MergeTogether.tests.ps1
@@ -1,0 +1,73 @@
+using module "./Invoke-MergeTogether.psm1"
+
+Describe 'Invoke-MergeTogether' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Invoke-MergeTogether.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Invoke-MergeTogether.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../testing.psm1"
+    }
+
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+    }
+
+    It 'reports a major failure if no branches are successful' {
+        $mocks = Initialize-MergeTogether `
+            -allBranches @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `
+            -messageTemplate 'Merge {}'
+
+        $result = Invoke-MergeTogether @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') -diagnostics $fw.diagnostics
+        $result.result | Should -Be $null
+        $result.failed | Should -Be @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3')
+        $result.successful | Should -BeNullOrEmpty
+        $fw.diagnostics | Should -Not -BeNullOrEmpty
+        Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $true
+        Invoke-VerifyMock $mocks -Times 1
+    }
+
+    It 'merges the branches that it can' {
+        $mocks = Initialize-MergeTogether `
+            -allBranches @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `
+            -successfulBranches @('feature/FOO-1', 'feature/FOO-3') `
+            -resultCommitish 'result-commitish' `
+            -messageTemplate 'Merge {}'
+
+        $result = Invoke-MergeTogether @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') -diagnostics $fw.diagnostics
+        $result.result | Should -Be 'result-commitish'
+        $result.failed | Should -Be @('feature/FOO-2')
+        $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-3')
+        $fw.diagnostics | Should -Not -BeNullOrEmpty
+        Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $true
+        Invoke-VerifyMock $mocks -Times 1
+    }
+    
+    It 'can flag failed merges only as warnings' {
+        $mocks = Initialize-MergeTogether `
+            -allBranches @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `
+            -successfulBranches @('feature/FOO-1', 'feature/FOO-3') `
+            -resultCommitish 'result-commitish' `
+            -messageTemplate 'Merge {}'
+
+        $result = Invoke-MergeTogether @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') -diagnostics $fw.diagnostics -asWarnings
+        $result.result | Should -Be 'result-commitish'
+        $result.failed | Should -Be @('feature/FOO-2')
+        $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-3')
+        $fw.diagnostics | Should -Not -BeNullOrEmpty
+        Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $false
+        Invoke-VerifyMock $mocks -Times 1
+    }
+    
+    It 'does not throw or abort if exit code is zero' {
+        $mocks = Initialize-MergeTogether @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') -successfulBranches @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') -resultCommitish 'result-commitish'
+
+        $result = Invoke-MergeTogether @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') -diagnostics $fw.diagnostics
+
+        $result.result | Should -Be 'result-commitish'
+        $result.failed | Should -Be @()
+        $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3')
+        $fw.diagnostics | Should -BeNullOrEmpty
+        Invoke-VerifyMock $mocks -Times 1
+    }
+}

--- a/utils/input.mocks.psm1
+++ b/utils/input.mocks.psm1
@@ -1,0 +1,2 @@
+Import-Module -Scope Local "$PSScriptRoot/input/Assert-ValidBranchName.mocks.psm1"
+Export-ModuleMember -Function Initialize-AssertValidBranchName, Initialize-AssertInvalidBranchName

--- a/utils/input/Assert-ValidBranchName.tests.ps1
+++ b/utils/input/Assert-ValidBranchName.tests.ps1
@@ -7,18 +7,18 @@ Describe 'Assert-ValidBranchName' {
     }
     
     BeforeEach {
-        Register-Framework
+        $fw = Register-Framework
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = $fw.diagnostics
     }
 
     Context 'when diagnostics are passed' {
         It 'allows a valid branch' {
-            $diag = New-Diagnostics
             Initialize-AssertValidBranchName 'good-branch'
             Assert-ValidBranchName -branchName 'good-branch' -diagnostics $diag
             Should -ActualValue $diag.Count -BeExactly 0
         }
         It 'disallows an invalid branch name' {
-            $diag = New-Diagnostics
             Initialize-AssertInvalidBranchName 'bad-branch'
             Assert-ValidBranchName -branchName 'bad-branch' -diagnostics $diag
             Should -ActualValue $diag.Count -BeExactly 1
@@ -26,7 +26,6 @@ Describe 'Assert-ValidBranchName' {
             $diag[0].level | Should -Be 'error'
         }
         It 'can accept multiple via a pipeline' {
-            $diag = New-Diagnostics
             Initialize-AssertValidBranchName 'branch-a'
             Initialize-AssertValidBranchName 'branch-b'
             Initialize-AssertInvalidBranchName 'bad-branch-1'

--- a/utils/query-state.mocks.psm1
+++ b/utils/query-state.mocks.psm1
@@ -5,6 +5,7 @@ Import-Module -Scope Local "$PSScriptRoot/query-state/Select-UpstreamBranches.mo
 Import-Module -Scope Local "$PSScriptRoot/query-state/Update-GitRemote.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-CurrentBranch.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-GitFile.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/query-state/Get-MergeTree.mocks.psm1"
 
 Export-ModuleMember -Function `
     Initialize-CleanWorkingDirectory, Initialize-DirtyWorkingDirectory, Initialize-UntrackedFiles `
@@ -14,3 +15,4 @@ Export-ModuleMember -Function `
     , Initialize-UpdateGitRemote `
     , Initialize-CurrentBranch, Initialize-NoCurrentBranch `
     , Initialize-OtherGitFilesAsBlank, Initialize-GitFile `
+    , Initialize-MergeTree `

--- a/utils/query-state.psm1
+++ b/utils/query-state.psm1
@@ -6,6 +6,7 @@ Import-Module -Scope Local "$PSScriptRoot/query-state/Select-UpstreamBranches.ps
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-UpstreamBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-CurrentBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-GitFile.psm1"
+Import-Module -Scope Local "$PSScriptRoot/query-state/Get-MergeTree.psm1"
 
 Export-ModuleMember -Function Get-Configuration `
     , Update-GitRemote `
@@ -15,3 +16,4 @@ Export-ModuleMember -Function Get-Configuration `
     , Get-UpstreamBranch `
     , Get-CurrentBranch `
     , Get-GitFile `
+    , Get-MergeTree `

--- a/utils/query-state/Compress-UpstreamBranches.tests.ps1
+++ b/utils/query-state/Compress-UpstreamBranches.tests.ps1
@@ -22,7 +22,9 @@ Describe 'Compress-UpstreamBranches' {
     }
 
     BeforeEach {
-        Register-Framework
+        $fw = Register-Framework
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = $fw.diagnostics
     }
 
     It 'can handle a flat string' {
@@ -46,11 +48,6 @@ Describe 'Compress-UpstreamBranches' {
     }
 
     Context 'with diagnostics' {
-        BeforeEach {
-            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-            $diag = New-Diagnostics
-        }
-        
         It 'can handle a flat string' {
             Compress-UpstreamBranches my-branch $diag | Should -Be @( 'my-branch' )
             Should -ActualValue (Get-DiagnosticStrings $diag) -Be @()

--- a/utils/query-state/Configuration.psm1
+++ b/utils/query-state/Configuration.psm1
@@ -11,13 +11,13 @@ function Get-Configuration() {
 
 function Get-ConfiguredRemote() {
     $result = git config scaled-git.remote
-    if ($result -ne $nil) { return $result }
+    if ($null -ne $result) { return $result }
     return git remote | Select-Object -First 1
 }
 
 function Get-ConfiguredUpstreamBranch() {
     $result = git config scaled-git.upstreamBranch
-    if ($result -ne $nil) {
+    if ($null -ne $result) {
         return $result;
     }
     return '_upstream'
@@ -25,18 +25,18 @@ function Get-ConfiguredUpstreamBranch() {
 
 function Get-ConfiguredDefaultServiceLine([string]$remote) {
     $result = git config scaled-git.defaultServiceLine
-    if ($result -ne $nil) { return $result }
+    if ($null -ne $result) { return $result }
 
-    git rev-parse --verify ($remote -eq $nil -OR $remote -eq '' ? 'main' : "$($remote)/main") -q > $nil 2> $nil
+    git rev-parse --verify ($null -eq $remote -OR $remote -eq '' ? 'main' : "$($remote)/main") -q > $null 2> $null
     if ($LASTEXITCODE -eq 0) {
         return "main"
     }
-    return $nil
+    return $null
 }
 
 function Get-ConfiguredAtomicPushEnabled() {
 	$result = git config scaled-git.atomicPushEnabled
-	if ($result -ne $nil) { return [bool]::Parse($result) }
+	if ($null -ne $result) { return [bool]::Parse($result) }
 	return $true
 }
 

--- a/utils/query-state/Configuration.tests.ps1
+++ b/utils/query-state/Configuration.tests.ps1
@@ -17,7 +17,7 @@ Describe 'Get-Configuration' {
         Invoke-MockGit 'config scaled-git.upstreamBranch'
         Invoke-MockGit 'config scaled-git.atomicPushEnabled'
 
-        Get-Configuration | Assert-ShouldBeObject @{ remote = $nil; upstreamBranch = '_upstream'; defaultServiceLine = 'main'; atomicPushEnabled = $true }
+        Get-Configuration | Assert-ShouldBeObject @{ remote = $null; upstreamBranch = '_upstream'; defaultServiceLine = 'main'; atomicPushEnabled = $true }
     }
 
     It 'Defaults values with no main branch' {
@@ -28,7 +28,7 @@ Describe 'Get-Configuration' {
         Invoke-MockGit 'config scaled-git.upstreamBranch'
         Invoke-MockGit 'config scaled-git.atomicPushEnabled'
 
-        Get-Configuration | Assert-ShouldBeObject @{ remote = $nil; upstreamBranch = '_upstream'; defaultServiceLine = $nil; atomicPushEnabled = $true }
+        Get-Configuration | Assert-ShouldBeObject @{ remote = $null; upstreamBranch = '_upstream'; defaultServiceLine = $null; atomicPushEnabled = $true }
     }
 
     It 'Defaults values with a remote main branch' {

--- a/utils/query-state/Get-MergeTree.mocks.psm1
+++ b/utils/query-state/Get-MergeTree.mocks.psm1
@@ -1,0 +1,29 @@
+Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../git.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Get-MergeTree.psm1"
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Get-MergeTree' @PSBoundParameters
+}
+
+function Initialize-MergeTree(
+    [Parameter(Mandatory)][string] $commitishA, 
+    [Parameter(Mandatory)][string] $commitishB, 
+    [string] $resultTree,
+    [string[]] $conflictingFiles,
+    [switch] $fail
+) {
+    Invoke-MockGit "merge-tree --name-only --write-tree --no-messages $commitishA $commitishB" {
+        $resultTree
+        foreach ($e in $conflictingFiles) {
+            $e
+        }
+        if ($fail -OR $conflictingFiles.Count -gt 0) {
+            $global:LASTEXITCODE = 1
+        }
+    }.GetNewClosure()
+}
+
+Export-ModuleMember -Function Initialize-MergeTree

--- a/utils/query-state/Get-MergeTree.psm1
+++ b/utils/query-state/Get-MergeTree.psm1
@@ -1,0 +1,18 @@
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+
+# While this function actually writes the tree to git's object store, it doesn't have any serious side effects (like updating refs, working directory, etc.)
+# so it is placed in the query-state folder.
+function Get-MergeTree([string]$commitishA, [string]$commitishB) {
+	$output = Invoke-ProcessLogs "git merge-tree --name-only --write-tree --no-messages $commitishA $commitishB" {
+        git merge-tree --name-only --write-tree --no-messages $commitishA $commitishB
+    } -allowSuccessOutput -quiet
+	$isClean = $global:LASTEXITCODE -eq 0 # git-merge-tree uses 0 for clean, 1 for not, and <0 for various other errors
+	return [ordered]@{
+		isSuccess = $isClean;
+		treeish = $output | Select-Object -First 1
+		# Just because this list is empty doesn't mean there aren't issues merging
+		conflicts = ($output | Select-Object -Skip 1)
+	}
+}
+
+Export-ModuleMember -Function Get-MergeTree

--- a/utils/query-state/Get-MergeTree.tests.ps1
+++ b/utils/query-state/Get-MergeTree.tests.ps1
@@ -1,0 +1,43 @@
+using module "./Get-MergeTree.psm1"
+
+Describe 'Get-MergeTree' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Get-MergeTree.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Get-MergeTree.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../testing.psm1"
+    }
+
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+    }
+
+    It 'merges successfully' {
+        $mocks = Initialize-MergeTree 'feature/FOO-1' 'feature/FOO-2' 'result-treeish'
+
+        $result = Get-MergeTree 'feature/FOO-1' 'feature/FOO-2'
+        $result.isSuccess | Should -Be $true
+        $result.treeish | Should -Be 'result-treeish'
+        Invoke-VerifyMock $mocks -Times 1
+    }
+    
+    It 'fails without conflicts' {
+        $mocks = Initialize-MergeTree 'feature/FOO-1' 'feature/FOO-2' 'result-treeish' -fail
+
+        $result = Get-MergeTree 'feature/FOO-1' 'feature/FOO-2'
+        $result.isSuccess | Should -Be $false
+        $result.treeish | Should -Be 'result-treeish'
+        Invoke-VerifyMock $mocks -Times 1
+    }
+    
+    It 'fails with conflicts' {
+        $mocks = Initialize-MergeTree 'feature/FOO-1' 'feature/FOO-2' 'result-treeish' @('file1.txt', 'readme.md') -fail
+
+        $result = Get-MergeTree 'feature/FOO-1' 'feature/FOO-2'
+        $result.isSuccess | Should -Be $false
+        $result.treeish | Should -Be 'result-treeish'
+        $result.conflicts | Should -Be @('file1.txt', 'readme.md')
+        Invoke-VerifyMock $mocks -Times 1
+    }
+}

--- a/utils/scripting.mocks.psm1
+++ b/utils/scripting.mocks.psm1
@@ -1,0 +1,2 @@
+Import-Module -Scope Local "$PSScriptRoot/scripting/Invoke-Script.mocks.psm1"
+Export-ModuleMember -Function Invoke-ScriptedCommand

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
@@ -1,3 +1,4 @@
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedString.psm1"
 Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedArray.psm1"
 Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedObject.psm1"
@@ -22,7 +23,7 @@ function ConvertFrom-ParameterizedAnything(
             $targetScript = [ScriptBlock]::Create('
                 Set-StrictMode -Version 3.0; 
                 try {
-                    ' + $script.replace('`', '``').replace('{', '`{').replace('}', '`}') + '
+                    @{ result = ' + $script.replace('`', '``').replace('{', '`{').replace('}', '`}').replace(';', '`;') + '; fail = $false }
                 } catch {
                     $null
                 }
@@ -32,7 +33,7 @@ function ConvertFrom-ParameterizedAnything(
             $entry = $null
         }
         if ($null -ne $entry) {
-            return @{ result = $entry; fail = $false }
+            return $entry
         } else {
             Add-ErrorDiagnostic $diagnostics "Error trying to handle script '$_'; please ensure strings use `$(...) syntax"
             return @{ result = $null; fail = $true }

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
@@ -35,7 +35,7 @@ function ConvertFrom-ParameterizedAnything(
         if ($null -ne $entry) {
             return $entry
         } else {
-            Add-ErrorDiagnostic $diagnostics "Error trying to handle script '$_'; please ensure strings use `$(...) syntax"
+            Add-ErrorDiagnostic $diagnostics "Error trying to handle script '$script'; please ensure strings use `$(...) syntax"
             return @{ result = $null; fail = $true }
         }
     } elseif ($script -is [string]) {

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
@@ -40,6 +40,28 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }
     }
     
+    It 'can evaluate parameters in single-element-arrays nested in objects without extra syntax' {
+        $target = @{ 'foo' = @('$params.foo'); 'baz' = '$params.banter' }
+        $params = @{ foo = @('bar'); banter = @('woot') }
+        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar'); 'baz' = 'woot' }
+    }
+    
+    It 'can evaluate parameters in empty arrays nested in objects without extra syntax' {
+        $target = @{ 'foo' = @('$params.foo'); 'baz' = '$params.banter' }
+        $params = @{ foo = @(); banter = @('woot') }
+        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $result.result | Assert-ShouldBeObject @{ 'foo' = @(); 'baz' = 'woot' }
+    }
+    
+    It 'can evaluate single-element arrays as arrays' {
+        $target = @('$params.foo')
+        $params = @{ foo = @('bar'); banter = @('woot') }
+        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $result.result.Count | Should -Be 1
+        Should -ActualValue $result.result -Be @('bar')
+    }
+    
     It 'can evaluate complex strings' {
         $target = '$($params.foo) and $($params.baz)'
         $target = $target | ConvertTo-Json | ConvertFrom-Json

--- a/utils/scripting/ConvertFrom-ParameterizedArray.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedArray.tests.ps1
@@ -6,7 +6,9 @@ Describe 'ConvertFrom-ParameterizedArray' {
         Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedArray.psm1"
     }
     BeforeEach {
-        Register-Framework
+        $fw = Register-Framework
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = $fw.diagnostics
     }
 
     It 'can evaluate single parameters' {
@@ -30,7 +32,6 @@ Describe 'ConvertFrom-ParameterizedArray' {
     }
 
     It 'reports warnings if diagnostics are provided' {
-        $diag = New-Diagnostics
         $params = @{ foo = @('bar', 'baz') }
         $result = ConvertFrom-ParameterizedArray @('foo', '$($config.upstreamBranch)') -config @{} -params $params -actions @{} -diagnostics $diag -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true
@@ -41,7 +42,6 @@ Describe 'ConvertFrom-ParameterizedArray' {
     }
 
     It 'reports errors if diagnostics are provided and flagged to fail on error' {
-        $diag = New-Diagnostics
         $params = @{ foo = @('bar', 'baz') }
         $result = ConvertFrom-ParameterizedArray @('foo', '$($config.upstreamBranch)') -config @{} -params $params -actions @{} -diagnostics $diag -failOnError -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true

--- a/utils/scripting/ConvertFrom-ParameterizedObject.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedObject.tests.ps1
@@ -5,6 +5,12 @@ Describe 'ConvertFrom-ParameterizedObject' {
         Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedString.psm1"
         Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedObject.psm1"
     }
+    
+    BeforeEach {
+        $fw = Register-Framework
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = $fw.diagnostics
+    }
 
     It 'ignores non-parameterized objects' {
         $target = @{ 'foo' = 'bar'; 'baz' = 'woot' }
@@ -53,7 +59,6 @@ Describe 'ConvertFrom-ParameterizedObject' {
     }
     
     It 'reports warnings if diagnostics are provided' {
-        $diag = New-Diagnostics
         $target = @{ 'foo' = '$($params.foo)'; 'baz' = '$($params.banter)' }
         $result = ConvertFrom-ParameterizedObject $target -config @{} -params @{} -actions @{} -diagnostics $diag -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true
@@ -66,7 +71,6 @@ Describe 'ConvertFrom-ParameterizedObject' {
     }
 
     It 'reports errors if diagnostics are provided and flagged to fail on error' {
-        $diag = New-Diagnostics
         $target = @{ 'foo' = '$($params.foo)'; 'baz' = '$($params.banter)' }
         $result = ConvertFrom-ParameterizedObject $target -config @{} -params @{} -actions @{} -diagnostics $diag -failOnError -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true

--- a/utils/scripting/ConvertFrom-ParameterizedString.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedString.tests.ps1
@@ -4,6 +4,12 @@ Describe 'ConvertFrom-ParameterizedString' {
         Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedString.psm1"
     }
 
+    BeforeEach {
+        $fw = Register-Framework
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $diag = $fw.diagnostics
+    }
+
     It 'can evaluate from params' {
         $params = @{ foo = 'bar' }
         $result = ConvertFrom-ParameterizedString -script '$($params.foo)' -config @{} -params $params -actions @{}
@@ -37,7 +43,6 @@ Describe 'ConvertFrom-ParameterizedString' {
     }
 
     It 'reports warnings if diagnostics are provided' {
-        $diag = New-Diagnostics
         $result = ConvertFrom-ParameterizedString -script '$($config.upstreamBranch)' -config @{} -params @{} -actions @{} -diagnostics $diag
         $result.result | Should -Be $null
         $result.fail | Should -Be $true
@@ -48,7 +53,6 @@ Describe 'ConvertFrom-ParameterizedString' {
     }
 
     It 'reports errors if diagnostics are provided and flagged to fail on error' {
-        $diag = New-Diagnostics
         $result = ConvertFrom-ParameterizedString -script '$($config.upstreamBranch)' -config @{} -params @{} -actions @{} -diagnostics $diag -failOnError
         $result.result | Should -Be $null
         $result.fail | Should -Be $true

--- a/utils/scripting/Invoke-Script.mocks.psm1
+++ b/utils/scripting/Invoke-Script.mocks.psm1
@@ -1,0 +1,29 @@
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../git.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../testing.psm1"
+
+function Invoke-ScriptedCommand {
+    [OutputType([scriptblock])]
+    param (
+        [Parameter(Mandatory)][scriptblock] $action
+    )
+
+    return {
+        try {
+            Write-Host "running $action"
+            & $action
+        } catch {
+            try {
+                # Ensure diagnostics are flushed. Register-Framework will reuse the diagnostic array
+                $diag = New-Diagnostics
+                Assert-Diagnostics $diag
+            } catch { }
+
+            throw
+        }
+    }
+}
+
+Export-ModuleMember -Function Invoke-ScriptedCommand

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -18,7 +18,8 @@ function Invoke-Script(
         $name = $script.local[$i].id ?? "#$($i + 1) (1-based)";
         $local = ConvertFrom-ParameterizedAnything -script $script.local[$i] -config $config -params $params -actions $actions -diagnostics $diagnostics
         if ($local.fail) {
-            Add-ErrorDiagnostic $diagnostics "Could not apply parameters to local action $name; see above errors."
+            Add-ErrorDiagnostic $diagnostics "Could not apply parameters to local action $name; see above errors. Evaluation below:"
+            Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
             continue;
         }
         try {
@@ -27,7 +28,8 @@ function Invoke-Script(
                 $actions += @{ $local.result.id = @{ outputs = $outputs } }
             }
         } catch {
-            Add-ErrorDiagnostic $diagnostics "Encountered error while running local action $($name): see the following error."
+            Add-ErrorDiagnostic $diagnostics "Encountered error while running local action $($name), evaluated below, with the error following."
+            Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
             Add-ErrorException $diagnostics $_
         }
     }

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -10,63 +10,68 @@ function Invoke-Script(
     [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [switch] $dryRun
 ) {
-    $config = Get-Configuration
-    $actions = @{}
-    $params = $params ?? @{}
+    try {
+        $config = Get-Configuration
+        $actions = @{}
+        $params = $params ?? @{}
 
-    for ($i = 0; $i -lt $script.local.Count; $i++) {
-        $name = $script.local[$i].id ?? "#$($i + 1) (1-based)";
-        $local = ConvertFrom-ParameterizedAnything -script $script.local[$i] -config $config -params $params -actions $actions -diagnostics $diagnostics
-        if ($local.fail) {
-            Add-ErrorDiagnostic $diagnostics "Could not apply parameters to local action $name; see above errors. Evaluation below:"
-            Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
-            continue;
-        }
-        try {
-            $outputs = Invoke-LocalAction $local.result -diagnostics $diagnostics
-            if ($null -ne $local.result.id -AND $null -ne $outputs) {
-                $actions += @{ $local.result.id = @{ outputs = $outputs } }
+        for ($i = 0; $i -lt $script.local.Count; $i++) {
+            $name = $script.local[$i].id ?? "#$($i + 1) (1-based)";
+            $local = ConvertFrom-ParameterizedAnything -script $script.local[$i] -config $config -params $params -actions $actions -diagnostics $diagnostics
+            if ($local.fail) {
+                Add-ErrorDiagnostic $diagnostics "Could not apply parameters to local action $name; see above errors. Evaluation below:"
+                Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
+                continue;
             }
-        } catch {
-            Add-ErrorDiagnostic $diagnostics "Encountered error while running local action $($name), evaluated below, with the error following."
-            Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
-            Add-ErrorException $diagnostics $_
-        }
-    }
-
-    Assert-Diagnostics $diagnostics
-    
-    $allFinalize = ConvertFrom-ParameterizedAnything -script $script.finalize -config $config -params $params -actions $actions -diagnostics $diagnostics
-    if ($allFinalize.fail) {
-        Add-ErrorDiagnostic $diagnostics "Could not apply parameters for finalize actions; see above errors."
-        Assert-Diagnostics $diagnostics
-    }
-
-    $allFinalizeScripts = $allFinalize.result
-    if ($dryRun) {
-        # TODO: describe this rather than dumping JSON
-        Write-Host (ConvertTo-Json $allFinalizeScripts)
-        return
-    }
-
-    for ($i = 0; $i -lt $allFinalizeScripts.Count; $i++) {
-        $name = $allFinalizeScripts[$i].id ?? "#$($i + 1) (1-based)";
-        $finalize = $allFinalizeScripts[$i]
-        try {
-            $outputs = Invoke-FinalizeAction $finalize -diagnostics $diagnostics
-            if ($null -ne $finalize.id -AND $null -ne $outputs) {
-                $actions += @{ $finalize.id = @{ outputs = $outputs } }
+            try {
+                $outputs = Invoke-LocalAction $local.result -diagnostics $diagnostics
+                if ($null -ne $local.result.id -AND $null -ne $outputs) {
+                    $actions += @{ $local.result.id = @{ outputs = $outputs } }
+                }
+            } catch {
+                Add-ErrorDiagnostic $diagnostics "Encountered error while running local action $($name), evaluated below, with the error following."
+                Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
+                Add-ErrorException $diagnostics $_
             }
-        } catch {
-            Add-ErrorDiagnostic $diagnostics "Encountered error while running finalize action $($name): see the following error."
-            Add-ErrorException $diagnostics $_
         }
+
         Assert-Diagnostics $diagnostics
-    }
-    
-    if ($null -ne $script.output) {
-        $allOutput = ConvertFrom-ParameterizedAnything -script $script.output -config $config -params $params -actions $actions -diagnostics $diagnostics
-        $allOutput.result | Write-Output
+        
+        $allFinalize = ConvertFrom-ParameterizedAnything -script $script.finalize -config $config -params $params -actions $actions -diagnostics $diagnostics
+        if ($allFinalize.fail) {
+            Add-ErrorDiagnostic $diagnostics "Could not apply parameters for finalize actions; see above errors."
+            Assert-Diagnostics $diagnostics
+        }
+
+        $allFinalizeScripts = $allFinalize.result
+        if ($dryRun) {
+            # TODO: describe this rather than dumping JSON
+            Write-Host (ConvertTo-Json $allFinalizeScripts)
+            return
+        }
+
+        for ($i = 0; $i -lt $allFinalizeScripts.Count; $i++) {
+            $name = $allFinalizeScripts[$i].id ?? "#$($i + 1) (1-based)";
+            $finalize = $allFinalizeScripts[$i]
+            try {
+                $outputs = Invoke-FinalizeAction $finalize -diagnostics $diagnostics
+                if ($null -ne $finalize.id -AND $null -ne $outputs) {
+                    $actions += @{ $finalize.id = @{ outputs = $outputs } }
+                }
+            } catch {
+                Add-ErrorDiagnostic $diagnostics "Encountered error while running finalize action $($name): see the following error."
+                Add-ErrorException $diagnostics $_
+            }
+            Assert-Diagnostics $diagnostics
+        }
+        
+        if ($null -ne $script.output) {
+            $allOutput = ConvertFrom-ParameterizedAnything -script $script.output -config $config -params $params -actions $actions -diagnostics $diagnostics
+            $allOutput.result | Write-Output
+        }
+    } catch {
+        Assert-Diagnostics $diagnostics
+        throw
     }
 }
 

--- a/utils/scripting/Invoke-Script.tests.ps1
+++ b/utils/scripting/Invoke-Script.tests.ps1
@@ -151,7 +151,7 @@ Describe 'Invoke-Script' {
             }' | ConvertFrom-Json) -diagnostics $diag
         } | Should -Throw 'Fake Exit-DueToAssert'
         Get-HasErrorDiagnostic $diag | Should -Be $true
-        $output | Should -Contain 'ERR:  Encountered error while running local action #1 (1-based): See the following error.'
+        $output | Should -Contain 'ERR:  Encountered error while running local action #1 (1-based), evaluated below, with the error following.'
         $entry = ($output | Where-Object { $_.StartsWith('ERR:  Cannot run 1') })
         $entry.Count | Should -Be 1
 
@@ -177,7 +177,7 @@ Describe 'Invoke-Script' {
             }' | ConvertFrom-Json) -diagnostics $diag
         } | Should -Throw 'Fake Exit-DueToAssert'
         Get-HasErrorDiagnostic $diag | Should -Be $true
-        $output | Should -Contain 'ERR:  Could not apply parameters to local action 2; see above errors.'
+        $output | Should -Contain 'ERR:  Could not apply parameters to local action 2; see above errors. Evaluation below:'
 
         Should -InvokeVerifiable
     }

--- a/utils/testing/Invoke-MockGitModule.psm1
+++ b/utils/testing/Invoke-MockGitModule.psm1
@@ -1,6 +1,7 @@
 Import-Module -Scope Local "$PSScriptRoot/Invoke-VerifyMock.psm1"
 
 function Invoke-MockGitModule([string] $ModuleName, [string] $gitCli, [object] $MockWith) {
+    $gitCli = $gitCli.Replace("'", "''")
     $result = New-VerifiableMock `
         -ModuleName $ModuleName `
         -CommandName git `

--- a/utils/testing/Invoke-VerifyMock.psm1
+++ b/utils/testing/Invoke-VerifyMock.psm1
@@ -21,7 +21,7 @@ function Invoke-VerifyMock([Object] $verifiableMock,
         try {
             Should -ModuleName $_.ModuleName -Invoke -CommandName $_.commandName -ParameterFilter $_.parameterFilter -Times $Times
         } catch {
-            Write-Host "Exception encountered; $info"
+            Write-Host "Exception encountered while verifying mocks; $info"
             throw
         }
     }


### PR DESCRIPTION
- Moves simplifying of branch names to action for git-new
- Improves error messages in scripts for better testing
- Expose diagnostics objects via Register-Framework for better testing of `Assert-Diagnostic` assertions
- Pushes creation of the branch to the finalize stage, making the dry-run version of git-new work as expected.