### PR TITLE
Convert verify updated

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-vscode.powershell"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "files.eol": "\n"
+    "files.eol": "\n",
+    "powershell.pester.useLegacyCodeLens": false
 }

--- a/git-verify-updated.json
+++ b/git-verify-updated.json
@@ -16,7 +16,8 @@
         {
             "type": "assert-pushed",
             "parameters": {
-                "target": "$params.target"
+                "target": "$params.target",
+                "remoteMustExist": true
             }
         },
         {
@@ -43,8 +44,7 @@
             "condition": "$params.recurse ? $false : $true",
             "parameters": {
                 "source": "$($params.target)",
-                "upstreamBranches": ["$actions['get-upstream'].outputs"],
-                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+                "upstreamBranches": ["$actions['get-upstream'].outputs"]
             }
         },
         { 

--- a/git-verify-updated.json
+++ b/git-verify-updated.json
@@ -22,43 +22,12 @@
         },
         {
             "type": "recurse",
-            "condition": "$params.recurse",
             "parameters": {
                 "inputParameters": [{
-                    "target": "$params.target"
+                    "target": "$params.target",
+                    "recurse": "$params.recurse"
                 }],
                 "path": "git-verify-updated.recurse.json"
-            }
-        },
-        {
-            "id": "get-upstream",
-            "type": "get-upstream",
-            "condition": "$params.recurse ? $false : $true",
-            "parameters": {
-                "target": "$params.target"
-            }
-        },
-        {
-            "id": "merge-branches",
-            "type": "merge-branches",
-            "condition": "$params.recurse ? $false : $true",
-            "parameters": {
-                "source": "$($params.target)",
-                "upstreamBranches": ["$actions['get-upstream'].outputs"]
-            }
-        },
-        { 
-            "type": "add-diagnostic",
-            "condition": "$actions['merge-branches'].outputs['failed'] -AND -not $params.recurse",
-            "parameters": {
-                "message": "$($params.target) has incoming conflicts from $($actions['merge-branches'].outputs['failed'])."
-            }
-        },
-        { 
-            "type": "add-diagnostic",
-            "condition": "$actions['merge-branches'].outputs['hasChanges'] ? -not $params.recurse : $false",
-            "parameters": {
-                "message": "$($params.target) did not have the latest from $($actions['merge-branches'].outputs['successful'])."
             }
         }
     ],

--- a/git-verify-updated.json
+++ b/git-verify-updated.json
@@ -1,0 +1,69 @@
+{
+    "local": [
+        {
+            "type": "validate-branch-names",
+            "parameters": {
+                "branches": ["$params.target"]
+            }
+        },
+        {
+            "type": "assert-existence",
+            "parameters": {
+                "branches": ["$params.target"],
+                "shouldExist": true
+            }
+        },
+        {
+            "type": "assert-pushed",
+            "parameters": {
+                "target": "$params.target"
+            }
+        },
+        {
+            "type": "recurse",
+            "condition": "$params.recurse",
+            "parameters": {
+                "inputParameters": [{
+                    "target": "$params.target"
+                }],
+                "path": "git-verify-updated.recurse.json"
+            }
+        },
+        {
+            "id": "get-upstream",
+            "type": "get-upstream",
+            "condition": "$params.recurse ? $false : $true",
+            "parameters": {
+                "target": "$params.target"
+            }
+        },
+        {
+            "id": "merge-branches",
+            "type": "merge-branches",
+            "condition": "$params.recurse ? $false : $true",
+            "parameters": {
+                "source": "$($params.target)",
+                "upstreamBranches": ["$actions['get-upstream'].outputs"],
+                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+            }
+        },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions['merge-branches'].outputs['failed'] -AND -not $params.recurse",
+            "parameters": {
+                "message": "$($params.target) has incoming conflicts from $($actions['merge-branches'].outputs['failed'])."
+            }
+        },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions['merge-branches'].outputs['hasChanges'] ? -not $params.recurse : $false",
+            "parameters": {
+                "message": "$($params.target) did not have the latest from $($actions['merge-branches'].outputs['successful'])."
+            }
+        }
+    ],
+    "finalize": [],
+    "output": [
+        "$($params.target) is up-to-date with its upstreams"
+    ]
+}

--- a/git-verify-updated.ps1
+++ b/git-verify-updated.ps1
@@ -5,42 +5,12 @@ Param(
     [switch] $recurse
 )
 
+Import-Module -Scope Local "$PSScriptRoot/utils/input.psm1"
+Import-Module -Scope Local "$PSScriptRoot/utils/scripting.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
-Import-Module -Scope Local "$PSScriptRoot/config/git/Assert-BranchPushed.psm1"
 
-$config = Get-Configuration
-
-Update-GitRemote
-
-$noneSpecified = ($target -eq $nil -OR $target -eq '')
-$target = $noneSpecified ? (Get-CurrentBranch) : $target
-Assert-BranchPushed $target -m 'Please ensure changes are pushed (or reset) and try again.' -failIfNoUpstream
-
-$fullBranchName = $noneSpecified -OR $config.remote -eq $nil ? $target
-    : "$($config.remote)/$($target)"
-if ($fullBranchName -eq $nil) {
-    throw "No branch specified"
-}
-$rcCommit = git rev-parse --verify $fullBranchName
-if ($LASTEXITCODE -ne 0) {
-    throw "Unknown branch: $fullBranchName"
-}
-
-$parentBranches = [String[]]($recurse `
-    ? (Select-UpstreamBranches $target -includeRemote -config $config -recurse) `
-    : (Select-UpstreamBranches $target -includeRemote -config $config))
-
-if ($parentBranches -eq $nil -OR $parentBranches.Length -eq 0) {
-    throw "$fullBranchName has no parent branches"
-}
-
-$parentBranches | Where-Object { $_ -ne $nil } | ForEach-Object {
-    $parentCommit = git rev-parse --verify $_
-    if ($LASTEXITCODE -ne 0) {
-        throw "Unknown branch: $_"
-    }
-    if ((git merge-base $parentCommit $rcCommit) -ne $parentCommit) {
-        throw "Branch not up-to-date: $_"
-    }
-}
-Write-Host "All branches up-to-date."
+Invoke-JsonScript -scriptPath "$PSScriptRoot/git-verify-updated.json" -params @{
+    target = ($target ? $target : (Get-CurrentBranch ?? ''));
+    recurse = $recurse;
+    includeRemote = $includeRemote;
+} -dryRun:$dryRun

--- a/git-verify-updated.recurse.json
+++ b/git-verify-updated.recurse.json
@@ -1,7 +1,7 @@
 {
     "recursion": {
         "mode": "depth-first",
-        "paramScript": "$actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_ } }",
+        "paramScript": "$params.recurse ? ($actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_ } }) : @()",
         "map": "@{}",
         "reduceToOutput": "@{}"
     },

--- a/git-verify-updated.recurse.json
+++ b/git-verify-updated.recurse.json
@@ -1,9 +1,10 @@
 {
     "recursion": {
         "mode": "depth-first",
-        "paramScript": "$params.recurse ? ($actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_ } }) : @()",
+        "paramScript": "$params.recurse ? ($actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_; recurse = $params.recurse } }) : @()",
         "map": "@{}",
-        "reduceToOutput": "@{}"
+        "reduceToOutput": "@{}",
+        "actCondition": "$null -ne $actions['get-upstream'].outputs"
     },
     "prepare": [
         {
@@ -18,16 +19,16 @@
             "parameters": {
                 "target": "$params.target"
             }
-        }
-    ],
-    "act": [
+        },
         { 
             "type": "add-diagnostic",
-            "condition": "$null -eq $actions['get-upstream'].outputs",
+            "condition": "$params.depth -eq 0 -AND $null -eq $actions['get-upstream'].outputs",
             "parameters": {
                 "message": "$($params.target) has no upstream branches to verify."
             }
-        },
+        }
+    ],
+    "act": [
         {
             "id": "merge-branches",
             "type": "merge-branches",

--- a/git-verify-updated.recurse.json
+++ b/git-verify-updated.recurse.json
@@ -26,8 +26,7 @@
             "type": "merge-branches",
             "parameters": {
                 "source": "$($params.target)",
-                "upstreamBranches": ["$actions['get-upstream'].outputs"],
-                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+                "upstreamBranches": ["$actions['get-upstream'].outputs"]
             }
         },
         { 

--- a/git-verify-updated.recurse.json
+++ b/git-verify-updated.recurse.json
@@ -1,0 +1,48 @@
+{
+    "recursion": {
+        "mode": "depth-first",
+        "paramScript": "$actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_ } }",
+        "map": "@{}",
+        "reduceToOutput": "@{}"
+    },
+    "prepare": [
+        {
+            "type": "assert-pushed",
+            "parameters": {
+                "target": "$params.target"
+            }
+        },
+        {
+            "id": "get-upstream",
+            "type": "get-upstream",
+            "parameters": {
+                "target": "$params.target"
+            }
+        }
+    ],
+    "act": [
+        {
+            "id": "merge-branches",
+            "type": "merge-branches",
+            "parameters": {
+                "source": "$($params.target)",
+                "upstreamBranches": ["$actions['get-upstream'].outputs"],
+                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+            }
+        },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions['merge-branches'].outputs['failed']",
+            "parameters": {
+                "message": "$($params.target) has incoming conflicts from $($actions['merge-branches'].outputs['failed'])."
+            }
+        },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions['merge-branches'].outputs['hasChanges'] ? $true : $false",
+            "parameters": {
+                "message": "$($params.target) did not have the latest from $($actions['merge-branches'].outputs['successful'])."
+            }
+        }
+    ]
+}

--- a/git-verify-updated.recurse.json
+++ b/git-verify-updated.recurse.json
@@ -21,6 +21,13 @@
         }
     ],
     "act": [
+        { 
+            "type": "add-diagnostic",
+            "condition": "$null -eq $actions['get-upstream'].outputs",
+            "parameters": {
+                "message": "$($params.target) has no upstream branches to verify."
+            }
+        },
         {
             "id": "merge-branches",
             "type": "merge-branches",

--- a/git-verify-updated.tests.ps1
+++ b/git-verify-updated.tests.ps1
@@ -36,7 +36,7 @@ Describe 'git-verify-updated' {
                 -resultCommitish 'result-commitish' `
                 -source 'feature/PS-2'
 
-                & $PSScriptRoot/git-verify-updated.ps1
+            & $PSScriptRoot/git-verify-updated.ps1
         }
 
         It 'uses the branch specified' {
@@ -50,7 +50,17 @@ Describe 'git-verify-updated' {
                 -resultCommitish 'result-commitish' `
                 -source 'feature/PS-2'
 
-                & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2
+            & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2
+        }
+
+        It 'fails if there are no upstreams on the initial branch' {
+            Initialize-AssertValidBranchName 'feature/PS-2'
+            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+            Initialize-UpstreamBranches @{ 'feature/PS-2' = @() }
+
+            { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
+                | Should -Throw 'ERR:  feature/PS-2 has no upstream branches to verify.'
         }
 
         It 'throws when one branch is out of date' {
@@ -65,7 +75,7 @@ Describe 'git-verify-updated' {
                 -resultCommitish 'result-commitish' `
                 -source 'feature/PS-2'
 
-                { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
+            { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
                 | Should -Throw 'ERR:  feature/PS-2 did not have the latest from feature/PS-1 infra/build-improvements.'
         }
 
@@ -130,7 +140,7 @@ Describe 'git-verify-updated' {
                 -source 'feature/PS-2' `
                 -initialCommits $initialCommits
 
-                & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 -recurse
+            & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 -recurse
         }
     }
 

--- a/git-verify-updated.tests.ps1
+++ b/git-verify-updated.tests.ps1
@@ -4,6 +4,8 @@ BeforeAll {
     Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
     Import-Module -Scope Local "$PSScriptRoot/utils/query-state.mocks.psm1"
     Import-Module -Scope Local "$PSScriptRoot/config/git/Assert-BranchPushed.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/utils/input.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/utils/actions.mocks.psm1"
 
     # User-interface commands are a bit noisy; TODO: add quiet option and test it by making this throw
     Mock -CommandName Write-Host {}
@@ -25,112 +27,101 @@ Describe 'git-verify-updated' {
     It 'uses the default branch when none specified, without a remote' {
         Initialize-ToolConfiguration -noRemote
         Initialize-CurrentBranch 'feature/PS-2'
-
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify feature/PS-2' } { 'target-branch-hash' }
-
-        Mock -CommandName Select-UpstreamBranches -ParameterFilter { $branchName -eq 'feature/PS-2' -AND $includeRemote -AND -not $recurse } {
-            'feature/PS-1'
-            'infra/build-improvements'
-        }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify feature/PS-1" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base feature-PS1-branch-hash target-branch-hash" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify infra/build-improvements" } { "infra-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base infra-branch-hash target-branch-hash" } { "infra-branch-hash" }
+        Initialize-AssertValidBranchName 'feature/PS-2'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+            -resultCommitish 'result-commitish' `
+            -source 'feature/PS-2'
 
         & $PSScriptRoot/git-verify-updated.ps1
     }
 
     It 'uses the branch specified, without a remote' {
         Initialize-ToolConfiguration -noRemote
-
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify feature/PS-2' } { 'target-branch-hash' }
-
-        Mock -CommandName Select-UpstreamBranches -ParameterFilter { $branchName -eq 'feature/PS-2' -AND $includeRemote -AND -not $recurse } {
-            'feature/PS-1'
-            'infra/build-improvements'
-        }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify feature/PS-1" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base feature-PS1-branch-hash target-branch-hash" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify infra/build-improvements" } { "infra-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base infra-branch-hash target-branch-hash" } { "infra-branch-hash" }
+        Initialize-AssertValidBranchName 'feature/PS-2'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+            -resultCommitish 'result-commitish' `
+            -source 'feature/PS-2'
 
         & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2
     }
 
     It 'throws when one branch is out of date' {
         Initialize-ToolConfiguration -noRemote
+        Initialize-AssertValidBranchName 'feature/PS-2'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+            -successfulBranches @('feature/PS-1') `
+            -noChangeBranches @('infra/build-improvements') `
+            -resultCommitish 'result-commitish' `
+            -source 'feature/PS-2'
 
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify feature/PS-2' } { 'target-branch-hash' }
-
-        Mock -CommandName Select-UpstreamBranches -ParameterFilter { $branchName -eq 'feature/PS-2' -AND $includeRemote -AND -not $recurse } {
-            'feature/PS-1'
-            'infra/build-improvements'
-        }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify feature/PS-1" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base feature-PS1-branch-hash target-branch-hash" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify infra/build-improvements" } { "infra-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base infra-branch-hash target-branch-hash" } { "other-hash" }
-
-        { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 } | Should -Throw
+        { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
+            | Should -Throw 'ERR:  feature/PS-2 did not have the latest from feature/PS-1 infra/build-improvements.'
     }
 
     It 'uses the current branch if none specified, with a remote' {
         Initialize-ToolConfiguration
-        Initialize-CurrentBranch 'feature/PS-2'
-        Initialize-BranchPushed 'feature/PS-2'
         Initialize-UpdateGitRemote
-
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'fetch origin -q' } { }
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify feature/PS-2' } { 'target-branch-hash' }
-
-        Mock -CommandName Select-UpstreamBranches -ParameterFilter { $branchName -eq 'feature/PS-2' -AND $includeRemote -AND -not $recurse } {
-            'origin/feature/PS-1'
-            'origin/infra/build-improvements'
-        }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify origin/feature/PS-1" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base feature-PS1-branch-hash target-branch-hash" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify origin/infra/build-improvements" } { "infra-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base infra-branch-hash target-branch-hash" } { "infra-branch-hash" }
+        Initialize-CurrentBranch 'feature/PS-2'
+        Initialize-AssertValidBranchName 'feature/PS-2'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+        Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+            -resultCommitish 'result-commitish' `
+            -source 'feature/PS-2'
 
         & $PSScriptRoot/git-verify-updated.ps1
     }
 
     It 'uses the current branch if none specified, with a remote, but fails if not pushed' {
         Initialize-ToolConfiguration
-        Initialize-CurrentBranch 'feature/PS-2'
-        Initialize-BranchNotPushed 'feature/PS-2'
         Initialize-UpdateGitRemote
+        Initialize-CurrentBranch 'feature/PS-2'
+        Initialize-AssertValidBranchName 'feature/PS-2'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+        Initialize-LocalActionAssertPushedAhead 'feature/PS-2'
 
         { & $PSScriptRoot/git-verify-updated.ps1 }
-            | Should -Throw "Branch feature/PS-2 has changes not pushed to origin/feature/PS-2. Please ensure changes are pushed (or reset) and try again."
+            | Should -Throw "ERR:  The local branch for feature/PS-2 has changes that are not pushed to the remote"
     }
 
     It 'uses the current branch if none specified, with a remote, but fails if not tracked to the remote' {
         Initialize-ToolConfiguration
-        Initialize-CurrentBranch 'feature/PS-2'
-        Initialize-BranchNoUpstream 'feature/PS-2'
         Initialize-UpdateGitRemote
+        Initialize-CurrentBranch 'feature/PS-2'
+        Initialize-AssertValidBranchName 'feature/PS-2'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+        Initialize-LocalActionAssertPushedNotTracked 'feature/PS-2'
 
         { & $PSScriptRoot/git-verify-updated.ps1 }
-            | Should -Throw "Branch feature/PS-2 does not have a remote tracking branch. Please ensure changes are pushed (or reset) and try again."
+            | Should -Throw "ERR:  The local branch for feature/PS-2 does not exist on the remote"
     }
 
     It 'uses the branch specified, with a remote' {
         Initialize-ToolConfiguration
         Initialize-UpdateGitRemote
-        Initialize-BranchPushed 'feature/PS-2'
-
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'fetch origin -q' } { }
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/feature/PS-2' } { 'target-branch-hash' }
-
-        Mock -CommandName Select-UpstreamBranches -ParameterFilter { $branchName -eq 'feature/PS-2' -AND $includeRemote -AND -not $recurse} {
-            'origin/feature/PS-1'
-            'origin/infra/build-improvements'
-        }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify origin/feature/PS-1" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base feature-PS1-branch-hash target-branch-hash" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify origin/infra/build-improvements" } { "infra-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base infra-branch-hash target-branch-hash" } { "infra-branch-hash" }
+        Initialize-AssertValidBranchName 'feature/PS-2'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+        Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+            -resultCommitish 'result-commitish' `
+            -source 'feature/PS-2'
 
         & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2
     }
@@ -138,19 +129,63 @@ Describe 'git-verify-updated' {
     It 'uses the branch specified, recursively, with a remote' {
         Initialize-ToolConfiguration
         Initialize-UpdateGitRemote
-        Initialize-BranchPushed 'feature/PS-2'
-
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'fetch origin -q' } { }
-        Mock git -ParameterFilter { ($args -join ' ') -eq 'rev-parse --verify origin/feature/PS-2' } { 'target-branch-hash' }
-
-        Mock -CommandName Select-UpstreamBranches -ParameterFilter { $branchName -eq 'feature/PS-2' -AND $includeRemote -AND $recurse } {
-            'origin/feature/PS-1'
-            'origin/infra/build-improvements'
+        Initialize-AssertValidBranchName 'feature/PS-2'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+        Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+        Initialize-UpstreamBranches @{
+            'feature/PS-2' = @('feature/PS-1','infra/build-improvements')
+            'feature/PS-1' = @('infra/ts-update')
+            'infra/build-improvements' = @('infra/ts-update')
+            'infra/ts-update' = @('main')
         }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify origin/feature/PS-1" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base feature-PS1-branch-hash target-branch-hash" } { "feature-PS1-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "rev-parse --verify origin/infra/build-improvements" } { "infra-branch-hash" }
-        Mock git -ParameterFilter { ($args -join ' ') -eq "merge-base infra-branch-hash target-branch-hash" } { "infra-branch-hash" }
+        Initialize-AssertValidBranchName 'feature/PS-1'
+        Initialize-LocalActionAssertExistence -branches @('feature/PS-1') -shouldExist $true
+        Initialize-LocalActionAssertPushedSuccess 'feature/PS-1'
+
+        Initialize-AssertValidBranchName 'infra/build-improvements'
+        Initialize-LocalActionAssertExistence -branches @('infra/build-improvements') -shouldExist $true
+        Initialize-LocalActionAssertPushedSuccess 'infra/build-improvements'
+
+        Initialize-AssertValidBranchName 'infra/ts-update'
+        Initialize-LocalActionAssertExistence -branches @('infra/ts-update') -shouldExist $true
+        Initialize-LocalActionAssertPushedSuccess 'infra/ts-update'
+
+        Initialize-AssertValidBranchName 'main'
+        Initialize-LocalActionAssertExistence -branches @('main') -shouldExist $true
+        Initialize-LocalActionAssertPushedSuccess 'main'
+
+        $initialCommits = @{
+            "origin/main" = "origin/main-commitish"
+            "origin/feature/PS-1" = "origin/feature/PS-1-commitish"
+            "origin/infra/ts-update" = "origin/infra/ts-update-commitish"
+            "origin/infra/build-improvements" = "origin/infra/build-improvements-commitish"
+            "origin/feature/PS-2" = "origin/feature/PS-2-commitish"
+        }
+
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('main') `
+            -noChangeBranches @('main') `
+            -resultCommitish $initialCommits['origin/infra/ts-update'] `
+            -source 'infra/ts-update' `
+            -initialCommits $initialCommits
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('infra/ts-update') `
+            -noChangeBranches @('infra/ts-update') `
+            -resultCommitish $initialCommits['origin/infra/build-improvements'] `
+            -source 'infra/build-improvements' `
+            -initialCommits $initialCommits
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('infra/ts-update') `
+            -noChangeBranches @('infra/ts-update') `
+            -resultCommitish $initialCommits['origin/feature/PS-1'] `
+            -source 'feature/PS-1' `
+            -initialCommits $initialCommits
+        Initialize-LocalActionMergeBranches `
+            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+            -resultCommitish $initialCommits['origin/feature/PS-2'] `
+            -source 'feature/PS-2' `
+            -initialCommits $initialCommits
 
         & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 -recurse
     }

--- a/git-verify-updated.tests.ps1
+++ b/git-verify-updated.tests.ps1
@@ -87,7 +87,7 @@ Describe 'git-verify-updated' {
             )
 
             { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
-                | Should -Throw 'ERR:  feature/PS-2 did not have the latest from feature/PS-1 infra/build-improvements.'
+                | Should -Throw 'ERR:  feature/PS-2 did not have the latest from feature/PS-1.'
             Invoke-VerifyMock $mocks -Times 1
         }
 

--- a/git-verify-updated.tests.ps1
+++ b/git-verify-updated.tests.ps1
@@ -25,86 +25,73 @@ Describe 'git-verify-updated' {
         }
     
         It 'uses the default branch when none specified' {
-            Initialize-CurrentBranch 'feature/PS-2'
-            Initialize-AssertValidBranchName 'feature/PS-2'
-            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
-            Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
-            Initialize-LocalActionMergeBranches `
-                -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-                -noChangeBranches @('feature/PS-1','infra/build-improvements') `
-                -resultCommitish 'result-commitish' `
-                -source 'feature/PS-2'
+            $mocks = @(
+                Initialize-CurrentBranch 'feature/PS-2'
+                Initialize-AssertValidBranchName 'feature/PS-2'
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+                Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                    -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+                    -resultCommitish 'result-commitish' `
+                    -source 'feature/PS-2'
+            )
 
             & $PSScriptRoot/git-verify-updated.ps1
+            Invoke-VerifyMock $mocks -Times 1
         }
 
         It 'uses the branch specified' {
-            Initialize-AssertValidBranchName 'feature/PS-2'
-            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
-            Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
-            Initialize-LocalActionMergeBranches `
-                -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-                -noChangeBranches @('feature/PS-1','infra/build-improvements') `
-                -resultCommitish 'result-commitish' `
-                -source 'feature/PS-2'
+            $mocks = @(
+                Initialize-AssertValidBranchName 'feature/PS-2'
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+                Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                    -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+                    -resultCommitish 'result-commitish' `
+                    -source 'feature/PS-2'
+            )
 
             & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2
+            Invoke-VerifyMock $mocks -Times 1
         }
 
         It 'fails if there are no upstreams on the initial branch' {
-            Initialize-AssertValidBranchName 'feature/PS-2'
-            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
-            Initialize-UpstreamBranches @{ 'feature/PS-2' = @() }
+            $mocks = @(
+                Initialize-AssertValidBranchName 'feature/PS-2'
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+                Initialize-UpstreamBranches @{ 'feature/PS-2' = @() }
+            )
 
             { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
                 | Should -Throw 'ERR:  feature/PS-2 has no upstream branches to verify.'
+            Invoke-VerifyMock $mocks -Times 1
         }
 
         It 'throws when one branch is out of date' {
-            Initialize-AssertValidBranchName 'feature/PS-2'
-            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
-            Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
-            Initialize-LocalActionMergeBranches `
-                -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-                -successfulBranches @('feature/PS-1') `
-                -noChangeBranches @('infra/build-improvements') `
-                -resultCommitish 'result-commitish' `
-                -source 'feature/PS-2'
+            $mocks = @(
+                Initialize-AssertValidBranchName 'feature/PS-2'
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+                Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                    -successfulBranches @('feature/PS-1') `
+                    -noChangeBranches @('infra/build-improvements') `
+                    -resultCommitish 'result-commitish' `
+                    -source 'feature/PS-2'
+            )
 
             { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
                 | Should -Throw 'ERR:  feature/PS-2 did not have the latest from feature/PS-1 infra/build-improvements.'
+            Invoke-VerifyMock $mocks -Times 1
         }
 
         It 'uses the branch specified, recursively' {
-            Initialize-AssertValidBranchName 'feature/PS-2'
-            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
-            Initialize-UpstreamBranches @{
-                'feature/PS-2' = @('feature/PS-1','infra/build-improvements')
-                'feature/PS-1' = @('infra/ts-update')
-                'infra/build-improvements' = @('infra/ts-update')
-                'infra/ts-update' = @('main')
-            }
-            Initialize-AssertValidBranchName 'feature/PS-1'
-            Initialize-LocalActionAssertExistence -branches @('feature/PS-1') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'feature/PS-1'
-
-            Initialize-AssertValidBranchName 'infra/build-improvements'
-            Initialize-LocalActionAssertExistence -branches @('infra/build-improvements') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'infra/build-improvements'
-
-            Initialize-AssertValidBranchName 'infra/ts-update'
-            Initialize-LocalActionAssertExistence -branches @('infra/ts-update') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'infra/ts-update'
-
-            Initialize-AssertValidBranchName 'main'
-            Initialize-LocalActionAssertExistence -branches @('main') -shouldExist $true
-            Initialize-LocalActionAssertPushedSuccess 'main'
-
             $remote = $(Get-Configuration).remote
             $remotePrefix = $remote ? "$remote/" : ""
             $initialCommits = @{
@@ -115,32 +102,49 @@ Describe 'git-verify-updated' {
                 "$($remotePrefix)feature/PS-2" = "$($remotePrefix)feature/PS-2-commitish"
             }
 
-            Initialize-LocalActionMergeBranches `
-                -upstreamBranches @('main') `
-                -noChangeBranches @('main') `
-                -resultCommitish $initialCommits["$($remotePrefix)infra/ts-update"] `
-                -source 'infra/ts-update' `
-                -initialCommits $initialCommits
-            Initialize-LocalActionMergeBranches `
-                -upstreamBranches @('infra/ts-update') `
-                -noChangeBranches @('infra/ts-update') `
-                -resultCommitish $initialCommits["$($remotePrefix)infra/build-improvements"] `
-                -source 'infra/build-improvements' `
-                -initialCommits $initialCommits
-            Initialize-LocalActionMergeBranches `
-                -upstreamBranches @('infra/ts-update') `
-                -noChangeBranches @('infra/ts-update') `
-                -resultCommitish $initialCommits["$($remotePrefix)feature/PS-1"] `
-                -source 'feature/PS-1' `
-                -initialCommits $initialCommits
-            Initialize-LocalActionMergeBranches `
-                -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-                -noChangeBranches @('feature/PS-1','infra/build-improvements') `
-                -resultCommitish $initialCommits["$($remotePrefix)feature/PS-2"] `
-                -source 'feature/PS-2' `
-                -initialCommits $initialCommits
+            $mocks = @(
+                Initialize-AssertValidBranchName 'feature/PS-2'
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+                Initialize-UpstreamBranches @{
+                    'feature/PS-2' = @('feature/PS-1','infra/build-improvements')
+                    'feature/PS-1' = @('infra/ts-update')
+                    'infra/build-improvements' = @('infra/ts-update')
+                    'infra/ts-update' = @('main')
+                }
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-1'
+                Initialize-LocalActionAssertPushedSuccess 'infra/build-improvements'
+                Initialize-LocalActionAssertPushedSuccess 'infra/ts-update'
+                Initialize-LocalActionAssertPushedSuccess 'main'
+
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('main') `
+                    -noChangeBranches @('main') `
+                    -resultCommitish $initialCommits["$($remotePrefix)infra/ts-update"] `
+                    -source 'infra/ts-update' `
+                    -initialCommits $initialCommits
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('infra/ts-update') `
+                    -noChangeBranches @('infra/ts-update') `
+                    -resultCommitish $initialCommits["$($remotePrefix)infra/build-improvements"] `
+                    -source 'infra/build-improvements' `
+                    -initialCommits $initialCommits
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('infra/ts-update') `
+                    -noChangeBranches @('infra/ts-update') `
+                    -resultCommitish $initialCommits["$($remotePrefix)feature/PS-1"] `
+                    -source 'feature/PS-1' `
+                    -initialCommits $initialCommits
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                    -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+                    -resultCommitish $initialCommits["$($remotePrefix)feature/PS-2"] `
+                    -source 'feature/PS-2' `
+                    -initialCommits $initialCommits
+            )
 
             & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 -recurse
+            Invoke-VerifyMock $mocks -Times 1
         }
     }
 

--- a/git-verify-updated.tests.ps1
+++ b/git-verify-updated.tests.ps1
@@ -17,177 +17,158 @@ Describe 'git-verify-updated' {
         Register-Framework
     }
 
-    It 'fails if no current branch and none provided' {
-        Initialize-ToolConfiguration -noRemote
-        Initialize-NoCurrentBranch
+    function Add-StandardTests {
+        It 'fails if no current branch and none provided' {
+            Initialize-NoCurrentBranch
 
-        { & $PSScriptRoot/git-verify-updated.ps1 } | Should -Throw
-    }
-
-    It 'uses the default branch when none specified, without a remote' {
-        Initialize-ToolConfiguration -noRemote
-        Initialize-CurrentBranch 'feature/PS-2'
-        Initialize-AssertValidBranchName 'feature/PS-2'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
-            -resultCommitish 'result-commitish' `
-            -source 'feature/PS-2'
-
-        & $PSScriptRoot/git-verify-updated.ps1
-    }
-
-    It 'uses the branch specified, without a remote' {
-        Initialize-ToolConfiguration -noRemote
-        Initialize-AssertValidBranchName 'feature/PS-2'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
-            -resultCommitish 'result-commitish' `
-            -source 'feature/PS-2'
-
-        & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2
-    }
-
-    It 'throws when one branch is out of date' {
-        Initialize-ToolConfiguration -noRemote
-        Initialize-AssertValidBranchName 'feature/PS-2'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-            -successfulBranches @('feature/PS-1') `
-            -noChangeBranches @('infra/build-improvements') `
-            -resultCommitish 'result-commitish' `
-            -source 'feature/PS-2'
-
-        { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
-            | Should -Throw 'ERR:  feature/PS-2 did not have the latest from feature/PS-1 infra/build-improvements.'
-    }
-
-    It 'uses the current branch if none specified, with a remote' {
-        Initialize-ToolConfiguration
-        Initialize-UpdateGitRemote
-        Initialize-CurrentBranch 'feature/PS-2'
-        Initialize-AssertValidBranchName 'feature/PS-2'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-        Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
-        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
-            -resultCommitish 'result-commitish' `
-            -source 'feature/PS-2'
-
-        & $PSScriptRoot/git-verify-updated.ps1
-    }
-
-    It 'uses the current branch if none specified, with a remote, but fails if not pushed' {
-        Initialize-ToolConfiguration
-        Initialize-UpdateGitRemote
-        Initialize-CurrentBranch 'feature/PS-2'
-        Initialize-AssertValidBranchName 'feature/PS-2'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-        Initialize-LocalActionAssertPushedAhead 'feature/PS-2'
-
-        { & $PSScriptRoot/git-verify-updated.ps1 }
-            | Should -Throw "ERR:  The local branch for feature/PS-2 has changes that are not pushed to the remote"
-    }
-
-    It 'uses the current branch if none specified, with a remote, but fails if not tracked to the remote' {
-        Initialize-ToolConfiguration
-        Initialize-UpdateGitRemote
-        Initialize-CurrentBranch 'feature/PS-2'
-        Initialize-AssertValidBranchName 'feature/PS-2'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-        Initialize-LocalActionAssertPushedNotTracked 'feature/PS-2'
-
-        { & $PSScriptRoot/git-verify-updated.ps1 }
-            | Should -Throw "ERR:  The local branch for feature/PS-2 does not exist on the remote"
-    }
-
-    It 'uses the branch specified, with a remote' {
-        Initialize-ToolConfiguration
-        Initialize-UpdateGitRemote
-        Initialize-AssertValidBranchName 'feature/PS-2'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-        Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
-        Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
-            -resultCommitish 'result-commitish' `
-            -source 'feature/PS-2'
-
-        & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2
-    }
-
-    It 'uses the branch specified, recursively, with a remote' {
-        Initialize-ToolConfiguration
-        Initialize-UpdateGitRemote
-        Initialize-AssertValidBranchName 'feature/PS-2'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
-        Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
-        Initialize-UpstreamBranches @{
-            'feature/PS-2' = @('feature/PS-1','infra/build-improvements')
-            'feature/PS-1' = @('infra/ts-update')
-            'infra/build-improvements' = @('infra/ts-update')
-            'infra/ts-update' = @('main')
+            { & $PSScriptRoot/git-verify-updated.ps1 } | Should -Throw
         }
-        Initialize-AssertValidBranchName 'feature/PS-1'
-        Initialize-LocalActionAssertExistence -branches @('feature/PS-1') -shouldExist $true
-        Initialize-LocalActionAssertPushedSuccess 'feature/PS-1'
+    
+        It 'uses the default branch when none specified' {
+            Initialize-CurrentBranch 'feature/PS-2'
+            Initialize-AssertValidBranchName 'feature/PS-2'
+            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+            Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+            Initialize-LocalActionMergeBranches `
+                -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+                -resultCommitish 'result-commitish' `
+                -source 'feature/PS-2'
 
-        Initialize-AssertValidBranchName 'infra/build-improvements'
-        Initialize-LocalActionAssertExistence -branches @('infra/build-improvements') -shouldExist $true
-        Initialize-LocalActionAssertPushedSuccess 'infra/build-improvements'
-
-        Initialize-AssertValidBranchName 'infra/ts-update'
-        Initialize-LocalActionAssertExistence -branches @('infra/ts-update') -shouldExist $true
-        Initialize-LocalActionAssertPushedSuccess 'infra/ts-update'
-
-        Initialize-AssertValidBranchName 'main'
-        Initialize-LocalActionAssertExistence -branches @('main') -shouldExist $true
-        Initialize-LocalActionAssertPushedSuccess 'main'
-
-        $initialCommits = @{
-            "origin/main" = "origin/main-commitish"
-            "origin/feature/PS-1" = "origin/feature/PS-1-commitish"
-            "origin/infra/ts-update" = "origin/infra/ts-update-commitish"
-            "origin/infra/build-improvements" = "origin/infra/build-improvements-commitish"
-            "origin/feature/PS-2" = "origin/feature/PS-2-commitish"
+                & $PSScriptRoot/git-verify-updated.ps1
         }
 
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('main') `
-            -noChangeBranches @('main') `
-            -resultCommitish $initialCommits['origin/infra/ts-update'] `
-            -source 'infra/ts-update' `
-            -initialCommits $initialCommits
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('infra/ts-update') `
-            -noChangeBranches @('infra/ts-update') `
-            -resultCommitish $initialCommits['origin/infra/build-improvements'] `
-            -source 'infra/build-improvements' `
-            -initialCommits $initialCommits
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('infra/ts-update') `
-            -noChangeBranches @('infra/ts-update') `
-            -resultCommitish $initialCommits['origin/feature/PS-1'] `
-            -source 'feature/PS-1' `
-            -initialCommits $initialCommits
-        Initialize-LocalActionMergeBranches `
-            -upstreamBranches @('feature/PS-1','infra/build-improvements') `
-            -noChangeBranches @('feature/PS-1','infra/build-improvements') `
-            -resultCommitish $initialCommits['origin/feature/PS-2'] `
-            -source 'feature/PS-2' `
-            -initialCommits $initialCommits
+        It 'uses the branch specified' {
+            Initialize-AssertValidBranchName 'feature/PS-2'
+            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+            Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+            Initialize-LocalActionMergeBranches `
+                -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+                -resultCommitish 'result-commitish' `
+                -source 'feature/PS-2'
 
-        & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 -recurse
+                & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2
+        }
+
+        It 'throws when one branch is out of date' {
+            Initialize-AssertValidBranchName 'feature/PS-2'
+            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+            Initialize-UpstreamBranches @{ 'feature/PS-2' = @('feature/PS-1','infra/build-improvements') }
+            Initialize-LocalActionMergeBranches `
+                -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                -successfulBranches @('feature/PS-1') `
+                -noChangeBranches @('infra/build-improvements') `
+                -resultCommitish 'result-commitish' `
+                -source 'feature/PS-2'
+
+                { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 }
+                | Should -Throw 'ERR:  feature/PS-2 did not have the latest from feature/PS-1 infra/build-improvements.'
+        }
+
+        It 'uses the branch specified, recursively' {
+            Initialize-AssertValidBranchName 'feature/PS-2'
+            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+            Initialize-UpstreamBranches @{
+                'feature/PS-2' = @('feature/PS-1','infra/build-improvements')
+                'feature/PS-1' = @('infra/ts-update')
+                'infra/build-improvements' = @('infra/ts-update')
+                'infra/ts-update' = @('main')
+            }
+            Initialize-AssertValidBranchName 'feature/PS-1'
+            Initialize-LocalActionAssertExistence -branches @('feature/PS-1') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'feature/PS-1'
+
+            Initialize-AssertValidBranchName 'infra/build-improvements'
+            Initialize-LocalActionAssertExistence -branches @('infra/build-improvements') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'infra/build-improvements'
+
+            Initialize-AssertValidBranchName 'infra/ts-update'
+            Initialize-LocalActionAssertExistence -branches @('infra/ts-update') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'infra/ts-update'
+
+            Initialize-AssertValidBranchName 'main'
+            Initialize-LocalActionAssertExistence -branches @('main') -shouldExist $true
+            Initialize-LocalActionAssertPushedSuccess 'main'
+
+            $remote = $(Get-Configuration).remote
+            $remotePrefix = $remote ? "$remote/" : ""
+            $initialCommits = @{
+                "$($remotePrefix)main" = "$($remotePrefix)main-commitish"
+                "$($remotePrefix)feature/PS-1" = "$($remotePrefix)feature/PS-1-commitish"
+                "$($remotePrefix)infra/ts-update" = "$($remotePrefix)infra/ts-update-commitish"
+                "$($remotePrefix)infra/build-improvements" = "$($remotePrefix)infra/build-improvements-commitish"
+                "$($remotePrefix)feature/PS-2" = "$($remotePrefix)feature/PS-2-commitish"
+            }
+
+            Initialize-LocalActionMergeBranches `
+                -upstreamBranches @('main') `
+                -noChangeBranches @('main') `
+                -resultCommitish $initialCommits["$($remotePrefix)infra/ts-update"] `
+                -source 'infra/ts-update' `
+                -initialCommits $initialCommits
+            Initialize-LocalActionMergeBranches `
+                -upstreamBranches @('infra/ts-update') `
+                -noChangeBranches @('infra/ts-update') `
+                -resultCommitish $initialCommits["$($remotePrefix)infra/build-improvements"] `
+                -source 'infra/build-improvements' `
+                -initialCommits $initialCommits
+            Initialize-LocalActionMergeBranches `
+                -upstreamBranches @('infra/ts-update') `
+                -noChangeBranches @('infra/ts-update') `
+                -resultCommitish $initialCommits["$($remotePrefix)feature/PS-1"] `
+                -source 'feature/PS-1' `
+                -initialCommits $initialCommits
+            Initialize-LocalActionMergeBranches `
+                -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+                -resultCommitish $initialCommits["$($remotePrefix)feature/PS-2"] `
+                -source 'feature/PS-2' `
+                -initialCommits $initialCommits
+
+                & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 -recurse
+        }
+    }
+
+    Context 'without a remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration -noRemote
+        }
+
+        Add-StandardTests
+    }
+
+    Context 'with a remote' {
+        BeforeEach {
+            Initialize-ToolConfiguration
+            Initialize-UpdateGitRemote
+        }
+
+        Add-StandardTests
+    
+        It 'uses the current branch if none specified, but fails if not pushed' {
+            Initialize-CurrentBranch 'feature/PS-2'
+            Initialize-AssertValidBranchName 'feature/PS-2'
+            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+            Initialize-LocalActionAssertPushedAhead 'feature/PS-2'
+
+            { & $PSScriptRoot/git-verify-updated.ps1 }
+                | Should -Throw "ERR:  The local branch for feature/PS-2 has changes that are not pushed to the remote"
+        }
+
+        It 'uses the current branch if none specified, but fails if not tracked to the remote' {
+            Initialize-CurrentBranch 'feature/PS-2'
+            Initialize-AssertValidBranchName 'feature/PS-2'
+            Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+            Initialize-LocalActionAssertPushedNotTracked 'feature/PS-2'
+
+            { & $PSScriptRoot/git-verify-updated.ps1 }
+                | Should -Throw "ERR:  The local branch for feature/PS-2 does not exist on the remote"
+        }
     }
 
 }

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -8,7 +8,7 @@ Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionGetU
 Export-ModuleMember -Function Initialize-UpstreamBranches
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionMergeBranches.mocks.psm1"
-Export-ModuleMember -Function Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess
+Export-ModuleMember -Function Initialize-LocalActionMergeBranches,Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionSetUpstream.mocks.psm1"
 Export-ModuleMember -Function Lock-LocalActionSetUpstream, Initialize-LocalActionSetUpstream

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -10,6 +10,9 @@ Export-ModuleMember -Function Initialize-UpstreamBranches
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionMergeBranches.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionMergeBranches,Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess
 
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionRecurse.mocks.psm1"
+Export-ModuleMember -Function Initialize-LocalActionRecurseSuccess
+
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionSetUpstream.mocks.psm1"
 Export-ModuleMember -Function Lock-LocalActionSetUpstream, Initialize-LocalActionSetUpstream
 
@@ -30,3 +33,6 @@ Export-ModuleMember -Function Initialize-FinalizeActionSetBranches
 
 Import-Module -Scope Local "$PSScriptRoot/actions/finalize/Register-FinalizeActionTrack.mocks.psm1"
 Export-ModuleMember -Function Initialize-FinalizeActionTrackDryRun, Initialize-FinalizeActionTrackSuccess
+
+Import-Module -Scope Local "$PSScriptRoot/actions/Invoke-LocalAction.mocks.psm1"
+Export-ModuleMember -Function Initialize-FakeLocalAction

--- a/utils/actions/Invoke-LocalAction.internal.psm1
+++ b/utils/actions/Invoke-LocalAction.internal.psm1
@@ -1,0 +1,40 @@
+Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+
+$localActions = @{}
+function Get-LocalActionsRegistry {
+    return $localActions
+}
+
+function Invoke-LocalAction(
+    [PSObject] $actionDefinition,
+    [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+) {
+    $actionDefinition = ConvertTo-Hashtable $actionDefinition
+
+    # look up type
+    $targetAction = $localActions[$actionDefinition.type]
+    if ($null -eq $targetAction) {
+        Add-ErrorDiagnostic $diagnostics "Could not find local action type '$($actionDefinition.type)'"
+        return $null
+    }
+
+    # if a condition is specified, ensure it is truthy
+    if ($actionDefinition.Keys -contains 'condition' -AND -not $actionDefinition.condition) {
+        return $null
+    }
+
+    # run
+    $parameters = ConvertTo-Hashtable $actionDefinition.parameters
+    try {
+        $outputs = & $targetAction @parameters -diagnostics $diagnostics
+    } catch {
+        Write-Host "ex: $_"
+        Add-ErrorDiagnostic $diagnostics "Unhandled exception occurred while running $(ConvertTo-Json $actionDefinition -Depth 10):"
+        Add-ErrorException $diagnostics $_
+    }
+
+    return $outputs
+}
+
+Export-ModuleMember -Function Invoke-LocalAction, Get-LocalActionsRegistry

--- a/utils/actions/Invoke-LocalAction.internal.psm1
+++ b/utils/actions/Invoke-LocalAction.internal.psm1
@@ -6,6 +6,10 @@ function Get-LocalActionsRegistry {
     return $localActions
 }
 
+function Get-LocalAction([string] $type) {
+    return $localActions[$type]
+}
+
 function Invoke-LocalAction(
     [PSObject] $actionDefinition,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
@@ -13,7 +17,7 @@ function Invoke-LocalAction(
     $actionDefinition = ConvertTo-Hashtable $actionDefinition
 
     # look up type
-    $targetAction = $localActions[$actionDefinition.type]
+    $targetAction = Get-LocalAction $actionDefinition.type
     if ($null -eq $targetAction) {
         Add-ErrorDiagnostic $diagnostics "Could not find local action type '$($actionDefinition.type)'"
         return $null
@@ -37,4 +41,4 @@ function Invoke-LocalAction(
     return $outputs
 }
 
-Export-ModuleMember -Function Invoke-LocalAction, Get-LocalActionsRegistry
+Export-ModuleMember -Function Invoke-LocalAction, Get-LocalAction, Get-LocalActionsRegistry

--- a/utils/actions/Invoke-LocalAction.mocks.psm1
+++ b/utils/actions/Invoke-LocalAction.mocks.psm1
@@ -1,0 +1,14 @@
+Import-Module -Scope Local "$PSScriptRoot/Invoke-LocalAction.internal.psm1"
+
+function Initialize-FakeLocalAction(
+    [Parameter(Mandatory)][string] $actionType,
+    [Parameter()][scriptblock] $returns
+) {
+    Mock -CommandName Get-LocalAction `
+        -ModuleName "Invoke-LocalAction.internal" `
+        -ParameterFilter $([scriptblock]::Create("`$type -eq '$actionType'")) -MockWith {
+            return $returns
+        }.GetNewClosure()
+}
+
+Export-ModuleMember -Function Initialize-FakeLocalAction

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -1,57 +1,27 @@
-Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
-Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Invoke-LocalAction.internal.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAddDiagnostic.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertPushed.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionGetUpstream.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionFilterBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionMergeBranches.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionRecurse.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSetUpstream.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionSimplifyUpstreamBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionUpstreamsUpdated.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionValidateBranchNames.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertExistence.psm1"
 
-$localActions = @{}
+$localActions = Get-LocalActionsRegistry
 Register-LocalActionAddDiagnostic $localActions
 Register-LocalActionAssertPushed $localActions
 Register-LocalActionGetUpstream $localActions
 Register-LocalActionFilterBranches $localActions
 Register-LocalActionMergeBranches $localActions
+Register-LocalActionRecurse $localActions
 Register-LocalActionSetUpstream $localActions
 Register-LocalActionSimplifyUpstreamBranches $localActions
 Register-LocalActionUpstreamsUpdated $localActions
 Register-LocalActionValidateBranchNames $localActions
 Register-LocalActionAssertExistence $localActions
-
-function Invoke-LocalAction(
-    [PSObject] $actionDefinition,
-    [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-) {
-    $actionDefinition = ConvertTo-Hashtable $actionDefinition
-
-    # look up type
-    $targetAction = $localActions[$actionDefinition.type]
-    if ($null -eq $targetAction) {
-        Add-ErrorDiagnostic $diagnostics "Could not find local action type '$($actionDefinition.type)'"
-        return $null
-    }
-
-    # if a condition is specified, ensure it is truthy
-    if ($actionDefinition.Keys -contains 'condition' -AND -not $actionDefinition.condition) {
-        return $null
-    }
-
-    # run
-    $parameters = ConvertTo-Hashtable $actionDefinition.parameters
-    try {
-        $outputs = & $targetAction @parameters -diagnostics $diagnostics
-    } catch {
-        Write-Host "ex: $_"
-        Add-ErrorDiagnostic $diagnostics "Unhandled exception occurred while running $(ConvertTo-Json $actionDefinition -Depth 10):"
-        Add-ErrorException $diagnostics $_
-    }
-
-    return $outputs
-}
 
 Export-ModuleMember -Function Invoke-LocalAction

--- a/utils/actions/local/Register-LocalActionAssertPushed.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.mocks.psm1
@@ -13,6 +13,9 @@ function Initialize-LocalActionAssertPushedNotTracked(
 function Initialize-LocalActionAssertPushedSuccess(
     [string] $branchName
 ) {
+    $remote = $(Get-Configuration).remote
+    if ($null -eq $remote) { return }
+
     Initialize-RemoteBranchInSync $branchName
 }
 

--- a/utils/actions/local/Register-LocalActionAssertPushed.psm1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.psm1
@@ -6,6 +6,7 @@ function Register-LocalActionAssertPushed([PSObject] $localActions) {
     $localActions['assert-pushed'] = {
         param(
             [Parameter()][string] $target,
+            [Switch] $remoteMustExist,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
@@ -14,6 +15,8 @@ function Register-LocalActionAssertPushed([PSObject] $localActions) {
         $disallowed = @('>', '<>')
         if ($disallowed -contains $state) {
             Add-ErrorDiagnostic $diagnostics "The local branch for $target has changes that are not pushed to the remote"
+        } elseif ($remoteMustExist -AND -not $state) {
+            Add-ErrorDiagnostic $diagnostics "The local branch for $target does not exist on the remote"
         }
         
         return @{}

--- a/utils/actions/local/Register-LocalActionMergeBranches.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.mocks.psm1
@@ -4,6 +4,38 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionMergeBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
 
+function Initialize-LocalActionMergeBranches(
+    [Parameter(Mandatory)][string[]] $upstreamBranches,
+    [AllowEmptyCollection()][string[]] $successfulBranches,
+    [AllowEmptyCollection()][string[]] $noChangeBranches,
+    [Parameter()][Hashtable] $initialCommits = @{},
+    [Parameter()][string] $resultCommitish,
+    [Parameter()][string] $mergeMessageTemplate,
+    [Parameter()][string] $source,
+    [Switch] $sourceFailed
+) {
+    $config = Get-Configuration
+    if ($null -ne $config.remote) {
+        $upstreamBranches = [string[]]$upstreamBranches | Foreach-Object { "$($config.remote)/$_" }
+        $successfulBranches = [string[]]$successfulBranches | Where-Object { $_ } | Foreach-Object { "$($config.remote)/$_" }
+        $noChangeBranches = [string[]]$noChangeBranches | Where-Object { $_ } | Foreach-Object { "$($config.remote)/$_" }
+        if ($null -ne $source -AND '' -ne $source) {
+            $source = "$($config.remote)/$source"
+        }
+    }
+
+    if ($sourceFailed) {
+        Initialize-MergeTogetherAllFailed @($source)
+        return
+    }
+
+    Initialize-MergeTogether -allBranches $upstreamBranches -successfulBranches $successfulBranches -noChangeBranches $noChangeBranches `
+        -initialCommits $initialCommits `
+        -source $source `
+        -messageTemplate $mergeMessageTemplate `
+        -resultCommitish $resultCommitish
+}
+
 function Initialize-LocalActionMergeBranchesFailure(
     [Parameter(Mandatory)][string[]] $upstreamBranches,
     [Parameter(Mandatory)][string[]] $failures,
@@ -11,25 +43,14 @@ function Initialize-LocalActionMergeBranchesFailure(
     [Parameter(Mandatory)][string] $mergeMessageTemplate,
     [Parameter()][string] $source
 ) {
-    $config = Get-Configuration
-    if ($null -ne $config.remote) {
-        $upstreamBranches = [string[]]$upstreamBranches | Foreach-Object { "$($config.remote)/$_" }
-        $failures = [string[]]$failures | Foreach-Object { "$($config.remote)/$_" }
-        if ($null -ne $source -AND '' -ne $source) {
-            $source = "$($config.remote)/$source"
-        }
-    }
-
     $successfulBranches = ($upstreamBranches | Where-Object { $_ -notin $failures })
-    if ($source -in $failures) {
-        Initialize-MergeTogetherAllFailed @($source)
-        return
-    }
-
-    Initialize-MergeTogether -allBranches $upstreamBranches -successfulBranches $successfulBranches `
+    Initialize-LocalActionMergeBranches `
+        -upstreamBranches $upstreamBranches `
+        -successfulBranches $successfulBranches `
+        -resultCommitish $resultCommitish `
+        -mergeMessageTemplate $mergeMessageTemplate `
         -source $source `
-        -messageTemplate $mergeMessageTemplate `
-        -resultCommitish $resultCommitish
+        -sourceFailed:($source -in $failures)
 }
 
 function Initialize-LocalActionMergeBranchesSuccess(
@@ -40,26 +61,16 @@ function Initialize-LocalActionMergeBranchesSuccess(
     [Parameter()][int] $failAtMerge = -1,
     [Parameter()][string[]] $failedBranches
 ) {
-    $config = Get-Configuration
-    if ($null -ne $config.remote) {
-        $upstreamBranches = [string[]]$upstreamBranches | Foreach-Object { "$($config.remote)/$_" }
-        if ($null -ne $source -AND '' -ne $source) {
-            $source = "$($config.remote)/$source"
-        }
-        if ($failedBranches) {
-            $failedBranches = [string[]]$failedBranches | Foreach-Object { "$($config.remote)/$_" }
-        }
-    }
-
     [string[]]$successfulBranches = $failAtMerge -eq -1 -AND -not $failedBranches ? $upstreamBranches
         : $failedBranches ? ($upstreamBranches | Where-Object { $failedBranches -notcontains $_ })
         : $failAtMerge -eq 0 ? @()
         : ($upstreamBranches | Select-Object -First $failAtMerge)
-
-    Initialize-MergeTogether -allBranches $upstreamBranches -successfulBranches $successfulBranches `
-        -source $source `
-        -messageTemplate $mergeMessageTemplate `
-        -resultCommitish $resultCommitish
+    Initialize-LocalActionMergeBranches `
+        -upstreamBranches $upstreamBranches `
+        -successfulBranches $successfulBranches `
+        -resultCommitish $resultCommitish `
+        -mergeMessageTemplate $mergeMessageTemplate `
+        -source $source
 }
 
-Export-ModuleMember -Function Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess
+Export-ModuleMember -Function Initialize-LocalActionMergeBranches, Initialize-LocalActionMergeBranchesFailure,Initialize-LocalActionMergeBranchesSuccess

--- a/utils/actions/local/Register-LocalActionMergeBranches.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.mocks.psm1
@@ -10,7 +10,7 @@ function Initialize-LocalActionMergeBranches(
     [AllowEmptyCollection()][string[]] $noChangeBranches,
     [Parameter()][Hashtable] $initialCommits = @{},
     [Parameter()][string] $resultCommitish,
-    [Parameter()][string] $mergeMessageTemplate,
+    [Parameter()][string] $mergeMessageTemplate = "Merge {}",
     [Parameter()][string] $source,
     [Switch] $sourceFailed
 ) {

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -8,7 +8,7 @@ function Register-LocalActionMergeBranches([PSObject] $localActions) {
         param(
             [string] $source,
             [string[]] $upstreamBranches,
-            [string] $mergeMessageTemplate,
+            [string] $mergeMessageTemplate = "Merge {}",
             [Parameter()][bool] $errorOnFailure = $false,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -15,9 +15,19 @@ function Register-LocalActionMergeBranches([PSObject] $localActions) {
 
         $config = Get-Configuration
         if ($null -ne $config.remote) {
-            $upstreamBranches = [string[]]$upstreamBranches | Foreach-Object { "$($config.remote)/$_" }
+            $upstreamBranches = [string[]]$upstreamBranches | Where-Object { $_ } | Foreach-Object { "$($config.remote)/$_" }
             if ($null -ne $source -AND '' -ne $source) {
                 $source = "$($config.remote)/$source"
+            }
+        }
+
+        if ($null -eq $upstreamBranches) {
+            # Nothing to merge
+            return @{
+                commit = $null;
+                hasChanges = $false;
+                failed = @();
+                successful = $();
             }
         }
 

--- a/utils/actions/local/Register-LocalActionRecurse.md
+++ b/utils/actions/local/Register-LocalActionRecurse.md
@@ -1,0 +1,100 @@
+# Local Action 'recurse'
+
+This action is intended to run another script recursively. The primary action
+looks like this:
+
+```json
+{
+    "type": "recurse",
+    "parameters": {
+        "inputParameters": [],
+        "path": "path-to-recursion-script.json"
+    }
+}
+```
+
+- `inputParameters` is an array of seed inputs into the recursion script; the
+  initial stack. This must be an array of objects. If a `depth` property is not
+  set on any of the input objects, `depth` will be added to indicate the recursive
+  depth of the algorithm, starting with 0 for the initial input.
+- `path` is the path to the recursion script, based on the root of this
+  repository.
+
+## Recursive Script definition
+
+The contents of the recursion script should be something like the following:
+
+```json
+{
+    "recursion": {
+        "mode": "depth-first", // otherwise behaves as breadth-first
+        "paramScript": "pwsh-script",
+        "map": "pwsh-script",
+        "reduceToOutput": "pwsh-script",
+        "actCondition": "pwsh-script" // optional
+    },
+    "prepare": [
+        // set of local-actions
+    ],
+    "act": [
+        // set of local-actions
+    ]
+}
+```
+
+### `recursion.mode`
+
+If `depth-first`, recursion will be done via a depth-first strategy. Otherwise,
+recursion will be breadth-first.
+
+### `recursion.paramScript`
+
+A powershell script that:
+- runs after the `prepare` actions for each input of the recursive algorithm
+- receives the following variables:
+    - `$params` contains the current input object of the recursive algorithm.
+    - `$actions` is the result of the `prepare` actions
+- should return an array of new inputs for the recursive algorithm
+
+### `recursion.map`
+
+A powershell script that:
+- runs after the `act` actions for each input of the recursive algorithm
+- receives the following variables:
+    - `$params` contains the current input object of the recursive algorithm.
+    - `$actions` is the result of the `prepare` actions
+- should return a value to be reduced in the `recursion.reduceToOutput` script
+
+### `recursion.reduceToOutput`
+
+A powershell script that:
+- runs after all `recursion.map` scripts have run
+- receives the following variables:
+    - `$mapped` is an array containing the results of each previous
+      `recursion.map` script
+- returns the value to be bound to the output of the `recurse` action that
+  invoked the script
+
+### `recursion.actCondition`
+
+An optional powershell script that:
+- runs after the `prepare` actions for each input of the recursive algorithm
+- receives the following variables:
+    - `$params` contains the current input object of the recursive algorithm.
+    - `$actions` is the result of the `prepare` actions
+- returns a falsy value if the `act` actions should not be run for this
+  recursive input
+
+### `prepare`
+
+A set of "local" actions that:
+- run once for each set of inputs, before any `act` actions are run
+- in the order as determined by `recursion.mode`
+
+### `act`
+
+A set of "local" actions that:
+- run once for each set of inputs, after all `prepare` actions are run
+- if the `recursion.actCondition` is either not present or evaluates to a truthy
+  value
+- in the order as determined by `recursion.mode`

--- a/utils/actions/local/Register-LocalActionRecurse.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.mocks.psm1
@@ -1,0 +1,12 @@
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionRecurse.psm1"
+
+function Initialize-LocalActionRecurseSuccess(
+) {
+
+}
+
+Export-ModuleMember -Function Initialize-LocalActionRecurseSuccess

--- a/utils/actions/local/Register-LocalActionRecurse.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.mocks.psm1
@@ -5,8 +5,15 @@ Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionRecurse.psm1"
 
 function Initialize-LocalActionRecurseSuccess(
+    [Parameter(Mandatory)][string] $ScriptName,
+    [Parameter(Mandatory)][string] $ScriptContents
 ) {
-
+    $mockScriptFullPath = "$PSScriptRoot/../../../$ScriptName"
+    Mock -CommandName Get-Content `
+        -ModuleName "Register-LocalActionRecurse" `
+        -ParameterFilter $([scriptblock]::Create("`$path -eq '$mockScriptFullPath'")) -MockWith {
+        $ScriptContents
+    }.GetNewClosure()
 }
 
 Export-ModuleMember -Function Initialize-LocalActionRecurseSuccess

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -75,6 +75,9 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
             if ($null -ne $newParams) {
                 $allInputs += $newParams
             }
+            if (Get-HasErrorDiagnostic $diagnostics) {
+                return $null
+            }
         }
 
         [System.Collections.ArrayList]$mapped = @()
@@ -87,6 +90,9 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
             $inputs.actions = Invoke-Act -actScripts $instructions.act @inputs @commonParams
             $mapResult = & $mapScript -actions $inputs.actions
             $mapped.Add($mapResult) > $null
+            if (Get-HasErrorDiagnostic $diagnostics) {
+                return $null
+            }
         }
 
         return & $reduceToOutput -mapped $mapped
@@ -120,7 +126,9 @@ function Invoke-Prepare(
             Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
             Add-ErrorException $diagnostics $_
         }
-        Assert-Diagnostics $diagnostics
+        if (Get-HasErrorDiagnostic $diagnostics) {
+            return $actions
+        }
     }
 
     return $actions
@@ -153,7 +161,9 @@ function Invoke-Act(
             Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
             Add-ErrorException $diagnostics $_
         }
-        Assert-Diagnostics $diagnostics
+        if (Get-HasErrorDiagnostic $diagnostics) {
+            return $actions
+        }
     }
 
     return $actions

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -1,0 +1,153 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../scripting/ConvertFrom-ParameterizedAnything.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.internal.psm1"
+
+function Register-LocalActionRecurse([PSObject] $localActions) {
+    $localActions['recurse'] = {
+        param(
+            [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $inputParameters,
+            [Parameter(Mandatory)][string] $path,
+            
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+
+        $config = Get-Configuration
+        $commonParams = @{
+            config = $config
+            diagnostics = $diagnostics
+        }
+
+        $instructions = Get-Content "$PSScriptRoot/../../../$path" | ConvertFrom-Json
+
+        [System.Collections.ArrayList]$allInputs = $inputParameters
+        [System.Collections.ArrayList]$inputStack = $inputParameters
+        [System.Collections.ArrayList]$pendingAct = @()
+
+        $paramScript = [ScriptBlock]::Create('
+            param($actions, $previous)
+            Set-StrictMode -Version 3.0; 
+            try {
+                ' + $instructions.recursion.paramScript + '
+            } catch {
+            }
+        ')
+        $mapScript = [ScriptBlock]::Create('
+            param($actions)
+            Set-StrictMode -Version 3.0; 
+            try {
+                ' + $instructions.recursion.mapScript + '
+            } catch {
+            }
+        ')
+        $reduceToOutput = [ScriptBlock]::Create('
+            param($mapped)
+            Set-StrictMode -Version 3.0; 
+            try {
+                ' + $instructions.recursion.reduceToOutput + '
+            } catch {
+            }
+        ');
+
+        while ($inputStack.Count -gt 0) {
+            $params = $inputStack[0];
+            $inputStack.RemoveAt(0);
+            $actions = @{}
+            $inputs = @{
+                params = $params;
+                actions = $actions;
+            }
+            $inputs.actions = Invoke-Prepare -prepareScripts $instructions.prepare @inputs @commonParams
+            if ($instructions.recursion.mode -eq 'depth-first') {
+                $pendingAct.Insert(0, $inputs)
+            } else {
+                $pendingAct.Add($inputs) > $null
+            }
+            [array]$newParams = & $paramScript -actions $inputs.actions -previous $allInputs
+            if ($null -ne $newParams) {
+                $inputStack.AddRange($newParams)
+                $allInputs.AddRange($newParams)
+            }
+        }
+
+        [System.Collections.ArrayList]$mapped = @()
+        while ($pendingAct.Count -gt 0) {
+            $inputs = $pendingAct[0]
+            $pendingAct.RemoveAt(0);
+            $inputs.actions = Invoke-Act -actScripts $instructions.act @inputs @commonParams
+            $mapResult = & $mapScript -actions $inputs.actions
+            $mapped.Add($mapResult) > $null
+        }
+
+        return & $reduceToOutput -mapped $mapped
+    }
+}
+
+function Invoke-Prepare(
+    $config,
+    $prepareScripts,
+    $params,
+    $actions,
+
+    [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+) {
+    
+    for ($i = 0; $i -lt $prepareScripts.Count; $i++) {
+        $name = $prepareScripts[$i].id ?? "#$($i + 1) (1-based)";
+        $local = ConvertFrom-ParameterizedAnything -script $prepareScripts[$i] -config $config -params $params -actions $actions -diagnostics $diagnostics
+        if ($local.fail) {
+            Add-ErrorDiagnostic $diagnostics "Could not apply parameters to recursive prepare (local) action $name; see above errors. Evaluation below:"
+            Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
+            break
+        }
+        try {
+            $outputs = Invoke-LocalAction $local.result -diagnostics $diagnostics
+            if ($null -ne $local.result.id) {
+                $actions += @{ $local.result.id = @{ outputs = $outputs } }
+            }
+        } catch {
+            Add-ErrorDiagnostic $diagnostics "Encountered error while running recursive prepare (local) action $($name), evaluated below, with the error following."
+            Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
+            Add-ErrorException $diagnostics $_
+        }
+        Assert-Diagnostics $diagnostics
+    }
+
+    return $actions
+}
+
+function Invoke-Act(
+    $config,
+    $actScripts,
+    $params,
+    $actions,
+
+    [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+) {
+    
+    for ($i = 0; $i -lt $actScripts.Count; $i++) {
+        $name = $actScripts[$i].id ?? "#$($i + 1) (1-based)";
+        $local = ConvertFrom-ParameterizedAnything -script $actScripts[$i] -config $config -params $params -actions $actions -diagnostics $diagnostics
+        if ($local.fail) {
+            Add-ErrorDiagnostic $diagnostics "Could not apply parameters to recursive act (local) action $name; see above errors. Evaluation below:"
+            Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
+            break
+        }
+        try {
+            $outputs = Invoke-LocalAction $local.result -diagnostics $diagnostics
+            if ($null -ne $local.result.id) {
+                $actions += @{ $local.result.id = @{ outputs = $outputs } }
+            }
+        } catch {
+            Add-ErrorDiagnostic $diagnostics "Encountered error while running recursive act (local) action $($name), evaluated below, with the error following."
+            Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
+            Add-ErrorException $diagnostics $_
+        }
+        Assert-Diagnostics $diagnostics
+    }
+
+    return $actions
+}
+
+Export-ModuleMember -Function Register-LocalActionRecurse

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -41,6 +41,10 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
         [System.Collections.ArrayList]$inputStack = @() + $inputParameters
         [System.Collections.ArrayList]$pendingAct = @()
 
+        if ($depthFirst) {
+            $inputStack.Reverse()
+        }
+
         $paramScript = New-SafeScript -header 'param($actions, $params, $previous)' `
             -script $instructions.recursion.paramScript 
         $canActScript = New-SafeScript -header 'param($actions, $params)' `
@@ -69,6 +73,8 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
                     $pendingAct.Insert(0, $inputs)
                 }
                 if ($null -ne $newParams) {
+                    [array]$newParams = @() + [array]$newParams
+                    [array]::Reverse($newParams)
                     $inputStack.InsertRange(0, $newParams)
                 }
             } else {
@@ -88,9 +94,6 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
         }
 
         [System.Collections.ArrayList]$mapped = @()
-        if ($depthFirst) {
-            $pendingAct.Reverse()
-        }
         while ($pendingAct.Count -gt 0) {
             $inputs = $pendingAct[0]
             $pendingAct.RemoveAt(0);

--- a/utils/actions/local/Register-LocalActionRecurse.tests.ps1
+++ b/utils/actions/local/Register-LocalActionRecurse.tests.ps1
@@ -92,6 +92,7 @@ Describe 'local action "recurse"' {
             } 
             Initialize-FakeLocalAction "handle-target" {
                 param($target)
+                return $target
                 if ($target -eq '11') { return '1' }
                 if ($target -eq '12') { return '2' }
                 if ($target -eq '13') { return '3' }
@@ -102,7 +103,7 @@ Describe 'local action "recurse"' {
             }
 
             $output = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
-            $output | Should -Be '1 2 3 4 5 6 7'
+            $output | Should -Be '11 12 13 10 21 22 20'
 
             Invoke-FlushAssertDiagnostic $fw.diagnostics
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty

--- a/utils/actions/local/Register-LocalActionRecurse.tests.ps1
+++ b/utils/actions/local/Register-LocalActionRecurse.tests.ps1
@@ -1,0 +1,32 @@
+Describe 'local action "recurse"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../actions.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $standardScript = ('{ 
+            "type": "recurse", 
+            "parameters": {
+                /* implement me */
+            }
+        }' | ConvertFrom-Json)
+    }
+
+    It 'will be implemented' -Pending {
+        Initialize-LocalActionRecurseSuccess
+
+        Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+    }
+}

--- a/utils/actions/local/Register-LocalActionRecurse.tests.ps1
+++ b/utils/actions/local/Register-LocalActionRecurse.tests.ps1
@@ -9,24 +9,115 @@ Describe 'local action "recurse"' {
     }
     
     BeforeEach {
+        Initialize-ToolConfiguration
+
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $fw = Register-Framework
 
         [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
         $standardScript = ('{ 
-            "type": "recurse", 
+            "type": "recurse",
             "parameters": {
-                /* implement me */
+                "inputParameters": [{
+                    "target": "10"
+                }, {
+                    "target": "20"
+                }],
+                "path": "mock-script"
             }
         }' | ConvertFrom-Json)
+
+        function Get-InnerScript([string] $mode) {
+            return '{
+                "recursion": {
+                    "mode": "' + $mode + '",
+                    "paramScript": "$actions.children.outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_ } }",
+                    "map": "$actions.handled.outputs",
+                    "reduceToOutput": "$mapped -join \" \""
+                },
+                "prepare": [{
+                    "id": "children",
+                    "type": "get-children",
+                    "parameters": {
+                        "target": "$params.target"
+                    }
+                }],
+                "act": [{
+                    "id": "handled",
+                    "type": "handle-target",
+                    "parameters": {
+                        "target": "$params.target"
+                    }
+                }]
+            }'
+        }
+
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $depthFirstInnerScript = Get-InnerScript "depth-first"
+
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $depthFirstInnerScript = Get-InnerScript "breadth-first"
     }
 
-    It 'will be implemented' -Pending {
-        Initialize-LocalActionRecurseSuccess
+    Context 'depth-first' {
+        BeforeEach {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+            $innerScript = Get-InnerScript "depth-first"
+        }
 
-        Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+        It 'processes output in the correct order' {
+            Initialize-LocalActionRecurseSuccess -ScriptName "mock-script" -ScriptContents $innerScript
+            Initialize-FakeLocalAction "get-children" {
+                param($target)
+                if ($target -eq '10') { return @('11', '12') }
+                if ($target -eq '20') { return @('21', '22') }
+            } 
+            Initialize-FakeLocalAction "handle-target" {
+                param($target)
+                if ($target -eq '10') { return '1' }
+                if ($target -eq '11') { return '2' }
+                if ($target -eq '12') { return '3' }
+                if ($target -eq '20') { return '4' }
+                if ($target -eq '21') { return '5' }
+                if ($target -eq '22') { return '6' }
+            }
 
-        Invoke-FlushAssertDiagnostic $fw.diagnostics
-        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+            $output = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+            $output | Should -Be '1 2 3 4 5 6'
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'breadth-first' {
+        BeforeEach {
+            [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+            $innerScript = Get-InnerScript "breadth-first"
+        }
+
+        It 'processes output in the correct order' {
+            Initialize-LocalActionRecurseSuccess -ScriptName "mock-script" -ScriptContents $innerScript
+            Initialize-FakeLocalAction "get-children" {
+                param($target)
+                if ($target -eq '10') { return @('11', '12') }
+                if ($target -eq '20') { return @('21', '22') }
+            } 
+            Initialize-FakeLocalAction "handle-target" {
+                param($target)
+                if ($target -eq '10') { return '1' }
+                if ($target -eq '20') { return '2' }
+                if ($target -eq '11') { return '3' }
+                if ($target -eq '12') { return '4' }
+                if ($target -eq '21') { return '5' }
+                if ($target -eq '22') { return '6' }
+            }
+
+            $output = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+            $output | Should -Be '1 2 3 4 5 6'
+
+            Invoke-FlushAssertDiagnostic $fw.diagnostics
+            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        }
     }
 }

--- a/utils/actions/local/Register-LocalActionRecurse.tests.ps1
+++ b/utils/actions/local/Register-LocalActionRecurse.tests.ps1
@@ -74,12 +74,12 @@ Describe 'local action "recurse"' {
             } 
             Initialize-FakeLocalAction "handle-target" {
                 param($target)
-                if ($target -eq '10') { return '1' }
-                if ($target -eq '11') { return '2' }
-                if ($target -eq '12') { return '3' }
-                if ($target -eq '20') { return '4' }
-                if ($target -eq '21') { return '5' }
-                if ($target -eq '22') { return '6' }
+                if ($target -eq '11') { return '1' }
+                if ($target -eq '12') { return '2' }
+                if ($target -eq '10') { return '3' }
+                if ($target -eq '21') { return '4' }
+                if ($target -eq '22') { return '5' }
+                if ($target -eq '20') { return '6' }
             }
 
             $output = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics

--- a/utils/actions/local/Register-LocalActionRecurse.tests.ps1
+++ b/utils/actions/local/Register-LocalActionRecurse.tests.ps1
@@ -51,12 +51,6 @@ Describe 'local action "recurse"' {
                 }]
             }'
         }
-
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $depthFirstInnerScript = Get-InnerScript "depth-first"
-
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
-        $depthFirstInnerScript = Get-InnerScript "breadth-first"
     }
 
     Context 'depth-first' {

--- a/utils/git/Invoke-MergeTogether.mocks.psm1
+++ b/utils/git/Invoke-MergeTogether.mocks.psm1
@@ -35,7 +35,9 @@ function Initialize-MergeTogetherAllFailed(
 function Initialize-MergeTogether(
     [AllowEmptyCollection()][string[]] $allBranches,
     [AllowEmptyCollection()][string[]] $successfulBranches,
+    [AllowEmptyCollection()][string[]] $noChangeBranches,
     [AllowNull()][string] $source = $null,
+    [Hashtable] $initialCommits = @{},
     [string] $messageTemplate = "Merge {}",
     [string] $resultCommitish
 ) {
@@ -47,16 +49,25 @@ function Initialize-MergeTogether(
     if ($null -ne $source -AND '' -ne $source -AND $successfulBranches -notcontains $source) {
         $successfulBranches = @($source) + ($successfulBranches | Where-Object { $_ })
     }
-    $initialSuccessfulBranch = ($allBranches | Where-Object { $successfulBranches -contains $_ } | Select-Object -First 1)
+    $initialSuccessfulBranch = ($allBranches | Where-Object { $successfulBranches -contains $_ -or $noChangeBranches -contains $_ } | Select-Object -First 1)
     
-    $commitish = $allBranches | ConvertTo-HashMap -getValue { "$_-commitish" }
+    $commitish = $allBranches | ConvertTo-HashMap -getValue { $initialCommits[$_] ?? "$_-commitish" }
     if ($null -ne $initialSuccessfulBranch) {
         $lastBranch = ($allBranches | Where-Object { $successfulBranches -contains $_ } | Select-Object -Last 1)
-        $resultCommitishes = $successfulBranches | Where-Object { $successfulBranches -contains $_ } | ConvertTo-HashMap -getValue { "$_-result-commitish" }
-        if ($lastBranch -eq $initialSuccessfulBranch) {
-            $resultCommitishes[$lastBranch] = $resultCommitish
+        $resultCommitishes = $successfulBranches | ConvertTo-HashMap -getValue { "$_-result-commitish" }
+
+        if ($null -eq $initialCommits[$initialSuccessfulBranch]) {
+            if ($lastBranch -eq $initialSuccessfulBranch) {
+                $resultCommitishes[$lastBranch] = $resultCommitish
+            }
+            $commitish[$initialSuccessfulBranch] = $resultCommitishes[$initialSuccessfulBranch]
+        } else {
+            $resultCommitishes[$initialSuccessfulBranch] = $commitish[$initialSuccessfulBranch]
+            if ($lastBranch -eq $initialSuccessfulBranch -AND $commitish[$initialSuccessfulBranch] -ne $resultCommitish) {
+                throw "Invalid Initialize-MergeTogether; `$initialCommits[$initialSuccessfulBranch] should be $resultCommitish"
+            }
         }
-        $commitish[$initialSuccessfulBranch] = $resultCommitishes[$initialSuccessfulBranch]
+
         if ($null -eq $resultCommitish) {
             throw 'Invalid Initialize-MergeTogether; -resultCommitish must be provided if any branches are successful'
         }
@@ -65,10 +76,15 @@ function Initialize-MergeTogether(
         Invoke-MockGit "rev-parse --verify $initialSuccessfulBranch" -MockWith { $commitish[$initialSuccessfulBranch] }.GetNewClosure()
     }
 
-
     for ($i = 0; $i -lt $allBranches.Count; $i++) {
         $current = $allBranches[$i]
-        if ($successfulBranches -contains $current) {
+        if ($noChangeBranches -contains $current) {
+            $success += $current
+            if ($current -eq $initialSuccessfulBranch) { continue }
+            Invoke-MockGit "rev-parse --verify $current" -MockWith $commitish[$current]
+
+            Invoke-MockGit "rev-list --count ^$currentCommit $($commitish[$current])" -MockWith "0"
+        } elseif ($successfulBranches -contains $current) {
             $success += $current
             if ($current -eq $initialSuccessfulBranch) { continue }
             Invoke-MockGit "rev-parse --verify $current" -MockWith $commitish[$current]

--- a/utils/git/Invoke-MergeTogether.psm1
+++ b/utils/git/Invoke-MergeTogether.psm1
@@ -96,11 +96,11 @@ function Invoke-MergeTogether(
 
                     $currentCommit = $resultCommit
                     $parentCommits += $targetCommit
+                    $successful += $target
                 }
                 $allFailed = $false
                 $i--
                 $remaining = $remaining | Where-Object { $_ -ne $target }
-                $successful += $target
                 break;
             }
             if ($allFailed -AND $remaining.Count -gt 0) {

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -33,14 +33,9 @@ function Invoke-Script(
                 Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
                 Add-ErrorException $diagnostics $_
             }
-            if (Get-HasErrorDiagnostic $diagnostics) {
-                # Don't bother continuing if anything failed; this leads to lots of noise in failed applied parameters
-                break
-            }
+            Assert-Diagnostics $diagnostics
         }
 
-        Assert-Diagnostics $diagnostics
-        
         if ($script.finalize) {
             $allFinalize = ConvertFrom-ParameterizedAnything -script $script.finalize -config $config -params $params -actions $actions -diagnostics $diagnostics
             if ($allFinalize.fail) {


### PR DESCRIPTION
- Adds a "recurse" local action that halts on any failure
- Adds a new `Initialize-LocalActionMergeBranches` mock setup that supports specifying the commits for each merge and a list of branches that will result in no changes
- Moves the `Invoke-LocalAction` function so it may be used by the "recurse" action without self-referencing its import

Misc. change (would have been an infra branch, but since we usually only have one contributor at a time...):
- Adds VSCode settings for PowerShell, including running (and debugging) tests from code lens
