### PR TITLE
Include success/failed/hasChanges in merge action

### DIFF
--- a/utils/actions/local/Register-LocalActionMergeBranches.tests.ps1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.tests.ps1
@@ -30,7 +30,12 @@ Describe 'local action "merge-branches"' {
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
             $diag | Should -BeNullOrEmpty
-            $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
+            $result | Assert-ShouldBeObject @{
+                commit = 'new-COMMIT'
+                hasChanges = $false
+                successful = @('baz')
+                failed = @()
+            }
         }
 
         It 'handles standard functionality' {
@@ -47,7 +52,12 @@ Describe 'local action "merge-branches"' {
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
             $diag | Should -Be $null
-            $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
+            $result | Assert-ShouldBeObject @{
+                commit = 'new-COMMIT'
+                hasChanges = $true
+                successful = @('baz', 'barbaz')
+                failed = @()
+            }
             Invoke-VerifyMock $mocks -Times 1
         }
 
@@ -68,7 +78,12 @@ Describe 'local action "merge-branches"' {
             }' | ConvertFrom-Json) -diagnostics $diag
             { Assert-Diagnostics $diag } | Should -Throw
             $output | Should -contain 'ERR:  No branches could be resolved to merge'
-            $result | Assert-ShouldBeObject @{ commit = $null }
+            $result | Assert-ShouldBeObject @{
+                commit = $null
+                hasChanges = $false
+                successful = $null
+                failed = @('baz', 'barbaz')
+            }
             Invoke-VerifyMock $mocks -Times 1
         }
 
@@ -89,7 +104,12 @@ Describe 'local action "merge-branches"' {
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
             $diag | Should -BeNullOrEmpty
-            $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
+            $result | Assert-ShouldBeObject @{
+                commit = 'new-COMMIT'
+                hasChanges = $true
+                successful = @('baz', 'barbaz')
+                failed = @()
+            }
             Invoke-VerifyMock $mocks -Times 1
         }
 
@@ -115,7 +135,12 @@ Describe 'local action "merge-branches"' {
             } else {
                 $output | Should -be @("ERR:  Could not resolve 'foo' for source of merge")
             }
-            $result | Assert-ShouldBeObject @{ commit = $null }
+            $result | Assert-ShouldBeObject @{
+                commit = $null
+                hasChanges = $false
+                successful = @()
+                failed = @('foo')
+            }
             Invoke-VerifyMock $mocks -Times 1
         }
     }
@@ -148,7 +173,12 @@ Describe 'local action "merge-branches"' {
             }' | ConvertFrom-Json) -diagnostics $diag
             { Assert-Diagnostics $diag } | Should -Not -Throw
             $output | Should -contain 'WARN: Could not merge the following branches: barbaz'
-            $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
+            $result | Assert-ShouldBeObject @{
+                commit = 'new-COMMIT'
+                hasChanges = $false
+                successful = @('baz')
+                failed = @('barbaz')
+            }
             Invoke-VerifyMock $mocks -Times 1
         }
     }
@@ -181,7 +211,12 @@ Describe 'local action "merge-branches"' {
             }' | ConvertFrom-Json) -diagnostics $diag
             { Assert-Diagnostics $diag } | Should -Not -Throw
             $output | Should -contain 'WARN: Could not merge the following branches: origin/barbaz'
-            $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
+            $result | Assert-ShouldBeObject @{
+                commit = 'new-COMMIT'
+                hasChanges = $false
+                successful = @('baz')
+                failed = @('barbaz')
+            }
             Invoke-VerifyMock $mocks -Times 1
         }
     }

--- a/utils/git/Invoke-MergeTogether.psm1
+++ b/utils/git/Invoke-MergeTogether.psm1
@@ -28,6 +28,7 @@ function Invoke-MergeTogether(
             
             return @{
                 result = $null
+                hasChanges = $false
                 successful = @()
                 failed = @($target)
             }
@@ -114,7 +115,9 @@ function Invoke-MergeTogether(
         }
     }
 
+    $hasChanges = $false
     if ($parentCommits.Count -gt 1) {
+        $hasChanges = $true
         $commitMessage = $messageTemplate.Replace('{}', $successful -join ', ')
         $parents = $parentCommits | ForEach-Object { @("-p", $_) }
         $currentCommit = Invoke-ProcessLogs "git commit-tree $nextTree -m $commitMessage $parents" {
@@ -124,6 +127,7 @@ function Invoke-MergeTogether(
 
     return @{
         result = $currentCommit
+        hasChanges = $hasChanges
         successful = $successful
         failed = $failed
     }

--- a/utils/git/Invoke-MergeTogether.tests.ps1
+++ b/utils/git/Invoke-MergeTogether.tests.ps1
@@ -22,6 +22,7 @@ Describe 'Invoke-MergeTogether' {
         $result.result | Should -Be $null
         $result.failed | Should -Be @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3')
         $result.successful | Should -BeNullOrEmpty
+        $result.hasChanges | Should -Be $false
         $fw.diagnostics | Should -Not -BeNullOrEmpty
         Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $true
         Invoke-VerifyMock $mocks -Times 1
@@ -38,6 +39,7 @@ Describe 'Invoke-MergeTogether' {
         $result.result | Should -Be 'result-commitish'
         $result.failed | Should -Be @('feature/FOO-2')
         $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-3')
+        $result.hasChanges | Should -Be $true
         $fw.diagnostics | Should -Not -BeNullOrEmpty
         Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $true
         Invoke-VerifyMock $mocks -Times 1
@@ -54,6 +56,7 @@ Describe 'Invoke-MergeTogether' {
         $result.result | Should -Be 'result-commitish'
         $result.failed | Should -Be @('feature/FOO-2')
         $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-3')
+        $result.hasChanges | Should -Be $true
         $fw.diagnostics | Should -Not -BeNullOrEmpty
         Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $false
         Invoke-VerifyMock $mocks -Times 1
@@ -71,6 +74,7 @@ Describe 'Invoke-MergeTogether' {
         $result.result | Should -Be 'result-commitish'
         $result.failed | Should -Be @('feature/FOO-2')
         $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-3')
+        $result.hasChanges | Should -Be $true
         $fw.diagnostics | Should -Not -BeNullOrEmpty
         Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $true
         Invoke-VerifyMock $mocks -Times 1
@@ -85,6 +89,7 @@ Describe 'Invoke-MergeTogether' {
         $result.failed | Should -Be @('main')
         $result.successful | Should -BeNullOrEmpty
         $fw.diagnostics | Should -Not -BeNullOrEmpty
+        $result.hasChanges | Should -Be $false
         Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $true
         Invoke-VerifyMock $mocks -Times 1
     }
@@ -97,6 +102,20 @@ Describe 'Invoke-MergeTogether' {
         $result.result | Should -Be 'result-commitish'
         $result.failed | Should -Be @()
         $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3')
+        $result.hasChanges | Should -Be $true
+        $fw.diagnostics | Should -BeNullOrEmpty
+        Invoke-VerifyMock $mocks -Times 1
+    }
+    
+    It 'succeeds with no changes if only one branch is provided' {
+        $mocks = Initialize-MergeTogether @('feature/FOO-1') -successfulBranches @('feature/FOO-1') -resultCommitish 'result-commitish'
+
+        $result = Invoke-MergeTogether @('feature/FOO-1') -diagnostics $fw.diagnostics
+
+        $result.result | Should -Be 'result-commitish'
+        $result.failed | Should -Be @()
+        $result.successful | Should -Be @('feature/FOO-1')
+        $result.hasChanges | Should -Be $false
         $fw.diagnostics | Should -BeNullOrEmpty
         Invoke-VerifyMock $mocks -Times 1
     }


### PR DESCRIPTION
The `merge-branches` action had a TODO comment "TODO - output successfully merged branches" which is partially needed for pull-upstream. This adds just that functionality.

Note that no other behaviors change, just more info is available to the JSON scripting.