### PR TITLE
Ensure the local branch is clean before resetting

### DIFF
--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -29,7 +29,7 @@ function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
 
         if ($null -ne $config.remote) {
             $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
-            $branchList = ConvertTo-PushBranchList $branches
+            [string[]]$branchList = ConvertTo-PushBranchList $branches
             if ($dryRun) {
                 "git push $($config.remote) $atomicPart $branchList"
                 return

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -45,6 +45,9 @@ function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
 
             foreach ($key in $branches.Keys) {
                 if ($currentBranch -eq $key) {
+                    Assert-CleanWorkingDirectory -diagnostics $diagnostics
+                    if (Get-HasErrorDiagnostic $diagnostics) { continue }
+
                     # update head, since it matches the branch to be "pushed"
                     if ($dryRun) {
                         "git reset --hard `"$($branches[$key])`""

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
@@ -59,6 +59,27 @@ Describe 'finalize action "set-branches"' {
             Invoke-VerifyMock $mocks -Times 1
         }
 
+        It 'handles standard functionality for a single branch' {
+            $standardScript = ('{ 
+                "type": "set-branches", 
+                "parameters": {
+                    "branches": {
+                        "other": "other-commitish"
+                    }
+                }
+            }' | ConvertFrom-Json)
+            Initialize-NoCurrentBranch
+            $mocks = @(
+                Initialize-AssertValidBranchName 'other'
+                Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' `
+                    -gitCli "branch other other-commitish -f"
+            )
+            
+            Invoke-FinalizeAction $standardScript -diagnostics $diag
+            $diag | Should -BeNullOrEmpty
+            Invoke-VerifyMock $mocks -Times 1
+        }
+
         It 'can execute a dry run' {
             Initialize-NoCurrentBranch
             $mocks = @(

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.tests.ps1
@@ -119,6 +119,15 @@ Describe 'finalize action "set-branches"' {
             $diag | Should -BeNullOrEmpty
             Invoke-VerifyMock $mocks -Times 1
         }
+        
+        It 'ensures the current branch, if updated, is clean' {
+            Initialize-CurrentBranch 'another'
+            $mocks = Initialize-FinalizeActionSetBranches $standardBranches -currentBranchDirty
+            Invoke-FinalizeAction $standardScript -diagnostics $diag
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -Be @('ERR:  Git working directory is not clean.')
+            Invoke-VerifyMock $mocks -Times 1
+        }
     }
 
     Context 'with remote' {

--- a/utils/actions/finalize/Register-FinalizeActionTrack.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.psm1
@@ -38,6 +38,8 @@ function Register-FinalizeActionTrack([PSObject] $finalizeActions) {
             
             if ($currentBranch -eq $localBranch) {
                 # update head
+                Assert-CleanWorkingDirectory -diagnostics $diagnostics
+                if (Get-HasErrorDiagnostic $diagnostics) { continue }
                 if ($dryRun) {
                     "git reset --hard `"refs/remotes/$($config.remote)/$branch`""
                 } else {


### PR DESCRIPTION
During add-upstream, if you have local changes, previously it would remove your changes that are not committed after performing the merge. This adds a check.

Also, the "set-branches" action had issues in certain cases with a single branch (important for `git pull-upstream`), which this also addresses.