### PR TITLE
Add utility to report local vs remote branch state

### DIFF
--- a/utils/query-state.mocks.psm1
+++ b/utils/query-state.mocks.psm1
@@ -16,3 +16,6 @@ Export-ModuleMember -Function `
     , Initialize-CurrentBranch, Initialize-NoCurrentBranch `
     , Initialize-OtherGitFilesAsBlank, Initialize-GitFile `
     , Initialize-MergeTree `
+
+Import-Module -Scope Local "$PSScriptRoot/query-state/Get-BranchSyncState.mocks.psm1"
+Export-ModuleMember -Function Initialize-RemoteBranchBehind, Initialize-RemoteBranchAhead, Initialize-RemoteBranchNotTracked, Initialize-RemoteBranchInSync, Initialize-RemoteBranchAheadAndBehind

--- a/utils/query-state.psm1
+++ b/utils/query-state.psm1
@@ -17,3 +17,6 @@ Export-ModuleMember -Function Get-Configuration `
     , Get-CurrentBranch `
     , Get-GitFile `
     , Get-MergeTree `
+
+Import-Module -Scope Local "$PSScriptRoot/query-state/Get-BranchSyncState.psm1"
+Export-ModuleMember -Function Get-BranchSyncState

--- a/utils/query-state/Get-BranchSyncState.mocks.psm1
+++ b/utils/query-state/Get-BranchSyncState.mocks.psm1
@@ -1,0 +1,38 @@
+Import-Module -Scope Local "$PSScriptRoot/../../utils/query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../utils/testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Get-BranchSyncState.psm1"
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Get-BranchSyncState' @PSBoundParameters
+}
+
+function Initialize-RemoteBranchSyncState([String] $branchName, [AllowEmptyString()][AllowNull()][string] $state) {
+    $remote = $(Get-Configuration).remote
+    if ($null -eq $remote) { throw 'Do not initialize remote state if remote is not set' }
+    $remoteBranch = "$remote/$branchName"
+
+    Invoke-MockGit "for-each-ref --format=%(if:equals=$remoteBranch)%(upstream:short)%(then)%(upstream:trackshort)%(else)%(end) refs/heads --omit-empty" $state
+}
+
+function Initialize-RemoteBranchBehind([String] $branchName) {
+    Initialize-RemoteBranchSyncState $branchName '<'
+}
+
+function Initialize-RemoteBranchAhead([String] $branchName) {
+    Initialize-RemoteBranchSyncState $branchName '>'
+}
+
+function Initialize-RemoteBranchNotTracked([String] $branchName) {
+    Initialize-RemoteBranchSyncState $branchName $null
+}
+
+function Initialize-RemoteBranchInSync([String] $branchName) {
+    Initialize-RemoteBranchSyncState $branchName '='
+}
+
+function Initialize-RemoteBranchAheadAndBehind([String] $branchName) {
+    Initialize-RemoteBranchSyncState $branchName '<>'
+}
+
+Export-ModuleMember -Function Initialize-RemoteBranchBehind, Initialize-RemoteBranchAhead, Initialize-RemoteBranchNotTracked, Initialize-RemoteBranchInSync, Initialize-RemoteBranchAheadAndBehind

--- a/utils/query-state/Get-BranchSyncState.psm1
+++ b/utils/query-state/Get-BranchSyncState.psm1
@@ -1,0 +1,20 @@
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
+
+function Get-BranchSyncState(
+    [Parameter(Mandatory)][String] $branchName
+) {
+    $config = Get-Configuration
+    if ($config.remote -ne $nil) {
+        # Will give empty string for not tracked, `<` for behind, `>` for commits that aren't pushed, `=` for same, and `<>` for both remote and local have extra commits
+        $syncState = Invoke-ProcessLogs "get local branch for $($config.remote)/$branchName" {
+            git for-each-ref "--format=%(if:equals=$($config.remote)/$branchName)%(upstream:short)%(then)%(upstream:trackshort)%(else)%(end)" refs/heads --omit-empty
+        } -allowSuccessOutput
+
+        return $syncState
+    } else {
+        return '='
+    }
+}
+
+Export-ModuleMember -Function Get-BranchSyncState

--- a/utils/query-state/Get-BranchSyncState.tests.ps1
+++ b/utils/query-state/Get-BranchSyncState.tests.ps1
@@ -1,0 +1,58 @@
+BeforeAll {
+    . "$PSScriptRoot/../../utils/testing.ps1"
+    Import-Module -Scope Local "$PSScriptRoot/../../utils/query-state.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Get-BranchSyncState.psm1"
+}
+
+Describe 'Get-BranchSyncState' {
+    It 'prevents using the mocks if configuration is local' {
+        Initialize-ToolConfiguration -noRemote
+        { Initialize-RemoteBranchBehind 'my-branch' } | Should -Throw
+    }
+
+    It 'reports in-sync if the branch is local' {
+        Initialize-ToolConfiguration -noRemote
+        { Initialize-RemoteBranchBehind 'my-branch' } | Should -Throw
+    }
+
+    Context 'with remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration
+        }
+
+        It 'reports when the branch is behind' {
+            Initialize-RemoteBranchBehind 'my-branch'
+
+            $result = Get-BranchSyncState 'my-branch'
+            $result | Should -Be '<'
+        }
+
+        It 'reports when the branch is ahead' {
+            Initialize-RemoteBranchAhead 'my-branch'
+
+            $result = Get-BranchSyncState 'my-branch'
+            $result | Should -Be '>'
+        }
+
+        It 'reports when the branch is up-to-date' {
+            Initialize-RemoteBranchInSync 'my-branch'
+
+            $result = Get-BranchSyncState 'my-branch'
+            $result | Should -Be '='
+        }
+
+        It 'reports when the branch is not tracked' {
+            Initialize-RemoteBranchNotTracked 'my-branch'
+
+            $result = Get-BranchSyncState 'my-branch'
+            $result | Should -BeNullOrEmpty
+        }
+
+        It 'reports when the branch is out of sync' {
+            Initialize-RemoteBranchAheadAndBehind 'my-branch'
+
+            $result = Get-BranchSyncState 'my-branch'
+            $result | Should -Be '<>'
+        }
+    }
+}


### PR DESCRIPTION
Leverages [git's `upstream:trackshort`](https://git-scm.com/docs/git-for-each-ref#Documentation/git-for-each-ref.txt-upstream) functionality to report whether the local branch is up-to-date or not. Will be used as part of the `add-upstream` refactor.