### PR TITLE
Add `get-upstream` to get existing upstreams

### DIFF
--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -1,14 +1,14 @@
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAssertPushed.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead
 
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionCreateBranch.mocks.psm1"
+Export-ModuleMember -Function Initialize-LocalActionCreateBranchSuccess
+
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionGetUpstream.mocks.psm1"
 Export-ModuleMember -Function Initialize-AnyUpstreamBranches,Initialize-UpstreamBranches
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionSetUpstream.mocks.psm1"
 Export-ModuleMember -Function Lock-LocalActionSetUpstream, Initialize-LocalActionSetUpstream
-
-Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionCreateBranch.mocks.psm1"
-Export-ModuleMember -Function Initialize-LocalActionCreateBranchSuccess
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionSimplifyUpstreamBranches.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionSimplifyUpstreamBranchesSuccess

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -1,3 +1,9 @@
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAssertPushed.mocks.psm1"
+Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead
+
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionGetUpstream.mocks.psm1"
+Export-ModuleMember -Function Initialize-AnyUpstreamBranches,Initialize-UpstreamBranches
+
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionSetUpstream.mocks.psm1"
 Export-ModuleMember -Function Lock-LocalActionSetUpstream, Initialize-LocalActionSetUpstream
 
@@ -6,6 +12,9 @@ Export-ModuleMember -Function Initialize-LocalActionCreateBranchSuccess
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionSimplifyUpstreamBranches.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionSimplifyUpstreamBranchesSuccess
+
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionValidateBranchNames.mocks.psm1"
+Export-ModuleMember -Function Initialize-LocalActionValidateBranchNamesSuccess
 
 Import-Module -Scope Local "$PSScriptRoot/actions/finalize/Register-FinalizeActionCheckout.mocks.psm1"
 Export-ModuleMember -Function Initialize-FinalizeActionCheckout

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -5,6 +5,7 @@ Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSetUpstream.
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionCreateBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSimplifyUpstreamBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionValidateBranchNames.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionGetUpstream.psm1"
 
 $localActions = @{}
 Register-LocalActionAssertPushed $localActions
@@ -12,6 +13,7 @@ Register-LocalActionSetUpstream $localActions
 Register-LocalActionCreateBranch $localActions
 Register-LocalActionSimplifyUpstreamBranches $localActions
 Register-LocalActionValidateBranchNames $localActions
+Register-LocalActionGetUpstream $localActions
 
 function Invoke-LocalAction(
     [PSObject] $actionDefinition,

--- a/utils/actions/local/Register-LocalActionGetUpstream.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.mocks.psm1
@@ -1,0 +1,7 @@
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionGetUpstream.psm1"
+
+Export-ModuleMember -Function Initialize-AnyUpstreamBranches,Initialize-UpstreamBranches

--- a/utils/actions/local/Register-LocalActionGetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.psm1
@@ -1,0 +1,18 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+
+function Register-LocalActionGetUpstream([PSObject] $localActions) {
+    $localActions['get-upstream'] = {
+        param(
+            [Parameter(Mandatory)][string] $target,
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+
+        [string[]]$result = Select-UpstreamBranches -branchName $target
+        
+        return $result
+    }
+}
+
+Export-ModuleMember -Function Register-LocalActionGetUpstream

--- a/utils/actions/local/Register-LocalActionGetUpstream.tests.ps1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.tests.ps1
@@ -1,0 +1,79 @@
+Describe 'local action "get-upstream"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionGetUpstream.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $standardScript = ('{ 
+            "type": "get-upstream", 
+            "parameters": {
+                "target": "my-branch"
+            }
+        }' | ConvertFrom-Json)
+    }
+
+    function Initialize-StandardTests {
+        It 'gets the configured upstream branches' {
+            Initialize-UpstreamBranches @{
+                'my-branch' = @('main')
+            }
+    
+            $results = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+    
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            $results | Should -Be @('main')
+        }
+
+        It 'gets all configured upstream branches' {
+            Initialize-UpstreamBranches @{
+                'my-branch' = @('feature-base', 'infra/refactor')
+            }
+    
+            $results = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+    
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            $results | Should -Be @('feature-base', 'infra/refactor')
+        }
+
+        It 'gets an empty array if no configuration exists' {
+            Initialize-UpstreamBranches @{
+                'my-other-branch' = @('feature-base', 'infra/refactor')
+            }
+    
+            $results = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+    
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            $results | Should -Be @()
+        }
+    }
+
+    Context 'with remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration
+            Initialize-AnyUpstreamBranches
+        }
+
+        Initialize-StandardTests
+    }
+
+    Context 'without remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration -noRemote
+            Initialize-AnyUpstreamBranches
+        }
+
+        Initialize-StandardTests
+    }
+}


### PR DESCRIPTION
- Provides access to current upstreams of a branch for scripting system
- Does not add new mocks; instead, leverages existing ones
