### PR TITLE
Branch existence assertions

### DIFF
--- a/git-add-upstream.json
+++ b/git-add-upstream.json
@@ -1,6 +1,13 @@
 {
     "local": [
         {
+            "type": "assert-existence",
+            "parameters": {
+                "branches": ["$params.target", "$params.upstreamBranches"],
+                "shouldExist": true
+            }
+        },
+        {
             "type": "assert-pushed",
             "parameters": {
                 "target": "$params.target"

--- a/git-add-upstream.tests.ps1
+++ b/git-add-upstream.tests.ps1
@@ -20,6 +20,7 @@ Describe 'git-add-upstream' {
 
         It 'works on the current branch' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
                 Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
                 Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
@@ -46,6 +47,7 @@ Describe 'git-add-upstream' {
 
         It 'works if there are no upstream branches' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
                 Initialize-AnyUpstreamBranches
                 Initialize-UpstreamBranches @{ }
@@ -73,6 +75,7 @@ Describe 'git-add-upstream' {
 
         It 'works locally with multiple branches' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76', 'feature/FOO-84') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
                 Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
                 Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
@@ -99,6 +102,7 @@ Describe 'git-add-upstream' {
 
         It 'works locally against a target branch' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-NoCurrentBranch
                 Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
                 Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
@@ -125,6 +129,7 @@ Describe 'git-add-upstream' {
 
         It 'works locally with multiple branches against a target branch' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76', 'feature/FOO-84') -shouldExist $true
                 Initialize-NoCurrentBranch
                 Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
                 Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
@@ -158,6 +163,7 @@ Describe 'git-add-upstream' {
 
         It 'works on the current branch' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
                 Initialize-LocalActionAssertPushedSuccess 'rc/2022-07-14'
                 Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
@@ -185,6 +191,7 @@ Describe 'git-add-upstream' {
 
         It 'works if there are no upstream branches' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
                 Initialize-LocalActionAssertPushedSuccess 'rc/2022-07-14'
                 Initialize-AnyUpstreamBranches
@@ -213,6 +220,7 @@ Describe 'git-add-upstream' {
 
         It 'does nothing if the added branch is already included' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'infra/shared') -shouldExist $true
                 Initialize-LocalActionAssertPushedSuccess 'rc/2022-07-14'
                 Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services","infra/shared") }
                 Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
@@ -227,6 +235,7 @@ Describe 'git-add-upstream' {
 
         It 'simplifies if the added branch makes another redundant' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-123') -shouldExist $true
                 Initialize-CurrentBranch 'my-branch'
                 Initialize-LocalActionAssertPushedSuccess 'rc/2022-07-14'
                 Initialize-UpstreamBranches @{
@@ -259,6 +268,7 @@ Describe 'git-add-upstream' {
 
         It 'handles when the target branch doesn''t exist locally' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
                 Initialize-LocalActionAssertPushedNotTracked 'rc/2022-07-14'
                 Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
@@ -286,6 +296,7 @@ Describe 'git-add-upstream' {
 
         It 'outputs a helpful message if it fails' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
                 Initialize-LocalActionAssertPushedSuccess 'rc/2022-07-14'
                 Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
@@ -315,6 +326,7 @@ Describe 'git-add-upstream' {
 
         It 'ensures the remote is up-to-date' {
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-LocalActionAssertPushedAhead 'rc/2022-07-14'
             )
 

--- a/git-new.json
+++ b/git-new.json
@@ -7,6 +7,20 @@
             }
         },
         {
+            "type": "assert-existence",
+            "parameters": {
+                "branches": ["$params.branchName"],
+                "shouldExist": false
+            }
+        },
+        {
+            "type": "assert-existence",
+            "parameters": {
+                "branches": ["$params.upstreamBranches"],
+                "shouldExist": true
+            }
+        },
+        {
             "id": "simplify-upstream",
             "type": "simplify-upstream",
             "parameters": {

--- a/git-new.tests.ps1
+++ b/git-new.tests.ps1
@@ -26,6 +26,7 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'feature/PS-100-some-work'
 
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'main'
                 } -commitish 'new-commit'
@@ -49,6 +50,7 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'feature/PS-100-some-work'
             
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'main'
                 } -commitish 'new-commit'
@@ -73,6 +75,8 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'infra/foo'
 
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-600-some-work') -shouldExist $false
+                Initialize-LocalActionAssertExistence -branches @('infra/foo') -shouldExist $true
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-600-some-work' = 'infra/foo'
                 } -commitish 'new-commit'
@@ -98,6 +102,7 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'feature/PS-100-some-work'
             
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'main'
                 } -commitish 'new-commit'
@@ -145,6 +150,7 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'feature/PS-100-some-work'
 
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'main'
                 } -commitish 'new-commit'
@@ -169,6 +175,8 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'infra/foo'
 
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
+                Initialize-LocalActionAssertExistence -branches @('infra/foo') -shouldExist $true
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = 'infra/foo'
                 } -commitish 'new-commit'
@@ -195,6 +203,8 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'feature/homepage-redesign'
             
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
+                Initialize-LocalActionAssertExistence -branches @('infra/foo', 'main', 'feature/homepage-redesign') -shouldExist $true
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = @('feature/homepage-redesign')
                 } -commitish 'new-commit'
@@ -225,6 +235,8 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'infra/update-dependencies'
             
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
+                Initialize-LocalActionAssertExistence -branches @('infra/foo', 'main', 'feature/homepage-redesign', 'infra/update-dependencies') -shouldExist $true
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = @('feature/homepage-redesign', 'infra/update-dependencies')
                 } -commitish 'new-commit'
@@ -253,6 +265,8 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'infra/update-dependencies'
             
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
+                Initialize-LocalActionAssertExistence -branches @('feature/homepage-redesign', 'infra/update-dependencies') -shouldExist $true
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = @('feature/homepage-redesign', 'infra/update-dependencies')
                 } -commitish 'new-commit'
@@ -273,6 +287,8 @@ Describe 'git-new' {
             Initialize-AssertValidBranchName 'infra/update-dependencies'
             
             $mocks = @(
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-100-some-work') -shouldExist $false
+                Initialize-LocalActionAssertExistence -branches @('feature/homepage-redesign', 'infra/update-dependencies') -shouldExist $true
                 Initialize-LocalActionSetUpstream @{
                     'feature/PS-100-some-work' = @('feature/homepage-redesign', 'infra/update-dependencies')
                 } -commitish 'new-commit'

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -1,3 +1,6 @@
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAssertExistence.mocks.psm1"
+Export-ModuleMember -Function Initialize-LocalActionAssertExistence
+
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAssertPushed.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead
 

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -8,6 +8,7 @@ Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionMergeBranche
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSetUpstream.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSimplifyUpstreamBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionValidateBranchNames.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertExistence.psm1"
 
 $localActions = @{}
 Register-LocalActionAddDiagnostic $localActions
@@ -18,6 +19,7 @@ Register-LocalActionMergeBranches $localActions
 Register-LocalActionSetUpstream $localActions
 Register-LocalActionSimplifyUpstreamBranches $localActions
 Register-LocalActionValidateBranchNames $localActions
+Register-LocalActionAssertExistence $localActions
 
 function Invoke-LocalAction(
     [PSObject] $actionDefinition,

--- a/utils/actions/local/Register-LocalActionAssertExistence.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionAssertExistence.mocks.psm1
@@ -1,0 +1,23 @@
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionAssertExistence.psm1"
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Register-LocalActionAssertExistence' @PSBoundParameters
+}
+
+function Initialize-LocalActionAssertExistence(
+    [Parameter(Mandatory)][AllowEmptyCollection()] $branches,
+    [Parameter(Mandatory)][bool] $shouldExist
+) {
+    $remote = $(Get-Configuration).remote
+        
+    foreach ($branch in $branches) {
+        $actualBranch = ($null -eq $remote) ? $branch : "$remote/$branch"
+        Invoke-MockGit "rev-parse --verify $actualBranch" -MockWith ($shouldExist ? 'resolved-commit' : { $global:LASTEXITCODE = 128 })
+    }
+}
+
+Export-ModuleMember -Function Initialize-LocalActionAssertExistence

--- a/utils/actions/local/Register-LocalActionAssertExistence.psm1
+++ b/utils/actions/local/Register-LocalActionAssertExistence.psm1
@@ -1,0 +1,31 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+
+function Register-LocalActionAssertExistence([PSObject] $localActions) {
+    $localActions['assert-existence'] = {
+        param(
+            [Parameter(Mandatory)][AllowEmptyCollection()] $branches,
+            [Parameter(Mandatory)][bool] $shouldExist,
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+
+        $remote = $(Get-Configuration).remote
+        
+        foreach ($branch in $branches) {
+            $actualBranch = ($remote) ? "$remote/$branch" : $branch
+            Invoke-ProcessLogs "git rev-parse --verify $actualBranch" {
+                git rev-parse --verify $actualBranch
+            }
+            if ($global:LASTEXITCODE -ne 0 -AND $shouldExist) {
+                Add-ErrorDiagnostic $diagnostics "Branch $branch did not exist$($remote ? " on remote $remote" : '')."
+            } elseif ($global:LASTEXITCODE -eq 0 -AND -not $shouldExist) {
+                Add-ErrorDiagnostic $diagnostics "Branch $branch already exists$($remote ? " on remote $remote" : '')."
+            }
+        }
+
+        return @{}
+    }
+}
+
+Export-ModuleMember -Function Register-LocalActionAssertExistence

--- a/utils/actions/local/Register-LocalActionAssertExistence.tests.ps1
+++ b/utils/actions/local/Register-LocalActionAssertExistence.tests.ps1
@@ -1,0 +1,127 @@
+Describe 'local action "assert-existence"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../actions.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+    }
+
+    function AddStandardTests() {
+        Context 'with should exist' {
+            BeforeEach {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+                $standardScript = ('{ 
+                    "type": "assert-existence", 
+                    "parameters": {
+                        "branches": ["foo", "feature/bar"],
+                        "shouldExist": true
+                    }
+                }' | ConvertFrom-Json)
+            }
+
+            It 'does nothing when everything exists' {
+                Initialize-LocalActionAssertExistence -branches @('foo', 'feature/bar') -shouldExist $true
+
+                Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+                Invoke-FlushAssertDiagnostic $fw.diagnostics
+                $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            }
+
+            It 'gives one error if one fails' {
+                Initialize-LocalActionAssertExistence -branches @('foo') -shouldExist $true
+                Initialize-LocalActionAssertExistence -branches @('feature/bar') -shouldExist $false
+
+                Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+                Invoke-FlushAssertDiagnostic $fw.diagnostics
+
+                $remote = $(Get-Configuration).remote
+                $fw.assertDiagnosticOutput | Should -Be @("ERR:  Branch feature/bar did not exist$($remote ? " on remote $remote" : '').")
+            }
+
+            It 'gives more errors if multiple fail' {
+                Initialize-LocalActionAssertExistence -branches @('foo', 'feature/bar') -shouldExist $false
+
+                Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+                Invoke-FlushAssertDiagnostic $fw.diagnostics
+
+                $remote = $(Get-Configuration).remote
+                $fw.assertDiagnosticOutput | Should -Be @(
+                    "ERR:  Branch foo did not exist$($remote ? " on remote $remote" : '')."
+                    "ERR:  Branch feature/bar did not exist$($remote ? " on remote $remote" : '')."
+                )
+            }
+        }
+        
+        Context 'with should not exist' {
+            BeforeEach {
+                [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+                $standardScript = ('{ 
+                    "type": "assert-existence", 
+                    "parameters": {
+                        "branches": ["foo", "feature/bar"],
+                        "shouldExist": false
+                    }
+                }' | ConvertFrom-Json)
+            }
+
+            It 'does nothing when everything is missing' {
+                Initialize-LocalActionAssertExistence -branches @('foo', 'feature/bar') -shouldExist $false
+
+                Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+                Invoke-FlushAssertDiagnostic $fw.diagnostics
+                $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            }
+
+            It 'gives one error if one fails' {
+                Initialize-LocalActionAssertExistence -branches @('foo') -shouldExist $true
+                Initialize-LocalActionAssertExistence -branches @('feature/bar') -shouldExist $false
+
+                Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+                Invoke-FlushAssertDiagnostic $fw.diagnostics
+
+                $remote = $(Get-Configuration).remote
+                $fw.assertDiagnosticOutput | Should -Be @("ERR:  Branch foo already exists$($remote ? " on remote $remote" : '').")
+            }
+
+            It 'gives more errors if multiple fail' {
+                Initialize-LocalActionAssertExistence -branches @('foo', 'feature/bar') -shouldExist $true
+
+                Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+                Invoke-FlushAssertDiagnostic $fw.diagnostics
+
+                $remote = $(Get-Configuration).remote
+                $fw.assertDiagnosticOutput | Should -Be @(
+                    "ERR:  Branch foo already exists$($remote ? " on remote $remote" : '')."
+                    "ERR:  Branch feature/bar already exists$($remote ? " on remote $remote" : '')."
+                )
+            }
+        }
+    }
+
+    Context 'with remote' {
+        BeforeAll {
+            Initialize-ToolConfiguration
+        }
+        AddStandardTests
+    }
+
+    Context 'without remote' {
+        BeforeAll {
+            Initialize-ToolConfiguration -noRemote
+        }
+        AddStandardTests
+    }
+}


### PR DESCRIPTION
Asserts that branches do/do not exist appropriately for converted functions (`git new` and `git add-upstream`.)