### PR TITLE
Show the git commands with a dry-run

### DIFF
--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -23,4 +23,4 @@ Import-Module -Scope Local "$PSScriptRoot/actions/finalize/Register-FinalizeActi
 Export-ModuleMember -Function Initialize-FinalizeActionSetBranches
 
 Import-Module -Scope Local "$PSScriptRoot/actions/finalize/Register-FinalizeActionTrack.mocks.psm1"
-Export-ModuleMember -Function Initialize-FinalizeActionTrackSuccess
+Export-ModuleMember -Function Initialize-FinalizeActionTrackDryRun, Initialize-FinalizeActionTrackSuccess

--- a/utils/actions/Invoke-FinalizeAction.psm1
+++ b/utils/actions/Invoke-FinalizeAction.psm1
@@ -11,7 +11,8 @@ Register-FinalizeActionTrack $finalizeActions
 
 function Invoke-FinalizeAction(
     [PSObject] $actionDefinition,
-    [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
+    [switch] $dryRun
 ) {
     $actionDefinition = ConvertTo-Hashtable $actionDefinition
 
@@ -30,7 +31,7 @@ function Invoke-FinalizeAction(
     # run
     $parameters = ConvertTo-Hashtable $actionDefinition.parameters
     try {
-        $outputs = & $targetAction @parameters -diagnostics $diagnostics
+        $outputs = & $targetAction @parameters -diagnostics $diagnostics -dryRun:$dryRun
     } catch {
         Add-ErrorDiagnostic $diagnostics "Unhandled exception occurred while running '$(ConvertTo-Json $actionDefinition -Depth 10)':"
         Add-ErrorException $diagnostics $_

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
@@ -7,9 +7,14 @@ function Register-FinalizeActionCheckout([PSObject] $finalizeActions) {
     $finalizeActions['checkout'] = {
         param(
             [string] $HEAD,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
+            [switch] $dryRun
         )
 
+        if ($dryRun) {
+            "git checkout $HEAD"
+            return
+        }
         Assert-CleanWorkingDirectory -diagnostics $diagnostics
         if (-not (Get-HasErrorDiagnostic $diagnostics)) {
             Invoke-CheckoutBranch $HEAD -diagnostics $diagnostics

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.tests.ps1
@@ -35,6 +35,13 @@ Describe 'finalize action "checkout"' {
         Invoke-VerifyMock $mocks -Times 1
     }
 
+    It 'handles dry-run functionality' {
+        $dryRunCommands = Invoke-FinalizeAction $standardScript -diagnostics $diag -dryRun
+        $diag | Should -BeNullOrEmpty
+        
+        $dryRunCommands | Should -Contain 'git checkout new-branch'
+    }
+
     It 'fails if the working directory is not clean' {
         $mocks = @(
             Initialize-DirtyWorkingDirectory

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
@@ -59,6 +59,23 @@ Describe 'finalize action "set-branches"' {
             Invoke-VerifyMock $mocks -Times 1
         }
 
+        It 'can execute a dry run' {
+            Initialize-NoCurrentBranch
+            $mocks = @(
+                Initialize-AssertValidBranchName '_upstream'
+                Initialize-AssertValidBranchName 'other'
+                Initialize-AssertValidBranchName 'another'
+            )
+            
+            $dryRunCommands = Invoke-FinalizeAction $standardScript -diagnostics $diag -dryRun
+            $diag | Should -BeNullOrEmpty
+            Invoke-VerifyMock $mocks -Times 1
+
+            $dryRunCommands | Should -Contain 'git branch _upstream "new-upstream-commitish" -f'
+            $dryRunCommands | Should -Contain 'git branch other "other-commitish" -f'
+            $dryRunCommands | Should -Contain 'git branch another "another-commitish" -f'
+        }
+
         It 'handles standard functionality using mocks' {
             Initialize-NoCurrentBranch
             $mocks = Initialize-FinalizeActionSetBranches $standardBranches

--- a/utils/actions/finalize/Register-FinalizeActionTrack.mocks.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.mocks.psm1
@@ -8,6 +8,26 @@ function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
     return Invoke-MockGitModule -ModuleName 'Register-FinalizeActionTrack' @PSBoundParameters
 }
 
+function Initialize-FinalizeActionTrackDryRun(
+    [Parameter()][AllowEmptyCollection()][string[]] $branches,
+    [Parameter()][AllowEmptyCollection()][string[]] $untracked
+) {
+    $config = Get-Configuration
+    if ($null -eq $config.remote) {
+        return
+    }
+
+    foreach ($branch in $untracked) {
+        Initialize-GetLocalBranchForRemote $branch $null
+    }
+
+    foreach ($branch in $branches) {
+        if ($untracked -notcontains $branch) {
+            Initialize-GetLocalBranchForRemote $branch $branch
+        }
+    }
+}
+
 function Initialize-FinalizeActionTrackSuccess(
     [Parameter()][AllowEmptyCollection()][string[]] $branches,
     [Parameter()][AllowEmptyCollection()][string[]] $untracked
@@ -39,4 +59,4 @@ function Initialize-FinalizeActionTrackSuccess(
     }
 }
 
-Export-ModuleMember -Function Initialize-FinalizeActionTrackSuccess
+Export-ModuleMember -Function Initialize-FinalizeActionTrackDryRun, Initialize-FinalizeActionTrackSuccess

--- a/utils/actions/finalize/Register-FinalizeActionTrack.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.tests.ps1
@@ -70,7 +70,22 @@ Describe 'finalize action "track"' {
             Invoke-FlushAssertDiagnostic $fw.diagnostics
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
             Invoke-VerifyMock $mocks -Times 1
+        }
 
+        It 'can execute a dry run' {
+            Initialize-NoCurrentBranch
+            $mocks = Initialize-FinalizeActionTrackDryRun @('foo', 'bar')
+
+            $dryRunCommands = Invoke-FinalizeAction $standardScript -diagnostics $fw.diagnostics -dryRun
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            Invoke-VerifyMock $mocks -Times 1
+            
+            $dryRunCommands | Should -Be @(
+                'git branch foo "refs/remotes/origin/foo" -f'
+                'git branch bar "refs/remotes/origin/bar" -f'
+            )
         }
         
         It 'updates the current branch' {

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -48,17 +48,16 @@ function Invoke-Script(
         }
 
         $allFinalizeScripts = $allFinalize.result
-        if ($dryRun) {
-            # TODO: describe this rather than dumping JSON
-            Write-Host (ConvertTo-Json $allFinalizeScripts)
-            return
-        }
+        Write-Host -ForegroundColor Yellow "Executing dry run; would run the following commands:"
 
         for ($i = 0; $i -lt $allFinalizeScripts.Count; $i++) {
             $name = $allFinalizeScripts[$i].id ?? "#$($i + 1) (1-based)";
             $finalize = $allFinalizeScripts[$i]
             try {
-                $outputs = Invoke-FinalizeAction $finalize -diagnostics $diagnostics
+                $outputs = Invoke-FinalizeAction $finalize -diagnostics $diagnostics -dryRun:$dryRun
+                if ($dryRun) {
+                    $outputs | Write-Host
+                }
                 if ($null -ne $finalize.id) {
                     $actions += @{ $finalize.id = @{ outputs = $outputs } }
                 }

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -68,7 +68,7 @@ function Invoke-Script(
             Assert-Diagnostics $diagnostics
         }
         
-        if ($null -ne $script.output) {
+        if ($null -ne $script.output -AND -not $dryRun) {
             $allOutput = ConvertFrom-ParameterizedAnything -script $script.output -config $config -params $params -actions $actions -diagnostics $diagnostics
             $allOutput.result | Write-Output
         }


### PR DESCRIPTION
This PR runs finalize actions with a `$dryRun` switch instead of just showing the remaining scripts and updates existing finalize actions to show the corresponding git commands that would run.

However, this is not a user-friendly set of messages.
- Pushing a git hash to `_upstream` (or other remote branch) doesn't really clarify what actually changes
- Resetting branches and checking them out likewise doesn't communicate the result actions

I'm open to suggestions, though I think this is probably an improvement.