### PR TITLE
Improve performance for Select-UpstreamBranches

### DIFF
--- a/utils/query-state/Select-AllUpstreamBranches.mocks.psm1
+++ b/utils/query-state/Select-AllUpstreamBranches.mocks.psm1
@@ -7,41 +7,17 @@ function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
 	return Invoke-MockGitModule -ModuleName 'Select-AllUpstreamBranches' @PSBoundParameters
 }
 
-$treeSuffix = '^{tree}'
-
 function Initialize-AllUpstreamBranches([PSObject] $upstreamConfiguration) {
 	$upstream = Get-UpstreamBranch
 	$workDir = [System.IO.Path]::GetRandomFileName()
 	Invoke-MockGit "rev-parse --show-toplevel" -MockWith $workDir
 
-	$trees = @{ '' = @{} }
+	$treeEntries = $upstreamConfiguration.Keys | Sort-Object
+	Invoke-MockGit "ls-tree -r $upstream --format=%(path)" -MockWith $treeEntries
 
 	foreach ($branch in $upstreamConfiguration.Keys) {
-		$parts = $branch.Split('/')
-		for ($i = 0; $i -lt $parts.Count; $i++) {
-			$lastPart = $parts[$i]
-			$current = ($parts | Select-Object -First $i) -join '/'
-			$fullPath = ($parts | Select-Object -First ($i + 1)) -join '/'
-			if ($null -eq $trees[$current]) {
-				$trees[$current] = @{}
-			}
-
-			if ($i -eq ($parts.Count - 1)) {
-				$branchFile = $upstreamConfiguration[$branch]
-				Initialize-GitFile $upstream $fullPath $branchFile
-				$trees[$current][$lastPart] = "100644 blob hash-ignored`t$lastPart"
-			} else {
-				$trees[$current][$lastPart] = "040000 tree hash-ignored`t$lastPart"
-			}
-		}
-	}
-
-	foreach ($tree in $trees.Keys) {
-		$treeish = "$upstream$($tree ? ":$tree" : $treeSuffix)"
-		[string[]]$treeResult = $trees[$tree].Keys | Sort-Object { $_ } | ForEach-Object {
-			$trees[$tree][$_]
-		}
-		Invoke-MockGit "ls-tree $treeish" -MockWith $treeResult
+		$branchFile = $upstreamConfiguration[$branch]
+		Initialize-GitFile $upstream $fullPath $branchFile
 	}
 }
 Export-ModuleMember -Function Initialize-AllUpstreamBranches

--- a/utils/query-state/Select-AllUpstreamBranches.mocks.psm1
+++ b/utils/query-state/Select-AllUpstreamBranches.mocks.psm1
@@ -11,8 +11,8 @@ function Initialize-AllUpstreamBranches([PSObject] $upstreamConfiguration) {
 	$workDir = [System.IO.Path]::GetRandomFileName()
 	Invoke-MockGit "rev-parse --show-toplevel" -MockWith $workDir
 
-	$treeEntries = $upstreamConfiguration.Keys | ForEach-Object { "$_-blob`t$_" } | Sort-Object
-	Invoke-MockGit "ls-tree -r $upstream --format=%(objectname)`t%(path)" -MockWith $treeEntries
+	$treeEntries = $upstreamConfiguration.Keys | ForEach-Object { "100644 blob $_-blob`t$_" } | Sort-Object
+	Invoke-MockGit "ls-tree -r $upstream" -MockWith $treeEntries
 
 	if ($upstreamConfiguration.Count -gt 0) {
 		$result = ($upstreamConfiguration.Keys | ForEach-Object {

--- a/utils/query-state/Select-AllUpstreamBranches.psm1
+++ b/utils/query-state/Select-AllUpstreamBranches.psm1
@@ -19,14 +19,33 @@ function Select-AllUpstreamBranches([switch]$refresh) {
 
 	$upstreamBranch = Get-UpstreamBranch
 
-	$treeEntries = Invoke-ProcessLogs "git ls-tree -r $upstreamBranch --format=`"%(path)`"" {
-		git ls-tree -r $upstreamBranch '--format=%(path)'
+	$treeEntries = Invoke-ProcessLogs "git ls-tree -r $upstreamBranch --format=`"%(objectname)`t%(path)`"" {
+		git ls-tree -r $upstreamBranch "--format=%(objectname)`t%(path)"
 	} -allowSuccessOutput
 
-	foreach ($name in $treeEntries) {
-		# TODO - make the Get-GitFile lazy
-		$nodes[$name] = Get-GitFile $name $upstreamBranch
+	# build "$blobs", a Dictionary<hash, contents-split-by-line>
+	$hashes = $treeEntries | ForEach-Object { $_.Split("`t")[0] }
+	if ($hashes) {
+		$hashEntries = (Invoke-ProcessLogs "git cat-file '--batch=`t%(objectname)'" {
+			# --batch gives a header, in this case:"`t<blobhash>", followed by a new line,
+			# followed by the contents of the file, followed by two line breaks.
+			# Empty files, therefore, would have three subsequent line breaks and make the whole result messy
+			# I hope that no one adds files with "`t" in them.
+			$hashes | git cat-file "--batch=`t%(objectname)"
+		} -allowSuccessOutput) -join "`n" -split "`t" | Where-Object { $_ } | ForEach-Object { $_.Trim() }
+		$blobs = @{}
+		foreach ($entry in $hashEntries) {
+			$lines = $entry.Split("`n")
+			$blobs[$lines[0]] = $lines | Select-Object -Skip 1
+		}
+
+		foreach ($entry in $treeEntries) {
+			# entry is (hash '`t' name)
+			$hash, $name = $entry.Split("`t")
+			[string[]]$nodes[$name] = $blobs[$hash]
+		}
 	}
+
 	return $nodes
 }
 


### PR DESCRIPTION
Uses bulk operations, like `git ls-tree -r` and `git cat-file --batch`, per @yumaikas's suggestion. 