### PR TITLE
Update `git-add-upstream` to new framework

### DIFF
--- a/git-add-upstream.json
+++ b/git-add-upstream.json
@@ -1,0 +1,78 @@
+{
+    "local": [
+        {
+            "type": "assert-pushed",
+            "parameters": {
+                "target": "$params.target"
+            }
+        },
+        {
+            "id": "get-upstream",
+            "type": "get-upstream",
+            "parameters": {
+                "target": "$params.target"
+            }
+        },
+        {
+            "id": "simplify-upstream",
+            "type": "simplify-upstream",
+            "parameters": {
+                "upstreamBranches": ["$actions['get-upstream'].outputs", "$params.upstreamBranches"]
+            }
+        },
+        {
+            "id": "filtered-upstream",
+            "type": "filter-branches",
+            "parameters": {
+                "include": ["$actions['simplify-upstream'].outputs"],
+                "exclude": ["$actions['get-upstream'].outputs"]
+            }
+        },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions['filtered-upstream'].outputs ? $false : $true",
+            "parameters": {
+                "message": "No branches would be added."
+            }
+        },
+        {
+            "id": "set-upstream",
+            "type": "set-upstream",
+            "parameters": {
+                "upstreamBranches": {
+                    "$params.target": ["$actions['simplify-upstream'].outputs"]
+                },
+                "message": "Add branches $($actions['filtered-upstream'].outputs) to $($params.target)$($params.comment -eq '' ? '' : \" for $($params.comment)\")"
+            }
+        },
+        {
+            "id": "merge-branches",
+            "type": "merge-branches",
+            "parameters": {
+                "source": "$($params.target)",
+                "upstreamBranches": ["$actions['filtered-upstream'].outputs"],
+                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+            }
+        }
+    ],
+    "finalize": [
+        {
+            "type": "set-branches",
+            "parameters": {
+                "branches": {
+                    "$config.upstreamBranch": "$actions['set-upstream'].outputs['commit']",
+                    "$params.target": "$actions['merge-branches'].outputs['commit']"
+                }
+            }
+        },
+        {
+            "type": "track",
+            "parameters": {
+                "branches": ["$params.target"]
+            }
+        }
+    ],
+    "output": [
+        "$($params.target) has the following branches added upstream: $($actions['filtered-upstream'].outputs)"
+    ]
+}

--- a/git-add-upstream.ps1
+++ b/git-add-upstream.ps1
@@ -7,76 +7,12 @@ Param(
     [switch] $dryRun
 )
 
-# git doesn't pass them as separate items in the array
-. $PSScriptRoot/config/core/split-string.ps1
-$upstreamBranches = [String[]]($upstreamBranches -eq $nil ? @() : (Split-String $upstreamBranches))
-
-. $PSScriptRoot/config/core/coalesce.ps1
+Import-Module -Scope Local "$PSScriptRoot/utils/input.psm1"
+Import-Module -Scope Local "$PSScriptRoot/utils/scripting.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
-Import-Module -Scope Local "$PSScriptRoot/utils/git.psm1"
-Import-Module -Scope Local "$PSScriptRoot/config/git/Assert-BranchPushed.psm1"
-Import-Module -Scope Local "$PSScriptRoot/config/git/Set-MultipleUpstreamBranches.psm1"
 
-$config = Get-Configuration
-
-$isCurrentBranch = ($target -eq $nil -OR $target -eq '')
-$target = $isCurrentBranch ? (Get-CurrentBranch) : $target
-if ($target -eq $nil) {
-    throw 'Must specify a branch'
-}
-
-Assert-CleanWorkingDirectory
-Update-GitRemote
-
-Assert-BranchPushed $target -m 'Please ensure changes are pushed (or reset) and try again.' -failIfNoUpstream
-
-$parentBranches = [String[]](Select-UpstreamBranches $target)
-
-$finalBranches = [String[]](Compress-UpstreamBranches (@($upstreamBranches, $parentBranches) | ForEach-Object { $_ } | Select-Object -uniq))
-
-$addedBranches = [String[]]($finalBranches | Where-Object { $parentBranches -notcontains $_ })
-
-if ($addedBranches.length -eq 0) {
-    throw 'All branches already upstream of target branch'
-}
-
-$commitMessage = "Add $($upstreamBranches -join ', ') to $target"
-if ($comment -ne '') {
-    $commitMessage = $commitMessage + "for $comment"
-}
-
-$result = Invoke-PreserveBranch {
-    $fullBranchName = $config.remote -eq $nil ? $target : "$($config.remote)/$($target)"
-    $sha = git rev-parse --verify $fullBranchName -q 2> $nil
-    Invoke-CheckoutBranch $sha -quiet
-    Assert-CleanWorkingDirectory
-
-    $mergeResult = Invoke-MergeBranches ($config.remote -eq $nil ? $addedBranches : ($addedBranches | ForEach-Object { "$($config.remote)/$($_)" }))
-    if (-not $mergeResult.isValid) {
-        Write-Host -ForegroundColor yellow "Not all branches requested could be merged automatically. Please use the following commands to add it manually to your branch and then re-run ``git add-upstream``:"
-        Write-Host -ForegroundColor yellow "    git merge $($mergeResult.branch)"
-
-        return New-ResultAfterCleanup $false
-    }
-
-    $upstreamCommitish = Set-MultipleUpstreamBranches @{ $target = $finalBranches } -m $commitMessage
-    if ($upstreamCommitish -eq $nil -OR $commitish -eq '') {
-        throw 'Failed to update upstream branch commit'
-    }
-
-    if (-not $dryRun) {
-        if ($config.remote) {
-            $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
-            git push $config.remote @atomicPart "HEAD:$($target)" "$($upstreamCommitish):refs/heads/$($config.upstreamBranch)"
-        } else {
-            git branch -f $config.upstreamBranch $upstreamCommitish
-        }
-        git branch -f $target HEAD
-        if ($config.remote) {
-            Set-RemoteTracking $target
-        }
-    }
-}
-if ($result -eq $false) {
-    exit 1
-}
+Invoke-JsonScript -scriptPath "$PSScriptRoot/git-add-upstream.json" -params @{
+    target = ($target ? $target : (Get-CurrentBranch));
+    upstreamBranches = Expand-StringArray $upstreamBranches;
+    comment = $comment ?? '';
+} -dryRun:$dryRun

--- a/utils/actions/Invoke-FinalizeAction.psm1
+++ b/utils/actions/Invoke-FinalizeAction.psm1
@@ -13,6 +13,8 @@ function Invoke-FinalizeAction(
     [PSObject] $actionDefinition,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
 ) {
+    $actionDefinition = ConvertTo-Hashtable $actionDefinition
+
     # look up type
     $targetAction = $finalizeActions[$actionDefinition.type]
     if ($null -eq $targetAction) {
@@ -21,7 +23,7 @@ function Invoke-FinalizeAction(
     }
 
     # if a condition is specified, ensure it is truthy
-    if ($actionDefinition.PSObject.Properties.name -contains 'condition' -AND -not $actionDefinition.condition) {
+    if ($actionDefinition.Keys -contains 'condition' -AND -not $actionDefinition.condition) {
         return $null
     }
 

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -23,6 +23,8 @@ function Invoke-LocalAction(
     [PSObject] $actionDefinition,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
 ) {
+    $actionDefinition = ConvertTo-Hashtable $actionDefinition
+
     # look up type
     $targetAction = $localActions[$actionDefinition.type]
     if ($null -eq $targetAction) {
@@ -31,7 +33,7 @@ function Invoke-LocalAction(
     }
 
     # if a condition is specified, ensure it is truthy
-    if ($actionDefinition.PSObject.Properties.name -contains 'condition' -AND -not $actionDefinition.condition) {
+    if ($actionDefinition.Keys -contains 'condition' -AND -not $actionDefinition.condition) {
         return $null
     }
 

--- a/utils/actions/local/Register-LocalActionFilterBranches.tests.ps1
+++ b/utils/actions/local/Register-LocalActionFilterBranches.tests.ps1
@@ -28,6 +28,22 @@ Describe 'local action "filter-branches"' {
         $outputs | Should -Be @('foo', 'bar')
     }
 
+    It 'can filter to a single branch and return an array' {
+        $standardScript = ('{ 
+            "type": "filter-branches", 
+            "parameters": {
+                "include": ["foo","bar","baz"],
+                "exclude": ["bar", "baz"]
+            }
+        }' | ConvertFrom-Json)
+
+        $outputs = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        Should -ActualValue $outputs -Be @('foo')
+    }
+
     It 'allows for no branches to remove' {
         $standardScript = ('{ 
             "type": "filter-branches", 
@@ -73,6 +89,7 @@ Describe 'local action "filter-branches"' {
 
         Invoke-FlushAssertDiagnostic $fw.diagnostics
         $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
-        $outputs | Should -Be @()
+        # Powershell really doesn't like empty arrays, tends to convert them to $null
+        Should -ActualValue $outputs -Be $null
     }
 }

--- a/utils/query-state/Get-BranchSyncState.psm1
+++ b/utils/query-state/Get-BranchSyncState.psm1
@@ -7,7 +7,7 @@ function Get-BranchSyncState(
     $config = Get-Configuration
     if ($config.remote -ne $nil) {
         # Will give empty string for not tracked, `<` for behind, `>` for commits that aren't pushed, `=` for same, and `<>` for both remote and local have extra commits
-        $syncState = Invoke-ProcessLogs "get local branch for $($config.remote)/$branchName" {
+        $syncState = Invoke-ProcessLogs "get sync state for $($config.remote)/$branchName" {
             git for-each-ref "--format=%(if:equals=$($config.remote)/$branchName)%(upstream:short)%(then)%(upstream:trackshort)%(else)%(end)" refs/heads --omit-empty
         } -allowSuccessOutput
 

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -25,7 +25,7 @@ function Invoke-Script(
             }
             try {
                 $outputs = Invoke-LocalAction $local.result -diagnostics $diagnostics
-                if ($null -ne $local.result.id -AND $null -ne $outputs) {
+                if ($null -ne $local.result.id) {
                     $actions += @{ $local.result.id = @{ outputs = $outputs } }
                 }
             } catch {
@@ -59,7 +59,7 @@ function Invoke-Script(
             $finalize = $allFinalizeScripts[$i]
             try {
                 $outputs = Invoke-FinalizeAction $finalize -diagnostics $diagnostics
-                if ($null -ne $finalize.id -AND $null -ne $outputs) {
+                if ($null -ne $finalize.id) {
                     $actions += @{ $finalize.id = @{ outputs = $outputs } }
                 }
             } catch {


### PR DESCRIPTION
- Adds the git-add-upstream.json script
- Rewrites all the tests in git-add-upstream
- Normalizes objects passed to `Invoke-LocalAction` and `Invoke-FinalizeAction`


`git add-upstream` will now have success messages similar to:
```
PS C:\Users\mattd\source\git-demo> git add-upstream temp
WARN: Removing 'main' from branches; it is redundant via the following: temp
Working on 'git push origin'...
End 'git push origin'. (1.1s)
temp2 has the following branches added upstream: temp
```
... and error messages similar to:
```
PS C:\Users\mattd\source\git-demo> git add-upstream main
Logs for 'git fetch origin':
Logs for 'get sync state for origin/temp2':
Logs for 'git check-ref-format --branch feature/outdated':
    feature/outdated
Logs for 'git check-ref-format --branch temp':
    temp
Logs for 'git check-ref-format --branch main':
    main
WARN: Removing 'main' from branches; it is redundant via the following: feature/outdated temp
ERR:  No branches would be added.
```