### PR TITLE
Correct docker tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN echo "\$ErrorActionPreference = 'Stop'" > profile.ps1
 ADD . /git-tools
 
 WORKDIR /git-tools
-RUN pwsh -c 'Install-Module Pester -Force; Import-Module Pester -PassThru; Invoke-Pester'
+RUN pwsh -c 'Install-Module Pester -Force; Import-Module Pester -PassThru; Invoke-Pester; exit $lastExitCode'
 
 WORKDIR /repos/
 

--- a/utils/framework/processlog-framework.psm1
+++ b/utils/framework/processlog-framework.psm1
@@ -52,9 +52,13 @@ function Invoke-ProcessLogs {
     } else {
         $job = $null
     }
+    $tempErrorActionPreference = $global:ErrorActionPreference
     try {
+        # Since we want to capture error output inside this, don't just stop...
+        $global:ErrorActionPreference = 'Continue'
         & $process *>&1 | Write-ProcessLogs $processDescription -allowSuccessOutput:$allowSuccessOutput
     } finally {
+        $global:ErrorActionPreference = $tempErrorActionPreference
         $state.isRunning = $false
         $timer.Stop()
         if ($null -ne $job -AND $job.jobstateinfo.state -ne 'Completed') {


### PR DESCRIPTION
Unless explicitly throwing an exit code, `pwsh -c` does not return the last exit code. The processlog-framework tests have been failing for some time in main as a result; this also includes those fixes.