### PR TITLE
More refactorings for git-new to standardize

### DIFF
--- a/git-new.json
+++ b/git-new.json
@@ -1,6 +1,12 @@
 {
     "local": [
         {
+            "type": "validate-branch-names",
+            "parameters": {
+                "branches": ["$params.branchName", "$params.upstreamBranches"]
+            }
+        },
+        {
             "id": "simplify-upstream",
             "type": "simplify-upstream",
             "parameters": {
@@ -14,7 +20,7 @@
                 "upstreamBranches": {
                     "$params.branchName": ["$actions['simplify-upstream'].outputs"]
                 },
-                "message": "Add branch $($params.branchName)$($params.comment -eq '' ? '' : \" for $($params.comment)\")"
+                "message": "Add branch $($params.branchName)$($params.comment ? '' : \" for $($params.comment)\")"
             }
         },
         {

--- a/git-new.ps1
+++ b/git-new.ps1
@@ -23,24 +23,11 @@ Param(
     [switch] $dryRun
 )
 
-Import-Module -Scope Local "$PSScriptRoot/utils/framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/input.psm1"
-Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
-Import-Module -Scope Local "$PSScriptRoot/utils/git.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/scripting.psm1"
 
-$params = @{
+Invoke-JsonScript -scriptPath "$PSScriptRoot/git-new.json" -params @{
     branchName = $branchName;
     upstreamBranches = Expand-StringArray $upstreamBranches;
     comment = $comment ?? '';
-}
-$scriptPath = "$PSScriptRoot/git-new.json"
-
-$diagnostics = New-Diagnostics
-# TODO: move this into a JSON task
-Assert-ValidBranchName $branchName -diagnostics $diagnostics
-Assert-Diagnostics $diagnostics
-
-Update-GitRemote
-$instructions = Get-Content $scriptPath | ConvertFrom-Json
-Invoke-Script $instructions -params $params -diagnostics $diagnostics -dryRun:$dryRun
+} -dryRun:$dryRun

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -3,11 +3,13 @@ Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSetUpstream.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionCreateBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSimplifyUpstreamBranches.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionValidateBranchNames.psm1"
 
 $localActions = @{}
 Register-LocalActionSetUpstream $localActions
 Register-LocalActionCreateBranch $localActions
 Register-LocalActionSimplifyUpstreamBranches $localActions
+Register-LocalActionValidateBranchNames $localActions
 
 function Invoke-LocalAction(
     [PSObject] $actionDefinition,

--- a/utils/actions/local/Register-LocalActionValidateBranchNames.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionValidateBranchNames.mocks.psm1
@@ -1,0 +1,12 @@
+Import-Module -Scope Local "$PSScriptRoot/../../input.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionValidateBranchNames.psm1"
+
+function Initialize-LocalActionValidateBranchNamesSuccess(
+    [string[]] $branches
+) {
+    foreach ($branch in $branches) {
+        Initialize-AssertValidBranchName $branch
+    }
+}
+
+Export-ModuleMember -Function Initialize-LocalActionValidateBranchNamesSuccess

--- a/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
+++ b/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
@@ -1,0 +1,18 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
+
+function Register-LocalActionValidateBranchNames([PSObject] $localActions) {
+    $localActions['validate-branch-names'] = {
+        param(
+            [string[]] $branches,
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+
+        $branches | Assert-ValidBranchName -diagnostics $diagnostics
+        
+        return @{}
+    }
+}
+
+Export-ModuleMember -Function Register-LocalActionValidateBranchNames

--- a/utils/actions/local/Register-LocalActionValidateBranchNames.tests.ps1
+++ b/utils/actions/local/Register-LocalActionValidateBranchNames.tests.ps1
@@ -1,0 +1,42 @@
+Describe 'local action "validate-branch-names"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../input.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionValidateBranchNames.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $standardScript = ('{ 
+            "type": "validate-branch-names", 
+            "parameters": {
+                "branches": ["foo", "bar", "baz"]
+            }
+        }' | ConvertFrom-Json)
+    }
+
+    It 'handles standard functionality' {
+        Initialize-LocalActionValidateBranchNamesSuccess @('foo', 'bar', 'baz')
+
+        Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+    }
+
+    It 'throws errors for invalid branch names' {
+        Initialize-AssertValidBranchName 'foo'
+        Initialize-AssertValidBranchName 'bar'
+        Initialize-AssertInvalidBranchName 'baz'
+
+        Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+        Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $true
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -contain "ERR:  Invalid branch name specified: 'baz'"
+    }
+}

--- a/utils/actions/template/Register-LocalActionXxx.tests.ps1
+++ b/utils/actions/template/Register-LocalActionXxx.tests.ps1
@@ -9,12 +9,24 @@ Describe 'local action "xxx"' {
     }
     
     BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $fw = Register-Framework
+
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $output = $fw.assertDiagnosticOutput
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $diag = $fw.diagnostics
+        $standardScript = ('{ 
+            "type": "xxx", 
+            "parameters": {
+                /* implement me */
+            }
+        }' | ConvertFrom-Json)
     }
 
-    It 'will be implemented' -Pending {}
+    It 'will be implemented' -Pending {
+        Initialize-LocalActionXxxSuccess
+
+        Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+    }
 }

--- a/utils/framework.mocks.psm1
+++ b/utils/framework.mocks.psm1
@@ -5,7 +5,6 @@ Import-Module -Scope Local "$PSScriptRoot/git/Invoke-WriteBlob.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/git/Invoke-WriteTree.mocks.psm1"
 
 function Register-Framework {
-    [OutputType([System.Collections.ArrayList])]
     Param (
         [switch] $throwInsteadOfExit
     )
@@ -26,8 +25,14 @@ function Register-Framework {
     Lock-InvokeWriteTree
 }
 
+function Invoke-FlushAssertDiagnostic(
+    [Parameter(Mandatory)][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+) {
+    try { Assert-Diagnostics $diagnostics } catch { }
+}
+
 Export-ModuleMember -Function New-Diagnostics, Add-ErrorDiagnostic, Add-ErrorException, Add-WarningDiagnostic, Assert-Diagnostics, Get-HasErrorDiagnostic `
     , Invoke-ProcessLogs `
-    , Register-Framework `
+    , Register-Framework, Invoke-FlushAssertDiagnostic `
     , New-Diagnostics, Register-Diagnostics, Get-DiagnosticStrings `
     , Clear-ProcessLogs, Get-ProcessLogs

--- a/utils/scripting.psm1
+++ b/utils/scripting.psm1
@@ -1,3 +1,5 @@
 Import-Module -Scope Local "$PSScriptRoot/scripting/Invoke-Script.psm1"
-
 Export-ModuleMember -Function Invoke-Script
+
+Import-Module -Scope Local "$PSScriptRoot/scripting/Invoke-JsonScript.psm1"
+Export-ModuleMember -Function Invoke-JsonScript

--- a/utils/scripting/Invoke-JsonScript.psm1
+++ b/utils/scripting/Invoke-JsonScript.psm1
@@ -1,0 +1,18 @@
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../input.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../actions.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Invoke-Script.psm1"
+
+function Invoke-JsonScript(
+    [Parameter(Mandatory)][string] $scriptPath,
+    [Parameter(Mandatory)][PSObject] $params,
+    [switch] $dryRun
+) {
+    $diagnostics = New-Diagnostics
+    Update-GitRemote
+    $instructions = Get-Content $scriptPath | ConvertFrom-Json
+    Invoke-Script $instructions -params $params -diagnostics $diagnostics -dryRun:$dryRun
+}
+
+Export-ModuleMember -Function Invoke-JsonScript


### PR DESCRIPTION
- Moves validation of branch names from `git-new.ps1` to an action for reuse
- Moves what should be shared logic from `git-new.ps1` to an `Invoke-JsonScript` module for reuse
- Updates the local-action template for simpler testing
- Adds `Invoke-FlushAssertDiagnostic` for simpler testing. Since the framework mocks already capture output from those asserts, we don't need to wrap each `Assert-Diagnostics` call is wrapped with a try/catch to test the output is either not empty or has the specific errors/warnings we expect.