### PR TITLE
Add action to assert a branch is pushed

### DIFF
--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -1,11 +1,13 @@
 Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertPushed.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSetUpstream.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionCreateBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSimplifyUpstreamBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionValidateBranchNames.psm1"
 
 $localActions = @{}
+Register-LocalActionAssertPushed $localActions
 Register-LocalActionSetUpstream $localActions
 Register-LocalActionCreateBranch $localActions
 Register-LocalActionSimplifyUpstreamBranches $localActions

--- a/utils/actions/local/Register-LocalActionAssertPushed.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.mocks.psm1
@@ -1,0 +1,25 @@
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionAssertPushed.psm1"
+
+function Initialize-LocalActionAssertPushedNotTracked(
+    [string] $branchName
+) {
+    Initialize-RemoteBranchNotTracked $branchName
+}
+
+function Initialize-LocalActionAssertPushedSuccess(
+    [string] $branchName
+) {
+    Initialize-RemoteBranchInSync $branchName
+}
+
+function Initialize-LocalActionAssertPushedAhead(
+    [string] $branchName
+) {
+    Initialize-RemoteBranchAhead $branchName
+}
+
+Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead

--- a/utils/actions/local/Register-LocalActionAssertPushed.psm1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.psm1
@@ -1,0 +1,23 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+
+function Register-LocalActionAssertPushed([PSObject] $localActions) {
+    $localActions['assert-pushed'] = {
+        param(
+            [Parameter()][string] $target,
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+
+        $state = Get-BranchSyncState $target
+
+        $disallowed = @('>', '<>')
+        if ($disallowed -contains $state) {
+            Add-ErrorDiagnostic $diagnostics "The local branch for $target has changes that are not pushed to the remote"
+        }
+        
+        return @{}
+    }
+}
+
+Export-ModuleMember -Function Register-LocalActionAssertPushed

--- a/utils/actions/local/Register-LocalActionAssertPushed.tests.ps1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.tests.ps1
@@ -1,0 +1,69 @@
+Describe 'local action "assert-pushed"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionAssertPushed.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $standardScript = ('{ 
+            "type": "assert-pushed", 
+            "parameters": {
+                "target": "my-branch"
+            }
+        }' | ConvertFrom-Json)
+    }
+
+    Context 'with remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration
+        }
+
+        It 'passes if a branch is up-to-date' {
+            Initialize-LocalActionAssertPushedSuccess 'my-branch'
+
+            Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        }
+
+        It 'passes if a branch has no local' {
+            Initialize-RemoteBranchNotTracked 'my-branch'
+
+            Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        }
+
+        It 'fails if a branch has not pushed changes' {
+            Initialize-LocalActionAssertPushedAhead 'my-branch'
+
+            Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The local branch for my-branch has changes that are not pushed to the remote'
+        }
+    }
+    
+    Context 'without remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration -noRemote
+        }
+
+        It 'always passes' {
+            Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        }
+    }
+}


### PR DESCRIPTION
Ensures the local version of a branch is fully pushed, even if it may be behind locally.