### PR TITLE
Use single commit to merge multiple branches

### DIFF
--- a/utils/git/Invoke-MergeTogether.mocks.psm1
+++ b/utils/git/Invoke-MergeTogether.mocks.psm1
@@ -45,7 +45,7 @@ function Initialize-MergeTogether(
         $allBranches = @($source) + $allBranches
     }
     if ($null -ne $source -AND '' -ne $source -AND $successfulBranches -notcontains $source) {
-        $successfulBranches = @($source) + $successfulBranches
+        $successfulBranches = @($source) + ($successfulBranches | Where-Object { $_ })
     }
     $initialSuccessfulBranch = ($allBranches | Where-Object { $successfulBranches -contains $_ } | Select-Object -First 1)
     


### PR DESCRIPTION
Using this, a single `pull-upstream` or `new` will add at most a single commit to merge in the additional branches, even if there is more than one.