### PR TITLE
Finalize action "track"

### DIFF
--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -21,3 +21,6 @@ Export-ModuleMember -Function Initialize-FinalizeActionCheckout
 
 Import-Module -Scope Local "$PSScriptRoot/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1"
 Export-ModuleMember -Function Initialize-FinalizeActionSetBranches
+
+Import-Module -Scope Local "$PSScriptRoot/actions/finalize/Register-FinalizeActionTrack.mocks.psm1"
+Export-ModuleMember -Function Initialize-FinalizeActionTrackSuccess

--- a/utils/actions/Invoke-FinalizeAction.psm1
+++ b/utils/actions/Invoke-FinalizeAction.psm1
@@ -2,10 +2,12 @@ Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/finalize/Register-FinalizeActionCheckout.psm1"
 Import-Module -Scope Local "$PSScriptRoot/finalize/Register-FinalizeActionSetBranches.psm1"
+Import-Module -Scope Local "$PSScriptRoot/finalize/Register-FinalizeActionTrack.psm1"
 
 $finalizeActions = @{}
 Register-FinalizeActionCheckout $finalizeActions
 Register-FinalizeActionSetBranches $finalizeActions
+Register-FinalizeActionTrack $finalizeActions
 
 function Invoke-FinalizeAction(
     [PSObject] $actionDefinition,

--- a/utils/actions/finalize/Register-FinalizeActionTrack.mocks.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.mocks.psm1
@@ -10,16 +10,14 @@ function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
 
 function Initialize-FinalizeActionTrackSuccess(
     [Parameter()][AllowEmptyCollection()][string[]] $branches,
-    [Parameter()][AllowEmptyCollection()][string[]] $untracked,
-    [Parameter()][string] $currentBranch
+    [Parameter()][AllowEmptyCollection()][string[]] $untracked
 ) {
     $config = Get-Configuration
-
-    if ($currentBranch) {
-        Initialize-CurrentBranch $currentBranch
-    } else {
-        Initialize-NoCurrentBranch
+    if ($null -eq $config.remote) {
+        return
     }
+
+    $currentBranch = Get-CurrentBranch
 
     foreach ($branch in $untracked) {
         Initialize-GetLocalBranchForRemote $branch $null

--- a/utils/actions/finalize/Register-FinalizeActionTrack.mocks.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.mocks.psm1
@@ -1,0 +1,44 @@
+Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../input.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-FinalizeActionTrack.psm1"
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Register-FinalizeActionTrack' @PSBoundParameters
+}
+
+function Initialize-FinalizeActionTrackSuccess(
+    [Parameter()][AllowEmptyCollection()][string[]] $branches,
+    [Parameter()][AllowEmptyCollection()][string[]] $untracked,
+    [Parameter()][string] $currentBranch
+) {
+    $config = Get-Configuration
+
+    if ($currentBranch) {
+        Initialize-CurrentBranch $currentBranch
+    } else {
+        Initialize-NoCurrentBranch
+    }
+
+    foreach ($branch in $untracked) {
+        Initialize-GetLocalBranchForRemote $branch $null
+    }
+
+    foreach ($branch in $branches) {
+        if ($untracked -notcontains $branch) {
+            Initialize-GetLocalBranchForRemote $branch $branch
+        }
+
+        if ($branch -eq $currentBranch) {
+            if ($untracked -contains $currentBranch) {
+                Invoke-MockGit "branch $currentBranch --set-upstream-to refs/remotes/$($config.remote)/$currentBranch"
+            }
+            Invoke-MockGit "reset --hard refs/remotes/$($config.remote)/$branch"
+        } else {
+            Invoke-MockGit "branch $branch refs/remotes/$($config.remote)/$branch -f"
+        }
+    }
+}
+
+Export-ModuleMember -Function Initialize-FinalizeActionTrackSuccess

--- a/utils/actions/finalize/Register-FinalizeActionTrack.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.psm1
@@ -1,0 +1,52 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
+
+function Register-FinalizeActionTrack([PSObject] $finalizeActions) {
+    $finalizeActions['track'] = {
+        param(
+            [Parameter()][AllowEmptyCollection()][string[]] $branches,
+            [Parameter()][bool] $createIfNotTracked,
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+        [string[]] $tracked = @()
+        $config = Get-Configuration
+        if ($null -eq $config.remote) {
+            return $tracked
+        }
+
+        $currentBranch = Get-CurrentBranch
+        foreach ($branch in $branches) {
+            $localBranch = Get-LocalBranchForRemote $branch
+            if (-not $localBranch -AND $currentBranch -eq $branch) {
+                # current branch matches tracked one, but doesn't currently track the remote
+                $localBranch = $currentBranch
+                Invoke-ProcessLogs "git branch $localBranch --set-upstream-to refs/remotes/$($config.remote)/$branch" {
+                    git branch $localBranch --set-upstream-to "refs/remotes/$($config.remote)/$branch"
+                }
+            }
+            
+            if ($currentBranch -eq $localBranch) {
+                # update head
+                Invoke-ProcessLogs "git reset --hard refs/remotes/$($config.remote)/$branch" {
+                    git reset --hard "refs/remotes/$($config.remote)/$branch"
+                }
+            } elseif ($localBranch -OR $createIfNotTracked) {
+                $localBranch = $localBranch ? $localBranch : $branch
+                # update
+                Invoke-ProcessLogs "git branch $localBranch refs/remotes/$($config.remote)/$branch -f" {
+                    git branch $localBranch "refs/remotes/$($config.remote)/$branch" -f
+                }
+            } else {
+                continue
+            }
+            $tracked += $branch
+        }
+
+        return $tracked
+    }
+}
+
+Export-ModuleMember -Function Register-FinalizeActionTrack

--- a/utils/actions/finalize/Register-FinalizeActionTrack.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.tests.ps1
@@ -1,0 +1,108 @@
+Describe 'finalize action "track"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../input.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../actions.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-FinalizeAction.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $standardScript = ('{ 
+            "type": "track", 
+            "parameters": {
+                "branches": ["foo","bar"]
+            }
+        }' | ConvertFrom-Json)
+    }
+
+    Context 'without remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration -noRemote
+        }
+        
+        It 'does nothing' {
+            $result = Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
+
+            $result | Should -BeNullOrEmpty
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+
+        }
+    }
+
+    Context 'with remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration
+        }
+
+        It 'forces creation of local branches' {
+            $standardScript = ('{ 
+                "type": "track", 
+                "parameters": {
+                    "createIfNotTracked": true,
+                    "branches": ["foo","bar"]
+                }
+            }' | ConvertFrom-Json)
+
+            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -untracked @('foo', 'bar')
+
+            Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            Invoke-VerifyMock $mocks -Times 1
+
+        }
+        
+        It 'ensures local branches are updated' {
+            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar')
+
+            Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            Invoke-VerifyMock $mocks -Times 1
+
+        }
+        
+        It 'updates the current branch' {
+            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -currentBranch 'foo'
+
+            Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            Invoke-VerifyMock $mocks -Times 1
+
+        }
+        
+        It 'updates no branches if they are untracked' {
+            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -currentBranch 'foo'
+
+            Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            Invoke-VerifyMock $mocks -Times 1
+
+        }
+        
+        It 'updates the current branch even if it is untracked' {
+            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -untracked @('foo') -currentBranch 'foo'
+
+            Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            Invoke-VerifyMock $mocks -Times 1
+
+        }
+    }
+}

--- a/utils/actions/finalize/Register-FinalizeActionTrack.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.tests.ps1
@@ -33,7 +33,6 @@ Describe 'finalize action "track"' {
             $result | Should -BeNullOrEmpty
             Invoke-FlushAssertDiagnostic $fw.diagnostics
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
-
         }
     }
 
@@ -51,6 +50,7 @@ Describe 'finalize action "track"' {
                 }
             }' | ConvertFrom-Json)
 
+            Initialize-NoCurrentBranch
             $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -untracked @('foo', 'bar')
 
             Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
@@ -62,6 +62,7 @@ Describe 'finalize action "track"' {
         }
         
         It 'ensures local branches are updated' {
+            Initialize-NoCurrentBranch
             $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar')
 
             Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
@@ -73,7 +74,8 @@ Describe 'finalize action "track"' {
         }
         
         It 'updates the current branch' {
-            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -currentBranch 'foo'
+            Initialize-CurrentBranch 'foo'
+            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar')
 
             Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
 
@@ -84,25 +86,25 @@ Describe 'finalize action "track"' {
         }
         
         It 'updates no branches if they are untracked' {
-            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -currentBranch 'foo'
+            Initialize-CurrentBranch 'foo'
+            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar')
 
             Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
 
             Invoke-FlushAssertDiagnostic $fw.diagnostics
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
             Invoke-VerifyMock $mocks -Times 1
-
         }
         
         It 'updates the current branch even if it is untracked' {
-            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -untracked @('foo') -currentBranch 'foo'
+            Initialize-CurrentBranch 'foo'
+            $mocks = Initialize-FinalizeActionTrackSuccess @('foo', 'bar') -untracked @('foo')
 
             Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
 
             Invoke-FlushAssertDiagnostic $fw.diagnostics
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
             Invoke-VerifyMock $mocks -Times 1
-
         }
     }
 }

--- a/utils/actions/template/Register-FinalizeActionXxx.psm1
+++ b/utils/actions/template/Register-FinalizeActionXxx.psm1
@@ -15,4 +15,4 @@ function Register-FinalizeActionXxx([PSObject] $finalizeActions) {
     }
 }
 
-Export-ModuleMember -Function Register-FinalizeActionSetBranches
+Export-ModuleMember -Function Register-FinalizeActionXxx

--- a/utils/actions/template/Register-FinalizeActionXxx.tests.ps1
+++ b/utils/actions/template/Register-FinalizeActionXxx.tests.ps1
@@ -24,9 +24,9 @@ Describe 'finalize action "xxx"' {
 
     function AddStandardTests() {
         It 'will be implemented' -Pending {
-            Initialize-LocalActionXxxSuccess
+            Initialize-FinalizeActionXxxSuccess
 
-            Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+            Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics
 
             Invoke-FlushAssertDiagnostic $fw.diagnostics
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
@@ -18,6 +18,8 @@ function ConvertFrom-ParameterizedAnything(
 ) {
     if ($null -eq $script) {
         return @{ result = $null; fail = $false }
+    } elseif ($script -is [bool]) {
+        return @{ result = $script; fail = $false }
     } elseif ($script -is [string] -AND $script[0] -eq '$' -AND $script[1] -ne '(') {
         try {
             $targetScript = [ScriptBlock]::Create('

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
@@ -103,4 +103,12 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }
     }
     
+    It 'preserve boolean JSON types' {
+        $target = @{ 'foo' = $true; 'bar' = $false }
+        $target = $target | ConvertTo-Json | ConvertFrom-Json
+        $params = @{ }
+        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $result.result | Assert-ShouldBeObject @{ 'foo' = $true; 'bar' = $false }
+    }
+    
 }


### PR DESCRIPTION
Adds a new "track" finalize action that ensures local branches are updated with remote branches.
- Doesn't do anything for non-remote repositories, since those are always up-to-date (but gracefully completes)
- If the current branch's name matches a tracked remote branch but doesn't track it, tracks the remote and resets it to match the remote
- If the current branch tracks the remote, resets it to match the remote
