### PR TITLE
Correct git version requirements and support Mac

### DIFF
--- a/git-tool-update.tests.ps1
+++ b/git-tool-update.tests.ps1
@@ -49,7 +49,7 @@ Describe 'git-tool-update' {
         $mockPull = Invoke-MockGit 'pull --ff-only'
         Initialize-PreserveBranchNoCleanup
         Mock -CommandName git -ParameterFilter { ($args -join ' ') -like 'config alias.*' } -MockWith { $Global:LASTEXITCODE = 0 }
-        Invoke-MockGit 'version' -MockWith 'git version 2.38.0'
+        Invoke-MockGit 'version' -MockWith 'git version 2.41.0'
 
         & $PSScriptRoot/git-tool-update.ps1
 
@@ -74,12 +74,28 @@ Describe 'git-tool-update' {
         $mockPull = Invoke-MockGit 'pull --ff-only'
         Initialize-PreserveBranchNoCleanup
         Mock -CommandName git -ParameterFilter { ($args -join ' ') -like 'config alias.*' } -MockWith { $Global:LASTEXITCODE = 0 }
-        Invoke-MockGit 'version' -MockWith 'git version 2.38.0'
+        Invoke-MockGit 'version' -MockWith 'git version 2.41.0'
 
         & $PSScriptRoot/git-tool-update.ps1 -sourceBranch feature/test
 
         Invoke-VerifyMock $verifyMigrations -Times 1
         Invoke-VerifyMock $mockCheckout -Times 1
+        Invoke-VerifyMock $mockPull -Times 1
+    }
+    
+
+    It 'allows running the script for mac' {
+        Initialize-CleanWorkingDirectory
+        Initialize-CurrentBranch 'main'
+        $verifyMigrations = Initialize-RunNoMigrations 'old-commit'
+        $mockPull = Invoke-MockGit 'pull --ff-only'
+        Initialize-PreserveBranchNoCleanup
+        Mock -CommandName git -ParameterFilter { ($args -join ' ') -like 'config alias.*' } -MockWith { $Global:LASTEXITCODE = 0 }
+        Invoke-MockGit 'version' -MockWith 'git version 2.41.0 (Apple Git-143)'
+
+        & $PSScriptRoot/git-tool-update.ps1
+
+        Invoke-VerifyMock $verifyMigrations -Times 1
         Invoke-VerifyMock $mockPull -Times 1
     }
 }

--- a/init.ps1
+++ b/init.ps1
@@ -39,7 +39,7 @@ git config alias.verify-updated "!$dir/git-verify-updated.ps1"
 git config alias.release "!$dir/git-release.ps1"
 
 # Get the git version and warn about older versions
-[double]$ver = ((((git version) -split ' ') | Select-Object -Last 1) -split '\.',3 | Select-Object -First 2) -join '.'
-if ($ver -lt 2.38) {
-    throw 'Git version installed should be at least 2.38; unexpected issues may occur. Please update git.'
+[double]$ver = ((((git version) -split ' ')[2]) -split '\.',3 | Select-Object -First 2) -join '.'
+if ($ver -lt 2.41) {
+    throw 'Git version installed should be at least 2.41; unexpected issues may occur. Please update git.'
 }


### PR DESCRIPTION
2.41 is required for `git for-each-ref --omit-empty`