### PR TITLE
Update "merge-branches" to allow a source

### DIFF
--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -2,7 +2,7 @@ Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAsse
 Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionMergeBranches.mocks.psm1"
-Export-ModuleMember -Function Initialize-LocalActionMergeBranchesSuccess
+Export-ModuleMember -Function Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionGetUpstream.mocks.psm1"
 Export-ModuleMember -Function Initialize-AnyUpstreamBranches,Initialize-UpstreamBranches

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -1,11 +1,11 @@
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAssertPushed.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead
 
-Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionMergeBranches.mocks.psm1"
-Export-ModuleMember -Function Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess
-
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionGetUpstream.mocks.psm1"
 Export-ModuleMember -Function Initialize-AnyUpstreamBranches,Initialize-UpstreamBranches
+
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionMergeBranches.mocks.psm1"
+Export-ModuleMember -Function Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionSetUpstream.mocks.psm1"
 Export-ModuleMember -Function Lock-LocalActionSetUpstream, Initialize-LocalActionSetUpstream

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -1,21 +1,21 @@
 Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertPushed.psm1"
-Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSetUpstream.psm1"
-Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionMergeBranches.psm1"
-Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSimplifyUpstreamBranches.psm1"
-Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionValidateBranchNames.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionGetUpstream.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionFilterBranches.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionMergeBranches.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSetUpstream.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSimplifyUpstreamBranches.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionValidateBranchNames.psm1"
 
 $localActions = @{}
 Register-LocalActionAssertPushed $localActions
-Register-LocalActionSetUpstream $localActions
-Register-LocalActionMergeBranches $localActions
-Register-LocalActionSimplifyUpstreamBranches $localActions
-Register-LocalActionValidateBranchNames $localActions
 Register-LocalActionGetUpstream $localActions
 Register-LocalActionFilterBranches $localActions
+Register-LocalActionMergeBranches $localActions
+Register-LocalActionSetUpstream $localActions
+Register-LocalActionSimplifyUpstreamBranches $localActions
+Register-LocalActionValidateBranchNames $localActions
 
 function Invoke-LocalAction(
     [PSObject] $actionDefinition,

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -6,6 +6,7 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 function Register-LocalActionMergeBranches([PSObject] $localActions) {
     $localActions['merge-branches'] = {
         param(
+            [string] $source,
             [string[]] $upstreamBranches,
             [string] $mergeMessageTemplate,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
@@ -14,12 +15,17 @@ function Register-LocalActionMergeBranches([PSObject] $localActions) {
         $config = Get-Configuration
         if ($null -ne $config.remote) {
             $upstreamBranches = [string[]]$upstreamBranches | Foreach-Object { "$($config.remote)/$_" }
+            if ($null -ne $source -AND '' -ne $source) {
+                $source = "$($config.remote)/$source"
+            }
         }
 
-        $mergeResult = Invoke-MergeTogether $upstreamBranches -messageTemplate $mergeMessageTemplate -diagnostics $diagnostics -asWarnings
+        $mergeResult = Invoke-MergeTogether -source $source -commitishes $upstreamBranches -messageTemplate $mergeMessageTemplate -diagnostics $diagnostics -asWarnings
         $commit = $mergeResult.result
         if ($null -eq $commit) {
-            Add-ErrorDiagnostic $diagnostics "No branches could be resolved to merge"
+            if ($source -notin $mergeResult.failed) {
+                Add-ErrorDiagnostic $diagnostics "No branches could be resolved to merge"
+            }
         }
         # TODO - output successfully merged branches
         return @{ commit = $commit }


### PR DESCRIPTION
The "source" parameter for merge-branches forces the initial commit to be from a specific branch.

Will be used in: 
- `add-upstream`, to ensure that the source branch isn't lost in the process
- `rc`, to ensure that it starts with the service line