### PR TITLE
Refactor pull-upstream

### DIFF
--- a/docs/pull-upstream.md
+++ b/docs/pull-upstream.md
@@ -4,10 +4,14 @@ Merges all the "upstream" branches into the current branch, or the specified one
 
 Usage:
 
-    git-pull-upstream.ps1 [-target <string>]
+    git-pull-upstream.ps1 [-target <string>] [-dryRun]
 
 ## Parameters
 
 ### `[-target] <string>` (Optional)
 
 If provided, the script will change branches to the named branch, and pull-upstream for that branch. If it succeeds, `pull-upstream` will return to the original branch. Otherwise, conflicts will be left uncommitted.
+
+### `-dryRun` (Optional)
+
+If specified, only test merging, do not push the updates.

--- a/git-pull-upstream.json
+++ b/git-pull-upstream.json
@@ -1,0 +1,68 @@
+{
+    "local": [
+        {
+            "type": "validate-branch-names",
+            "parameters": {
+                "branches": ["$params.target"]
+            }
+        },
+        {
+            "type": "assert-existence",
+            "parameters": {
+                "branches": ["$params.target"],
+                "shouldExist": true
+            }
+        },
+        {
+            "type": "assert-pushed",
+            "parameters": {
+                "target": "$params.target"
+            }
+        },
+        {
+            "id": "get-upstream",
+            "type": "get-upstream",
+            "parameters": {
+                "target": "$params.target"
+            }
+        },
+        {
+            "id": "merge-branches",
+            "type": "merge-branches",
+            "parameters": {
+                "source": "$($params.target)",
+                "upstreamBranches": ["$actions['get-upstream'].outputs"],
+                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+            }
+        },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions['merge-branches'].outputs['hasChanges'] ? $false : $true",
+            "parameters": {
+                "isWarning": true,
+                "message": "No updates found."
+            }
+        }
+    ],
+    "finalize": [
+        {
+            "type": "set-branches",
+            "condition": "$actions['merge-branches'].outputs['hasChanges']",
+            "parameters": {
+                "branches": {
+                    "$params.target": "$actions['merge-branches'].outputs['commit']"
+                }
+            }
+        },
+        {
+            "type": "track",
+            "condition": "$actions['merge-branches'].outputs['hasChanges']",
+            "parameters": {
+                "branches": ["$params.target"]
+            }
+        }
+    ],
+    "output": [
+        "$($params.target) has been updated with its upstream branches"
+    ]
+}

--- a/utils/git/Invoke-MergeTogether.mocks.psm1
+++ b/utils/git/Invoke-MergeTogether.mocks.psm1
@@ -103,6 +103,7 @@ function Initialize-MergeTogether(
     if ($successfulBranches.Count -gt 1) {
         $message = $messageTemplate.Replace('{}', ($successfulBranches | Where-Object { $_ -ne $source }) -join ', ')
         $parents = $allBranches | Where-Object { $successfulBranches -contains $_ } | ForEach-Object { @("-p", $commitish[$_]) }
+        $treeish = "$lastBranch-tree"
         Invoke-MockGit "commit-tree $treeish -m $message $parents" -MockWith "$($resultCommitish)"
     }
 }

--- a/utils/git/Invoke-MergeTogether.mocks.psm1
+++ b/utils/git/Invoke-MergeTogether.mocks.psm1
@@ -78,7 +78,7 @@ function Initialize-MergeTogether(
             $treeish = "$current-tree"
             $message = $messageTemplate.Replace('{}', $current)
             Initialize-MergeTree $currentCommit $commitish[$current] $treeish
-            Invoke-MockGit "commit-tree $treeish -m $message -p $currentCommit -p $($commitish[$current])" -MockWith "$($resultCommitishes[$current])"
+            Invoke-MockGit "commit-tree $treeish -p $currentCommit -p $($commitish[$current]) -m interim merge" -MockWith "$($resultCommitishes[$current])"
             $currentCommit = $resultCommitishes[$current]
 
             foreach ($failedBranch in $failed) {

--- a/utils/git/Invoke-MergeTogether.psm1
+++ b/utils/git/Invoke-MergeTogether.psm1
@@ -88,8 +88,9 @@ function Invoke-MergeTogether(
 
                     # Successful merge
                     $commitMessage = $messageTemplate.Replace('{}', $target)
-                    $resultCommit = Invoke-ProcessLogs "git commit-tree $nextTree -m $commitMessage -p $currentCommit -p $targetCommit" {
-                        git commit-tree $nextTree -m $commitMessage -p $currentCommit -p $targetCommit
+                    $resultCommit = Invoke-ProcessLogs "git commit-tree $nextTree -p $currentCommit -p $targetCommit -m 'interim merge'" {
+                        # Order and message is different here from below so that the mocks can give different results
+                        git commit-tree $nextTree -p $currentCommit -p $targetCommit -m 'interim merge'
                     } -allowSuccessOutput
                     if ($global:LASTEXITCODE -ne 0) { continue }
 

--- a/utils/git/Invoke-MergeTogether.tests.ps1
+++ b/utils/git/Invoke-MergeTogether.tests.ps1
@@ -62,6 +62,23 @@ Describe 'Invoke-MergeTogether' {
         Invoke-VerifyMock $mocks -Times 1
     }
 
+    It 'can handle the last branch failing' {
+        $mocks = Initialize-MergeTogether `
+            -allBranches @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `
+            -successfulBranches @('feature/FOO-1', 'feature/FOO-2') `
+            -resultCommitish 'result-commitish' `
+            -messageTemplate 'Merge {}'
+
+        $result = Invoke-MergeTogether @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') -diagnostics $fw.diagnostics -asWarnings
+        $result.result | Should -Be 'result-commitish'
+        $result.failed | Should -Be @('feature/FOO-3')
+        $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-2')
+        $result.hasChanges | Should -Be $true
+        $fw.diagnostics | Should -Not -BeNullOrEmpty
+        Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $false
+        Invoke-VerifyMock $mocks -Times 1
+    }
+
     It 'starts with the source' {
         $mocks = Initialize-MergeTogether `
             -allBranches @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `

--- a/utils/git/Invoke-MergeTogether.tests.ps1
+++ b/utils/git/Invoke-MergeTogether.tests.ps1
@@ -79,6 +79,24 @@ Describe 'Invoke-MergeTogether' {
         Invoke-VerifyMock $mocks -Times 1
     }
 
+    It 'can handle the second branch failing with a source' {
+        $mocks = Initialize-MergeTogether `
+            -allBranches @('feature/FOO-2', 'feature/FOO-3') `
+            -successfulBranches @('feature/FOO-2') `
+            -source 'feature/FOO-1' `
+            -resultCommitish 'result-commitish' `
+            -messageTemplate 'Merge {}'
+
+        $result = Invoke-MergeTogether @('feature/FOO-2', 'feature/FOO-3') -source 'feature/FOO-1' -diagnostics $fw.diagnostics -asWarnings
+        $result.result | Should -Be 'result-commitish'
+        $result.failed | Should -Be @('feature/FOO-3')
+        $result.successful | Should -Be @('feature/FOO-2')
+        $result.hasChanges | Should -Be $true
+        $fw.diagnostics | Should -Not -BeNullOrEmpty
+        Get-HasErrorDiagnostic $fw.diagnostics | Should -Be $false
+        Invoke-VerifyMock $mocks -Times 1
+    }
+
     It 'starts with the source' {
         $mocks = Initialize-MergeTogether `
             -allBranches @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `


### PR DESCRIPTION
Refactors the `git pull-uptream` command to the new framework.

Also, improves the mocks for merging branches together (both the raw command and the action) to allow for more failure cases.