### PR TITLE
Convert git-show-upstream

### DIFF
--- a/docs/show-upstream.md
+++ b/docs/show-upstream.md
@@ -4,7 +4,7 @@ Shows what the upstream branches are of the current (or specified) branch.
 
 Usage:
 
-    git-show-upstream.ps1 [-target <string>] [-recurse]
+    git-show-upstream.ps1 [-target <string>] [-recurse] [-includeRemote] [-noFetch] [-quiet]
 
 ## Parameters
 
@@ -15,3 +15,19 @@ The name of the branch to list upstream branches. If not specified, use the curr
 ### `-recurse` (Optional)
 
 If specified, list all upstream branches recursively.
+
+### `-includeRemote` (Optional)
+
+If specified, include the remote name (if any) in the output branch list. For
+example, if the remote is `origin`, all branches listed would start with
+`origin/`.
+
+## `-noFetch` (Optional)
+
+By default, all scripts fetch the latest before processing. To skip this (which
+was the old behavior), include `-noFetch`.
+
+## `-quiet` (Optional)
+
+Suppress unnecessary output. Useful when a tool is designed to consume the
+output of this script via git rather than via PowerShell.

--- a/git-show-upstream.json
+++ b/git-show-upstream.json
@@ -1,0 +1,15 @@
+{
+    "local": [
+        {
+            "id": "get-upstream",
+            "type": "get-upstream",
+            "parameters": {
+                "recurse": "$params.recurse",
+                "includeRemote": "$params.includeRemote",
+                "target": "$params.target"
+            }
+        }
+    ],
+    "finalize": [],
+    "output": "$actions['get-upstream'].outputs"
+}

--- a/git-show-upstream.ps1
+++ b/git-show-upstream.ps1
@@ -2,19 +2,18 @@
 
 Param(
     [Parameter()][String] $target,
-    [switch] $recurse
+    [switch] $recurse,
+    [switch] $includeRemote,
+    [switch] $noFetch,
+    [switch] $quiet
 )
 
+Import-Module -Scope Local "$PSScriptRoot/utils/input.psm1"
+Import-Module -Scope Local "$PSScriptRoot/utils/scripting.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
-. $PSScriptRoot/config/core/coalesce.ps1
 
-$target = ($target -eq $nil -OR $target -eq '') ? (Get-CurrentBranch) : $target
-if ($target -eq $nil) {
-    throw 'Must specify a branch'
-}
-
-$parentBranches = [String[]]($recurse `
-    ? (Select-UpstreamBranches $target -includeRemote -recurse) `
-    : (Select-UpstreamBranches $target -includeRemote))
-
-$parentBranches
+Invoke-JsonScript -scriptPath "$PSScriptRoot/git-show-upstream.json" -params @{
+    target = ($target ? $target : (Get-CurrentBranch ?? ''));
+    recurse = $recurse;
+    includeRemote = $includeRemote;
+} -dryRun:$dryRun -noFetch:$noFetch -quiet:$quiet

--- a/git-show-upstream.tests.ps1
+++ b/git-show-upstream.tests.ps1
@@ -11,7 +11,7 @@ Describe 'git-show-upstream' {
         Initialize-ToolConfiguration
         Initialize-UpstreamBranches @{ 'feature/FOO-123' = @("main", "infra/add-services") }
 
-        $result = & ./git-show-upstream.ps1 -target 'feature/FOO-123'
+        $result = & ./git-show-upstream.ps1 -noFetch -includeRemote -target 'feature/FOO-123'
         $result | Should -Be @('origin/main', 'origin/infra/add-services')
     }
 
@@ -21,7 +21,7 @@ Describe 'git-show-upstream' {
 
         Initialize-UpstreamBranches @{ 'feature/FOO-123' = @("main", "infra/add-services") }
 
-        $result = & ./git-show-upstream.ps1
+        $result = & ./git-show-upstream.ps1 -noFetch -includeRemote
         $result | Should -Be @('origin/main', 'origin/infra/add-services')
     }
 
@@ -35,7 +35,9 @@ Describe 'git-show-upstream' {
             'infra/build-infrastructure' = $()
         }
 
-        $result = & ./git-show-upstream.ps1 -recurse
+        $result = & ./git-show-upstream.ps1 -noFetch -includeRemote -recurse
         $result | Should -Be @('origin/main', 'origin/infra/add-services', 'origin/infra/build-infrastructure')
     }
+
+    # TODO - improve tests, but shows that the old behavior can still be invoked
 }

--- a/utils/actions/local/Register-LocalActionGetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.psm1
@@ -6,10 +6,12 @@ function Register-LocalActionGetUpstream([PSObject] $localActions) {
     $localActions['get-upstream'] = {
         param(
             [Parameter(Mandatory)][string] $target,
+            [switch] $recurse,
+            [switch] $includeRemote,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
-        [string[]]$result = Select-UpstreamBranches -branchName $target
+        [string[]]$result = Select-UpstreamBranches -branchName $target -recurse:$recurse -includeRemote:$includeRemote
         
         return $result
     }

--- a/utils/framework/processlog-framework.psm1
+++ b/utils/framework/processlog-framework.psm1
@@ -33,9 +33,10 @@ function Invoke-ProcessLogs {
         [Parameter(Mandatory)][string]$processDescription,
         [Parameter(Mandatory)][scriptblock]$process,
         [Switch] $allowSuccessOutput,
+        [Switch] $quiet,
         [Parameter()] $beginThreshold = 0.5
     )
-    $state = @{ isRunning = $true; hasOutput = $false }
+    $state = @{ isRunning = $true; hasOutput = $false; quiet = $quiet }
     $quiet = Get-IsQuiet
     $timer = [Diagnostics.Stopwatch]::StartNew()
     if (-not $quiet) {
@@ -43,7 +44,7 @@ function Invoke-ProcessLogs {
             param ($state, $processDescription, $beginThreshold)
 
             Start-Sleep -Seconds $beginThreshold
-            if ($state.isRunning) {
+            if ($state.isRunning -AND -not $state.quiet) {
                 $state.hasOutput = $true
                 Write-Host "Working on '$($processDescription)'..."
             }

--- a/utils/query-state/Update-GitRemote.psm1
+++ b/utils/query-state/Update-GitRemote.psm1
@@ -3,14 +3,15 @@ Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
 
 function Update-GitRemote(
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
-    [switch] $prune
+    [switch] $prune,
+    [switch] $quiet
 ) {
     $config = Get-Configuration
     if ($config.remote -eq $nil) { return }
     $pruneArgs = $prune ? @('--prune') : @()
     Invoke-ProcessLogs "git fetch $($config.remote)" {
         git fetch $config.remote -q @pruneArgs
-    }
+    } -quiet:$quiet
 
     if ($LASTEXITCODE -ne 0) {
         Add-ErrorDiagnostic $diagnostics "Unable to update remote '$($config.remote)'"

--- a/utils/scripting/Invoke-JsonScript.psm1
+++ b/utils/scripting/Invoke-JsonScript.psm1
@@ -7,10 +7,14 @@ Import-Module -Scope Local "$PSScriptRoot/Invoke-Script.psm1"
 function Invoke-JsonScript(
     [Parameter(Mandatory)][string] $scriptPath,
     [Parameter(Mandatory)][PSObject] $params,
-    [switch] $dryRun
+    [switch] $dryRun,
+    [switch] $noFetch,
+    [switch] $quiet
 ) {
     $diagnostics = New-Diagnostics
-    Update-GitRemote
+    if (-not $noFetch) {
+        Update-GitRemote -quiet:$quiet
+    }
     $instructions = Get-Content $scriptPath | ConvertFrom-Json
     Invoke-Script $instructions -params $params -diagnostics $diagnostics -dryRun:$dryRun
 }


### PR DESCRIPTION
## ⚠️ This changes the default behavior on `git show-upstream`.

`git show-upstream` previously gave output always including the remote and only that:
```
origin/feature/CATUX-1122
origin/feature/manual-design_1.1
origin/integrate/rc/24.1.1/content-i18n_1.1
origin/feature/CATUX-643
origin/integrate/battery-retrofit_installation-adders-rc-24.1.1
```

Without any switches now, you may get:
```
Working on 'git fetch origin'...
End 'git fetch origin'. (1.2s)
feature/CATUX-1122
feature/manual-design_1.1
integrate/rc/24.1.1/content-i18n_1.1
feature/CATUX-643
integrate/battery-retrofit_installation-adders-rc-24.1.1
```

For scripting purposes, there are two options:
1. Use PowerShell scripts directly. The "Working... End" lines are on the "Host" stream, while branch names are on output. 
2. Additional switches are provided:
  - `-includeRemote` restores the remote prefix if desired
  - `-noFetch` skips fetching entirely
  - `-quiet` suppresses output from `noFetch` (and may suppress future output, too) but still allows the new behavior of fetching before displaying.