### PR TITLE
Improve efficiency of Select-UpstreamBranches

### DIFF
--- a/config/audit/audit-prune.tests.ps1
+++ b/config/audit/audit-prune.tests.ps1
@@ -129,7 +129,6 @@ Describe 'Invoke-PruneAudit' {
     Context 'with no remote' {
         BeforeAll {
             Initialize-ToolConfiguration -noRemote
-            Initialize-AnyUpstreamBranches
             Initialize-SelectBranches @(
                 'rc/2022-07-14',
                 'feature/FOO-123',
@@ -145,7 +144,6 @@ Describe 'Invoke-PruneAudit' {
     Context 'with remote' {
         BeforeAll {
             Initialize-ToolConfiguration
-            Initialize-AnyUpstreamBranches
             Initialize-SelectBranches @(
                 'origin/rc/2022-07-14',
                 'origin/feature/FOO-123',

--- a/config/audit/audit-simplify.tests.ps1
+++ b/config/audit/audit-simplify.tests.ps1
@@ -98,7 +98,6 @@ Describe 'Invoke-SimplifyAudit' {
     Context 'with no remote' {
         BeforeAll {
             Initialize-ToolConfiguration -noRemote
-            Initialize-AnyUpstreamBranches
             Initialize-SelectBranches @(
                 'rc/2022-07-14',
                 'feature/FOO-123',
@@ -116,7 +115,6 @@ Describe 'Invoke-SimplifyAudit' {
     Context 'with remote' {
         BeforeAll {
             Initialize-ToolConfiguration
-            Initialize-AnyUpstreamBranches
             Initialize-SelectBranches @(
                 'rc/2022-07-14',
                 'feature/FOO-123',

--- a/git-add-upstream.tests.ps1
+++ b/git-add-upstream.tests.ps1
@@ -49,7 +49,6 @@ Describe 'git-add-upstream' {
             $mocks = @(
                 Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
-                Initialize-AnyUpstreamBranches
                 Initialize-UpstreamBranches @{ }
                 Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
                     -from @("feature/FOO-76") `
@@ -194,7 +193,6 @@ Describe 'git-add-upstream' {
                 Initialize-LocalActionAssertExistence -branches @('rc/2022-07-14', 'feature/FOO-76') -shouldExist $true
                 Initialize-CurrentBranch 'rc/2022-07-14'
                 Initialize-LocalActionAssertPushedSuccess 'rc/2022-07-14'
-                Initialize-AnyUpstreamBranches
                 Initialize-UpstreamBranches @{ }
                 Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
                     -from @("feature/FOO-76") `

--- a/git-new.json
+++ b/git-new.json
@@ -34,7 +34,7 @@
                 "upstreamBranches": {
                     "$params.branchName": ["$actions['simplify-upstream'].outputs"]
                 },
-                "message": "Add branch $($params.branchName)$($params.comment ? '' : \" for $($params.comment)\")"
+                "message": "Add branch $($params.branchName)$($params.comment ? \" for $($params.comment)\" : '')"
             }
         },
         {

--- a/git-new.tests.ps1
+++ b/git-new.tests.ps1
@@ -18,7 +18,7 @@ Describe 'git-new' {
             Initialize-ToolConfiguration -noRemote
             Lock-LocalActionSetUpstream
 
-            Initialize-AnyUpstreamBranches
+            Initialize-UpstreamBranches @{}
             Initialize-NoCurrentBranch
         }
 
@@ -128,7 +128,6 @@ Describe 'git-new' {
             Initialize-CleanWorkingDirectory
             Initialize-NoCurrentBranch
 
-            Initialize-AnyUpstreamBranches
             Initialize-UpstreamBranches @{
                 'feature/homepage-redesign' = @('infra/foo')
                 'infra/foo' = @('main')

--- a/git-rc.tests.ps1
+++ b/git-rc.tests.ps1
@@ -41,7 +41,6 @@ Describe 'git-rc' {
     Context 'without remote' {
         BeforeAll {
             Initialize-ToolConfiguration -noRemote
-            Initialize-AnyUpstreamBranches
             Initialize-UpstreamBranches @{}
         }
 
@@ -64,7 +63,7 @@ Describe 'git-rc' {
         BeforeAll {
             Initialize-ToolConfiguration
             Initialize-UpdateGitRemote
-            Initialize-AnyUpstreamBranches
+            Initialize-UpstreamBranches @{}
         }
 
         It 'handles standard functionality' {

--- a/git-release.tests.ps1
+++ b/git-release.tests.ps1
@@ -35,6 +35,7 @@ Describe 'git-release' {
 
             Initialize-GitFileNames '_upstream' $($noRemoteBranches | ForEach-Object { $_.branch })
             Initialize-UpstreamBranches @{
+                'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services")
                 'feature/FOO-123' = @('main')
                 'feature/XYZ-1-services' = @('main')
                 'feature/FOO-124-comment' = @('main')
@@ -49,7 +50,6 @@ Describe 'git-release' {
             Mock git -ParameterFilter {($args -join ' ') -eq 'rev-list main ^rc/2022-07-14 --count'} {
                 "0"
             }
-            Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services")}
             Initialize-SetMultipleUpstreamBranches @{
                 'feature/FOO-123' = $nil;
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125", "main");
@@ -96,6 +96,7 @@ Describe 'git-release' {
                 'feature/FOO-76' = @('main')
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125","feature/XYZ-1-services")
                 'main' = {}
+                'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services")
             }
         }
 
@@ -105,7 +106,6 @@ Describe 'git-release' {
             Mock git -ParameterFilter {($args -join ' ') -eq 'rev-list origin/main ^origin/rc/2022-07-14 --count'} {
                 "0"
             }
-            Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
 
             Initialize-SetMultipleUpstreamBranches @{
                 'feature/FOO-123' = $nil
@@ -129,8 +129,6 @@ Describe 'git-release' {
                 "0"
             }
 
-            Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
-
             Initialize-SetMultipleUpstreamBranches @{
                 'feature/FOO-123' = $nil
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125", "main")
@@ -150,8 +148,16 @@ Describe 'git-release' {
             Mock git -ParameterFilter {($args -join ' ') -eq 'rev-list origin/main ^origin/rc/2022-07-14 --count'} {
                 "0"
             }
-
-            Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123", "integrate/FOO-125_XYZ-1") }
+            Initialize-UpstreamBranches @{
+                'feature/FOO-123' = @('main')
+                'feature/XYZ-1-services' = @('main')
+                'feature/FOO-124-comment' = @('main')
+                'feature/FOO-124_FOO-125' = @("feature/FOO-124-comment")
+                'feature/FOO-76' = @('main')
+                'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125","feature/XYZ-1-services")
+                'main' = {}
+                'rc/2022-07-14' = @("feature/FOO-123", "integrate/FOO-125_XYZ-1")
+            }
 
             Initialize-SetMultipleUpstreamBranches @{
                 'feature/FOO-123' = $nil
@@ -178,7 +184,13 @@ Describe 'git-release' {
             }
             Initialize-UpstreamBranches @{
                 'feature/FOO-123' = @('main')
-                'rc/2022-07-14' = @("integrate/FOO-125_XYZ-1")
+                'feature/XYZ-1-services' = @('main')
+                'feature/FOO-124-comment' = @('main')
+                'feature/FOO-124_FOO-125' = @("feature/FOO-124-comment")
+                'feature/FOO-76' = @('main')
+                'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125","feature/XYZ-1-services")
+                'main' = {}
+                'rc/2022-07-14' = @("feature/XYZ-1-services")
             }
 
             Initialize-SetMultipleUpstreamBranches @{
@@ -208,8 +220,6 @@ Describe 'git-release' {
             Mock git -ParameterFilter {($args -join ' ') -eq 'rev-list origin/rc/2022-07-14 ^origin/main --count'} {
                 "0"
             }
-
-            Initialize-UpstreamBranches @{ 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services") }
 
             Initialize-SetMultipleUpstreamBranches @{
                 'feature/FOO-123' = $nil

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -5,7 +5,7 @@ Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAsse
 Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionGetUpstream.mocks.psm1"
-Export-ModuleMember -Function Initialize-AnyUpstreamBranches,Initialize-UpstreamBranches
+Export-ModuleMember -Function Initialize-UpstreamBranches
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionMergeBranches.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess

--- a/utils/actions/local/Register-LocalActionGetUpstream.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.mocks.psm1
@@ -4,4 +4,4 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionGetUpstream.psm1"
 
-Export-ModuleMember -Function Initialize-AnyUpstreamBranches,Initialize-UpstreamBranches
+Export-ModuleMember -Function Initialize-UpstreamBranches

--- a/utils/actions/local/Register-LocalActionGetUpstream.tests.ps1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.tests.ps1
@@ -62,7 +62,6 @@ Describe 'local action "get-upstream"' {
     Context 'with remote' {
         BeforeEach {
             Initialize-ToolConfiguration
-            Initialize-AnyUpstreamBranches
         }
 
         Initialize-StandardTests
@@ -71,7 +70,6 @@ Describe 'local action "get-upstream"' {
     Context 'without remote' {
         BeforeEach {
             Initialize-ToolConfiguration -noRemote
-            Initialize-AnyUpstreamBranches
         }
 
         Initialize-StandardTests

--- a/utils/actions/local/Register-LocalActionMergeBranches.tests.ps1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.tests.ps1
@@ -124,7 +124,6 @@ Describe 'local action "merge-branches"' {
         BeforeEach {
             Initialize-ToolConfiguration -noRemote
 
-            Initialize-AnyUpstreamBranches
             Initialize-UpstreamBranches @{
                 'feature/homepage-redesign' = @('infra/upgrade-dependencies')
             }
@@ -158,7 +157,6 @@ Describe 'local action "merge-branches"' {
         BeforeEach {
             Initialize-ToolConfiguration
 
-            Initialize-AnyUpstreamBranches
             Initialize-UpstreamBranches @{
                 'feature/homepage-redesign' = @('infra/upgrade-dependencies')
             }

--- a/utils/query-state.mocks.psm1
+++ b/utils/query-state.mocks.psm1
@@ -11,7 +11,7 @@ Export-ModuleMember -Function `
     Initialize-CleanWorkingDirectory, Initialize-DirtyWorkingDirectory, Initialize-UntrackedFiles `
     , Initialize-ToolConfiguration `
     , Initialize-FetchUpstreamBranch `
-    , Initialize-AnyUpstreamBranches, Initialize-UpstreamBranches `
+    , Initialize-UpstreamBranches `
     , Initialize-UpdateGitRemote `
     , Initialize-CurrentBranch, Initialize-NoCurrentBranch `
     , Initialize-OtherGitFilesAsBlank, Initialize-GitFile `
@@ -22,3 +22,6 @@ Export-ModuleMember -Function Initialize-RemoteBranchBehind, Initialize-RemoteBr
 
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-LocalBranchForRemote.mocks.psm1"
 Export-ModuleMember -Function Initialize-GetLocalBranchForRemote
+
+Import-Module -Scope Local "$PSScriptRoot/query-state/Select-AllUpstreamBranches.mocks.psm1"
+Export-ModuleMember -Function Initialize-AllUpstreamBranches

--- a/utils/query-state.psm1
+++ b/utils/query-state.psm1
@@ -23,3 +23,6 @@ Export-ModuleMember -Function Get-BranchSyncState
 
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-LocalBranchForRemote.psm1"
 Export-ModuleMember -Function Get-LocalBranchForRemote
+
+Import-Module -Scope Local "$PSScriptRoot/query-state/Select-AllUpstreamBranches.psm1"
+Export-ModuleMember -Function Select-AllUpstreamBranches

--- a/utils/query-state/Select-AllUpstreamBranches.mocks.psm1
+++ b/utils/query-state/Select-AllUpstreamBranches.mocks.psm1
@@ -1,0 +1,47 @@
+Import-Module -Scope Local "$PSScriptRoot/../../utils/testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Get-UpstreamBranch.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Get-GitFile.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Select-AllUpstreamBranches.psm1"
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+	return Invoke-MockGitModule -ModuleName 'Select-AllUpstreamBranches' @PSBoundParameters
+}
+
+$treeSuffix = '^{tree}'
+
+function Initialize-AllUpstreamBranches([PSObject] $upstreamConfiguration) {
+	$upstream = Get-UpstreamBranch
+	$workDir = [System.IO.Path]::GetRandomFileName()
+	Invoke-MockGit "rev-parse --show-toplevel" -MockWith $workDir
+
+	$trees = @{ '' = @{} }
+
+	foreach ($branch in $upstreamConfiguration.Keys) {
+		$parts = $branch.Split('/')
+		for ($i = 0; $i -lt $parts.Count; $i++) {
+			$lastPart = $parts[$i]
+			$current = ($parts | Select-Object -First $i) -join '/'
+			$fullPath = ($parts | Select-Object -First ($i + 1)) -join '/'
+			if ($null -eq $trees[$current]) {
+				$trees[$current] = @{}
+			}
+
+			if ($i -eq ($parts.Count - 1)) {
+				$branchFile = $upstreamConfiguration[$branch]
+				Initialize-GitFile $upstream $fullPath $branchFile
+				$trees[$current][$lastPart] = "100644 blob hash-ignored`t$lastPart"
+			} else {
+				$trees[$current][$lastPart] = "040000 tree hash-ignored`t$lastPart"
+			}
+		}
+	}
+
+	foreach ($tree in $trees.Keys) {
+		$treeish = "$upstream$($tree ? ":$tree" : $treeSuffix)"
+		[string[]]$treeResult = $trees[$tree].Keys | Sort-Object { $_ } | ForEach-Object {
+			$trees[$tree][$_]
+		}
+		Invoke-MockGit "ls-tree $treeish" -MockWith $treeResult
+	}
+}
+Export-ModuleMember -Function Initialize-AllUpstreamBranches

--- a/utils/query-state/Select-AllUpstreamBranches.psm1
+++ b/utils/query-state/Select-AllUpstreamBranches.psm1
@@ -1,0 +1,56 @@
+Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Get-UpstreamBranch.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Get-GitFile.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
+
+# allUpstreams is a hashmap where the key is the git working directory and 
+$allUpstreams = @{}
+$treeSuffix = '^{tree}'
+
+function Select-AllUpstreamBranches([switch]$refresh) {
+	$workDir = Invoke-ProcessLogs "git rev-parse --show-toplevel" {
+		git rev-parse --show-toplevel
+	} -allowSuccessOutput
+	if ($allUpstreams[$workDir] -AND -not $refresh) {
+		return $allUpstreams[$workDir]
+	}
+
+	$nodes = $allUpstreams[$workDir] = @{}
+
+	$upstreamBranch = Get-UpstreamBranch
+
+	$queue = New-Object 'System.Collections.Generic.Queue[object]';
+
+	# Load all upstream branch configurations to the hashmap
+	$queue.Enqueue($null)
+	while ($queue.Count -gt 0) {
+		$baseName = $queue.Dequeue()
+		$treeish = "$upstreamBranch$($baseName ? ":$baseName" : $treeSuffix)"
+		$treeEntries = Invoke-ProcessLogs "git ls-tree $treeish" {
+			git ls-tree $treeish
+		} -allowSuccessOutput
+		foreach ($entry in $treeEntries) {
+			# entry is (permission ' ' ('tree' | 'blob') ' ' hash '`t' name)
+			$record, $name = $entry.Split("`t")
+			$permission, $type, $hash = $record.Split(' ')
+			$name = $baseName ? "$baseName/$name" : $name
+			if ($type -eq 'tree') {
+				$queue.Enqueue($name)
+			} else {
+				$nodes[$name] = Get-GitFile $name $upstreamBranch
+			}
+		}
+	}
+	return $nodes
+}
+
+function Clear-AllUpstreamBranchCache([string] $workDir) {
+	if ($workDir) {
+		$allUpstreams[$workDir] = $null
+	} else {
+		$allUpstreams = @{}
+	}
+}
+
+Export-ModuleMember -Function Select-AllUpstreamBranches, Clear-AllUpstreamBranchCache

--- a/utils/query-state/Select-AllUpstreamBranches.tests.ps1
+++ b/utils/query-state/Select-AllUpstreamBranches.tests.ps1
@@ -1,0 +1,67 @@
+BeforeAll {
+    . "$PSScriptRoot/../testing.ps1"
+    Import-Module -Scope Local "$PSScriptRoot/../framework.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Select-AllUpstreamBranches.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Select-AllUpstreamBranches.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/../query-state.mocks.psm1"
+}
+
+Describe 'Select-AllUpstreamBranches' {
+    BeforeEach {
+        Register-Framework
+    }
+
+    Describe 'simple structure' {
+        BeforeEach {
+            Initialize-ToolConfiguration -upstreamBranchName 'my-upstream'
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+            $mocks = Initialize-AllUpstreamBranches @{
+                'my-branch' = @("feature/FOO-123", "feature/XYZ-1-services")
+            }
+        }
+
+        It 'finds upstream branches from git' {
+            (Select-AllUpstreamBranches)['my-branch'] | Should -Be @( 'feature/FOO-123', 'feature/XYZ-1-services' )
+            Invoke-VerifyMock $mocks -Times 1
+        }
+
+        It 'provides $null for missing branches' {
+            (Select-AllUpstreamBranches)['not/a/branch'] | Should -Be $null
+            Invoke-VerifyMock $mocks -Times 1
+        }
+
+        It 'only runs once, even if called multiple times' {
+            Select-AllUpstreamBranches
+            Select-AllUpstreamBranches
+            Invoke-VerifyMock $mocks -Times 1
+            { 
+                Invoke-ProcessLogs 'testing' { Invoke-VerifyMock $mocks -Times 2 }
+            } | Should -Throw
+        }
+
+        It 'runs twice if specified' {
+            Select-AllUpstreamBranches
+            Select-AllUpstreamBranches -refresh
+            Invoke-VerifyMock $mocks -Times 2
+        }
+    }
+
+    Describe 'complex structures' {
+        BeforeEach {
+            Initialize-ToolConfiguration
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+            $mocks = Initialize-AllUpstreamBranches @{
+                'rc/1.1.0' = @("feature/FOO-123", "feature/XYZ-1-services")
+                'feature/FOO-123' = @("line/1.0")
+                'feature/XYZ-1-services' = @("infra/some-service")
+                'infra/some-service' = @("line/1.0")
+            }
+        }
+
+        It 'handles deep folders' {
+            (Select-AllUpstreamBranches)['feature/FOO-123'] | Should -Be @("line/1.0")
+            (Select-AllUpstreamBranches)['feature/XYZ-1-services'] | Should -Be @("infra/some-service")
+            Invoke-VerifyMock $mocks -Times 1
+        }
+    }
+}

--- a/utils/query-state/Select-UpstreamBranches.mocks.psm1
+++ b/utils/query-state/Select-UpstreamBranches.mocks.psm1
@@ -1,15 +1,8 @@
 Import-Module -Scope Local "$PSScriptRoot/Get-UpstreamBranch.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Get-GitFile.mocks.psm1"
-
-function Initialize-AnyUpstreamBranches() {
-    $upstream = Get-UpstreamBranch
-    Initialize-OtherGitFilesAsBlank $upstream
-}
+Import-Module -Scope Local "$PSScriptRoot/Select-AllUpstreamBranches.mocks.psm1"
 
 function Initialize-UpstreamBranches([PSObject] $upstreamConfiguration) {
-    $upstream = Get-UpstreamBranch
-    $upstreamConfiguration.Keys | Foreach-Object {
-        Initialize-GitFile $upstream $_ $upstreamConfiguration[$_]
-    }
+    Initialize-AllUpstreamBranches $upstreamConfiguration
 }
-Export-ModuleMember -Function Initialize-AnyUpstreamBranches,Initialize-UpstreamBranches
+Export-ModuleMember -Function Initialize-UpstreamBranches

--- a/utils/query-state/Select-UpstreamBranches.psm1
+++ b/utils/query-state/Select-UpstreamBranches.psm1
@@ -1,11 +1,10 @@
-Import-Module -Scope Local "$PSScriptRoot/Get-UpstreamBranch.psm1"
-Import-Module -Scope Local "$PSScriptRoot/Get-GitFile.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Select-AllUpstreamBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
 
 function Select-UpstreamBranches([String]$branchName, [switch] $includeRemote, [switch] $recurse, [string[]] $exclude) {
     $config = Get-Configuration
-    $upstreamBranch = Get-UpstreamBranch
-    $parentBranches = [string[]](Get-GitFile $branchName $upstreamBranch)
+    $all = Select-AllUpstreamBranches
+    $parentBranches = [string[]]($all[$branchName])
 
     $parentBranches = $parentBranches | Where-Object { $exclude -notcontains $_ }
 


### PR DESCRIPTION
New `Select-AllUpstreamBranches` loads the entire dependency tree once to cache it, which improves efficiencies overall.

If using these powershell scripts for something long-running, it may cause issues, but since each git alias loads a new powershell context, this won't be a problem.