### PR TITLE
Pull upstream recurse

### DIFF
--- a/docs/pull-upstream.md
+++ b/docs/pull-upstream.md
@@ -4,13 +4,19 @@ Merges all the "upstream" branches into the current branch, or the specified one
 
 Usage:
 
-    git-pull-upstream.ps1 [-target <string>] [-dryRun]
+    git-pull-upstream.ps1 [-target <string>] [-recurse] [-dryRun]
 
 ## Parameters
 
 ### `[-target] <string>` (Optional)
 
 If provided, the script will change branches to the named branch, and pull-upstream for that branch. If it succeeds, `pull-upstream` will return to the original branch. Otherwise, conflicts will be left uncommitted.
+
+### `-recurse` (Optional)
+
+If specified, will first attempt to merge branches further upstream. If any
+merges fail, the propagation will be halted to prevent irrelevant conflicts from
+being reported.
 
 ### `-dryRun` (Optional)
 

--- a/git-pull-upstream.json
+++ b/git-pull-upstream.json
@@ -14,30 +14,19 @@
             }
         },
         {
-            "type": "assert-pushed",
+            "id": "merge-recurse",
+            "type": "recurse",
             "parameters": {
-                "target": "$params.target"
+                "inputParameters": [{
+                    "target": "$params.target",
+                    "recurse": "$params.recurse"
+                }],
+                "path": "git-pull-upstream.recurse.json"
             }
         },
         {
-            "id": "get-upstream",
-            "type": "get-upstream",
-            "parameters": {
-                "target": "$params.target"
-            }
-        },
-        {
-            "id": "merge-branches",
-            "type": "merge-branches",
-            "parameters": {
-                "source": "$($params.target)",
-                "upstreamBranches": ["$actions['get-upstream'].outputs"],
-                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
-            }
-        },
-        { 
             "type": "add-diagnostic",
-            "condition": "$actions['merge-branches'].outputs['hasChanges'] ? $false : $true",
+            "condition": "$actions['merge-recurse'].outputs.hasChanges ? $false : $true",
             "parameters": {
                 "isWarning": true,
                 "message": "No updates found."
@@ -47,18 +36,16 @@
     "finalize": [
         {
             "type": "set-branches",
-            "condition": "$actions['merge-branches'].outputs['hasChanges']",
+            "condition": "$actions['merge-recurse'].outputs.hasChanges",
             "parameters": {
-                "branches": {
-                    "$params.target": "$actions['merge-branches'].outputs['commit']"
-                }
+                "branches": "$actions['merge-recurse'].outputs.push"
             }
         },
         {
             "type": "track",
-            "condition": "$actions['merge-branches'].outputs['hasChanges']",
+            "condition": "$actions['merge-recurse'].outputs.hasChanges",
             "parameters": {
-                "branches": ["$params.target"]
+                "branches": ["$actions['merge-recurse'].outputs.track"]
             }
         }
     ],

--- a/git-pull-upstream.ps1
+++ b/git-pull-upstream.ps1
@@ -2,6 +2,7 @@
 
 Param(
     [Parameter()][String] $target,
+    [switch] $recurse,
     [switch] $dryRun
 )
 
@@ -11,4 +12,5 @@ Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
 
 Invoke-JsonScript -scriptPath "$PSScriptRoot/git-pull-upstream.json" -params @{
     target = ($target ? $target : (Get-CurrentBranch ?? ''))
+    recurse = $recurse
 } -dryRun:$dryRun

--- a/git-pull-upstream.recurse.json
+++ b/git-pull-upstream.recurse.json
@@ -1,9 +1,12 @@
 {
     "recursion": {
         "mode": "depth-first",
-        "paramScript": "$params.recurse ? ($actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_; recurse = $params.recurse } }) : @()",
-        "map": "@{ hasChanges = $actions['merge-branches'].outputs.hasChanges; push = $actions['merge-branches'].outputs.hasChanges ? @{ \"$($params.target)\" = $actions['merge-branches'].outputs['commit'] } : @{}; track = $params.target; failures = @{ \"$($params.target)\" = $actions['merge-branches'].outputs.failed } }",
-        "reduceToOutput": "$mapped | ForEach-Object { $accum = @{ hasChanges = $false; push = @{}; track = @(); failures = @{} } } { $accum.hasChanges = $accum.hasChanges -OR $_.hasChanges; $accum.push = $accum.push + $_.push; $accum.track = $accum.track + $_.track; $accum.failures = $accum.failures + $_.failures } { $accum }",
+        "paramScript": [
+            "if (-not $params.recurse) { return @() }",
+            "($actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_; recurse = $params.recurse } })"
+        ],
+        "init": "$recursionContext.result = @{ hasChanges = $false; push = @{}; override = @{}; track = @(); failures = @{} }",
+        "reduceToOutput": "$recursionContext.result",
         "actCondition": "$null -ne $actions['get-upstream'].outputs"
     },
     "prepare": [
@@ -23,12 +26,51 @@
     ],
     "act": [
         {
-            "id": "merge-branches",
+            "id": "mergeBranches",
             "type": "merge-branches",
             "parameters": {
                 "source": "$params.target",
                 "upstreamBranches": ["$actions['get-upstream'].outputs"],
-                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+                "mergeMessageTemplate": "Merge '{}' to $($params.target)",
+                "commitMappingOverride": "$recursionContext.result.override"
+            }
+        },
+        {
+            "id": "iterationResult",
+            "type": "evaluate",
+            "parameters": {
+                "result": {
+                    "hasChanges": "$actions.mergeBranches.outputs.hasChanges",
+                    "push": {
+                        "$params.target": "$actions.mergeBranches.outputs['commit']"
+                    },
+                    "override": {
+                        "$($config.remote ? ($config.remote + '/') : '')$($params.target)": "$actions.mergeBranches.outputs['commit']"
+                    },
+                    "track": "$params.target",
+                    "failures": {
+                        "$params.target": "$actions.mergeBranches.outputs.failed"
+                    }
+                }
+            }
+        },
+        {
+            "id": "nextFullResult",
+            "type": "evaluate",
+            "parameters": {
+                "result": {
+                    "hasChanges": "$recursionContext.result.hasChanges -OR $actions.iterationResult.outputs.hasChanges",
+                    "push": "$actions.mergeBranches.outputs.hasChanges ? ($recursionContext.result.push + $actions.iterationResult.outputs.push) : $recursionContext.result.push",
+                    "override": "$actions.mergeBranches.outputs.hasChanges ? ($recursionContext.result.override + $actions.iterationResult.outputs.override) : $recursionContext.result.override",
+                    "track": "$recursionContext.result.track + $actions.iterationResult.outputs.track",
+                    "failures": "$recursionContext.result.failures + $actions.iterationResult.outputs.failures"
+                }
+            }
+        },
+        {
+            "type": "evaluate",
+            "parameters": {
+                "result": "$recursionContext.result = $actions.nextFullResult.outputs"
             }
         }
     ]

--- a/git-pull-upstream.recurse.json
+++ b/git-pull-upstream.recurse.json
@@ -1,0 +1,35 @@
+{
+    "recursion": {
+        "mode": "depth-first",
+        "paramScript": "$params.recurse ? ($actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_; recurse = $params.recurse } }) : @()",
+        "map": "@{ hasChanges = $actions['merge-branches'].outputs.hasChanges; push = $actions['merge-branches'].outputs.hasChanges ? @{ \"$($params.target)\" = $actions['merge-branches'].outputs['commit'] } : @{}; track = $params.target; failures = @{ \"$($params.target)\" = $actions['merge-branches'].outputs.failed } }",
+        "reduceToOutput": "$mapped | ForEach-Object { $accum = @{ hasChanges = $false; push = @{}; track = @(); failures = @{} } } { $accum.hasChanges = $accum.hasChanges -OR $_.hasChanges; $accum.push = $accum.push + $_.push; $accum.track = $accum.track + $_.track; $accum.failures = $accum.failures + $_.failures } { $accum }",
+        "actCondition": "$null -ne $actions['get-upstream'].outputs"
+    },
+    "prepare": [
+        {
+            "type": "assert-pushed",
+            "parameters": {
+                "target": "$params.target"
+            }
+        },
+        {
+            "id": "get-upstream",
+            "type": "get-upstream",
+            "parameters": {
+                "target": "$params.target"
+            }
+        }
+    ],
+    "act": [
+        {
+            "id": "merge-branches",
+            "type": "merge-branches",
+            "parameters": {
+                "source": "$params.target",
+                "upstreamBranches": ["$actions['get-upstream'].outputs"],
+                "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+            }
+        }
+    ]
+}

--- a/git-pull-upstream.recurse.json
+++ b/git-pull-upstream.recurse.json
@@ -35,6 +35,13 @@
                 "commitMappingOverride": "$recursionContext.result.override"
             }
         },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions.mergeBranches.outputs.failed -AND $params.depth -ne 0",
+            "parameters": {
+                "message": "$($params.target) has incoming conflicts from $($actions.mergeBranches.outputs.failed). Resolve them before continuing."
+            }
+        },
         {
             "id": "iterationResult",
             "type": "evaluate",

--- a/git-pull-upstream.tests.ps1
+++ b/git-pull-upstream.tests.ps1
@@ -92,6 +92,137 @@ Describe 'git-pull-upstream' {
             Invoke-VerifyMock $mocks -Times 1
         }
 
+        It 'uses the branch specified, recursively, and passes if there are no changes' {
+            $remote = $(Get-Configuration).remote
+            $remotePrefix = $remote ? "$remote/" : ""
+            $initialCommits = @{
+                "$($remotePrefix)main" = "$($remotePrefix)main-commitish"
+                "$($remotePrefix)feature/PS-1" = "$($remotePrefix)feature/PS-1-commitish"
+                "$($remotePrefix)infra/ts-update" = "$($remotePrefix)infra/ts-update-commitish"
+                "$($remotePrefix)infra/build-improvements" = "$($remotePrefix)infra/build-improvements-commitish"
+                "$($remotePrefix)feature/PS-2" = "$($remotePrefix)feature/PS-2-commitish"
+            }
+
+            $mocks = @(
+                Initialize-AssertValidBranchName 'feature/PS-2'
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+                Initialize-UpstreamBranches @{
+                    'feature/PS-2' = @('feature/PS-1','infra/build-improvements')
+                    'feature/PS-1' = @('infra/ts-update')
+                    'infra/build-improvements' = @('infra/ts-update')
+                    'infra/ts-update' = @('main')
+                }
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-1'
+                Initialize-LocalActionAssertPushedSuccess 'infra/build-improvements'
+                Initialize-LocalActionAssertPushedSuccess 'infra/ts-update'
+                Initialize-LocalActionAssertPushedSuccess 'main'
+
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('main') `
+                    -noChangeBranches @('main') `
+                    -resultCommitish $initialCommits["$($remotePrefix)infra/ts-update"] `
+                    -source 'infra/ts-update' `
+                    -initialCommits $initialCommits `
+                    -mergeMessageTemplate "Merge '{}' to infra/ts-update"
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('infra/ts-update') `
+                    -noChangeBranches @('infra/ts-update') `
+                    -resultCommitish $initialCommits["$($remotePrefix)infra/build-improvements"] `
+                    -source 'infra/build-improvements' `
+                    -initialCommits $initialCommits `
+                    -mergeMessageTemplate "Merge '{}' to infra/build-improvements"
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('infra/ts-update') `
+                    -noChangeBranches @('infra/ts-update') `
+                    -resultCommitish $initialCommits["$($remotePrefix)feature/PS-1"] `
+                    -source 'feature/PS-1' `
+                    -initialCommits $initialCommits `
+                    -mergeMessageTemplate "Merge '{}' to feature/PS-1"
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                    -noChangeBranches @('feature/PS-1','infra/build-improvements') `
+                    -resultCommitish $initialCommits["$($remotePrefix)feature/PS-2"] `
+                    -source 'feature/PS-2' `
+                    -initialCommits $initialCommits `
+                    -mergeMessageTemplate "Merge '{}' to feature/PS-2"
+            )
+
+            & $PSScriptRoot/git-pull-upstream.ps1 -target feature/PS-2 -recurse
+            Invoke-VerifyMock $mocks -Times 1
+        }
+
+        It 'uses the branch specified, recursively, and propagates merged changes' {
+            $remote = $(Get-Configuration).remote
+            $remotePrefix = $remote ? "$remote/" : ""
+            $initialCommits = @{
+                "$($remotePrefix)main" = "$($remotePrefix)main-commitish"
+                "$($remotePrefix)feature/PS-1" = "$($remotePrefix)feature/PS-1-commitish"
+                "$($remotePrefix)infra/build-improvements" = "$($remotePrefix)infra/build-improvements-commitish"
+                "$($remotePrefix)feature/PS-2" = "$($remotePrefix)feature/PS-2-commitish"
+            }
+            $updatedCommits = @{
+                "$($remotePrefix)feature/PS-1" = "PS-1-updated"
+                "$($remotePrefix)feature/PS-2" = "PS-2-updated"
+            }
+
+            $mocks = @(
+                Initialize-AssertValidBranchName 'feature/PS-2'
+                Initialize-LocalActionAssertExistence -branches @('feature/PS-2') -shouldExist $true
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-2'
+                Initialize-UpstreamBranches @{
+                    'feature/PS-2' = @('feature/PS-1','infra/build-improvements')
+                    'feature/PS-1' = @('main')
+                    'infra/build-improvements' = @('main')
+                }
+                Initialize-LocalActionAssertPushedSuccess 'feature/PS-1'
+                Initialize-LocalActionAssertPushedSuccess 'infra/build-improvements'
+                Initialize-LocalActionAssertPushedSuccess 'main'
+
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('main') `
+                    -successfulBranches @('main') `
+                    -resultCommitish $updatedCommits["$($remotePrefix)feature/PS-1"] `
+                    -source 'feature/PS-1' `
+                    -initialCommits $initialCommits `
+                    -mergeMessageTemplate "Merge '{}' to feature/PS-1"
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('main') `
+                    -noChangeBranches @('main') `
+                    -resultCommitish $initialCommits["$($remotePrefix)infra/build-improvements"] `
+                    -source 'infra/build-improvements' `
+                    -initialCommits $initialCommits `
+                    -mergeMessageTemplate "Merge '{}' to infra/build-improvements"
+                Initialize-LocalActionMergeBranches `
+                    -upstreamBranches @('feature/PS-1','infra/build-improvements') `
+                    -successfulBranches @('feature/PS-1') `
+                    -noChangeBranches @('infra/build-improvements') `
+                    -resultCommitish $updatedCommits["$($remotePrefix)feature/PS-2"] `
+                    -source 'feature/PS-2' `
+                    -initialCommits  @{
+                        # TODO: feature/PS-1 should not get set up with git rev-parse
+                        "$($remotePrefix)feature/PS-1" = $updatedCommits["$($remotePrefix)feature/PS-1"]
+
+                        "$($remotePrefix)infra/build-improvements" = "$($remotePrefix)infra/build-improvements-commitish"
+                        "$($remotePrefix)feature/PS-2" = "$($remotePrefix)feature/PS-2-commitish"
+                    } `
+                    -skipRevParse @(
+                        # feature/PS-1 was updated in a previous merge; we should automatically use that instead
+                        "$($remotePrefix)feature/PS-1"
+                    ) `
+                    -mergeMessageTemplate "Merge '{}' to feature/PS-2"
+                    
+                Initialize-CurrentBranch 'feature/FOO-456'
+                Initialize-FinalizeActionSetBranches @{
+                    'feature/PS-1' = $updatedCommits["$($remotePrefix)feature/PS-1"]
+                    'feature/PS-2' = $updatedCommits["$($remotePrefix)feature/PS-2"]
+                }
+                Initialize-FinalizeActionTrackSuccess @('feature/PS-1','feature/PS-2')
+            )
+
+            & $PSScriptRoot/git-pull-upstream.ps1 -target feature/PS-2 -recurse
+            Invoke-VerifyMock $mocks -Times 1
+        }
     }
 
     Context 'with a remote' {

--- a/git-pull-upstream.tests.ps1
+++ b/git-pull-upstream.tests.ps1
@@ -200,11 +200,9 @@ Describe 'git-pull-upstream' {
                     -resultCommitish $updatedCommits["$($remotePrefix)feature/PS-2"] `
                     -source 'feature/PS-2' `
                     -initialCommits  @{
-                        # TODO: feature/PS-1 should not get set up with git rev-parse
                         "$($remotePrefix)feature/PS-1" = $updatedCommits["$($remotePrefix)feature/PS-1"]
-
-                        "$($remotePrefix)infra/build-improvements" = "$($remotePrefix)infra/build-improvements-commitish"
-                        "$($remotePrefix)feature/PS-2" = "$($remotePrefix)feature/PS-2-commitish"
+                        "$($remotePrefix)infra/build-improvements" = $initialCommits["$($remotePrefix)infra/build-improvements"]
+                        "$($remotePrefix)feature/PS-2" = $initialCommits["$($remotePrefix)feature/PS-2"]
                     } `
                     -skipRevParse @(
                         # feature/PS-1 was updated in a previous merge; we should automatically use that instead
@@ -217,7 +215,7 @@ Describe 'git-pull-upstream' {
                     'feature/PS-1' = $updatedCommits["$($remotePrefix)feature/PS-1"]
                     'feature/PS-2' = $updatedCommits["$($remotePrefix)feature/PS-2"]
                 }
-                Initialize-FinalizeActionTrackSuccess @('feature/PS-1','feature/PS-2')
+                Initialize-FinalizeActionTrackSuccess @('infra/build-improvements', 'feature/PS-1','feature/PS-2')
             )
 
             & $PSScriptRoot/git-pull-upstream.ps1 -target feature/PS-2 -recurse

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -1,6 +1,7 @@
 Import-Module -Scope Local "$PSScriptRoot/Invoke-LocalAction.internal.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAddDiagnostic.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertPushed.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionEvaluate.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionGetUpstream.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionFilterBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionMergeBranches.psm1"
@@ -14,6 +15,7 @@ Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertExiste
 $localActions = Get-LocalActionsRegistry
 Register-LocalActionAddDiagnostic $localActions
 Register-LocalActionAssertPushed $localActions
+Register-LocalActionEvaluate $localActions
 Register-LocalActionGetUpstream $localActions
 Register-LocalActionFilterBranches $localActions
 Register-LocalActionMergeBranches $localActions

--- a/utils/actions/local/Register-LocalActionEvaluate.psm1
+++ b/utils/actions/local/Register-LocalActionEvaluate.psm1
@@ -1,0 +1,16 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+
+function Register-LocalActionEvaluate([PSObject] $localActions) {
+    $localActions['evaluate'] = {
+        param(
+            [Parameter(Mandatory)][object] $result,
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+        
+        return $result
+    }
+}
+
+Export-ModuleMember -Function Register-LocalActionEvaluate

--- a/utils/actions/local/Register-LocalActionEvaluate.tests.ps1
+++ b/utils/actions/local/Register-LocalActionEvaluate.tests.ps1
@@ -1,0 +1,57 @@
+Describe 'local action "evaluate"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../actions.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+    }
+
+    It 'can evaluate standard strings' {
+        $result = Invoke-LocalAction ('{ 
+            "type": "evaluate", 
+            "parameters": {
+                "result": "Standard string"
+            }
+        }' | ConvertFrom-Json) -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        $result | Should -Be "Standard string"
+    }
+
+    It 'can evaluate complex objects' {
+        $result = Invoke-LocalAction ('{ 
+            "type": "evaluate", 
+            "parameters": {
+                "result": {
+                    "one": 1,
+                    "two": 2,
+                }
+            }
+        }' | ConvertFrom-Json) -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        (ConvertTo-Json $result) | Should -Be (ConvertTo-Json @{ one=1; two=2 })
+    }
+
+    It 'can return arrays' {
+        $result = Invoke-LocalAction ('{ 
+            "type": "evaluate", 
+            "parameters": {
+                "result": [1,2,3]
+            }
+        }' | ConvertFrom-Json) -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        $result | Should -Be @(1, 2, 3)
+    }
+}

--- a/utils/actions/local/Register-LocalActionEvaluate.tests.ps1
+++ b/utils/actions/local/Register-LocalActionEvaluate.tests.ps1
@@ -39,7 +39,8 @@ Describe 'local action "evaluate"' {
 
         Invoke-FlushAssertDiagnostic $fw.diagnostics
         $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
-        (ConvertTo-Json $result) | Should -Be (ConvertTo-Json @{ one=1; two=2 })
+        $result.one | Should -Be 1
+        $result.two | Should -Be 2
     }
 
     It 'can return arrays' {

--- a/utils/actions/local/Register-LocalActionMergeBranches.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.mocks.psm1
@@ -9,6 +9,7 @@ function Initialize-LocalActionMergeBranches(
     [AllowEmptyCollection()][string[]] $successfulBranches,
     [AllowEmptyCollection()][string[]] $noChangeBranches,
     [Parameter()][Hashtable] $initialCommits = @{},
+    [Parameter()][string[]] $skipRevParse = @(),
     [Parameter()][string] $resultCommitish,
     [Parameter()][string] $mergeMessageTemplate = "Merge {}",
     [Parameter()][string] $source,
@@ -31,6 +32,7 @@ function Initialize-LocalActionMergeBranches(
 
     Initialize-MergeTogether -allBranches $upstreamBranches -successfulBranches $successfulBranches -noChangeBranches $noChangeBranches `
         -initialCommits $initialCommits `
+        -skipRevParse $skipRevParse `
         -source $source `
         -messageTemplate $mergeMessageTemplate `
         -resultCommitish $resultCommitish

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -9,6 +9,8 @@ function Register-LocalActionMergeBranches([PSObject] $localActions) {
             [string] $source,
             [string[]] $upstreamBranches,
             [string] $mergeMessageTemplate = "Merge {}",
+            [hashtable] $commitMappingOverride = @{},
+
             [Parameter()][bool] $errorOnFailure = $false,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
@@ -31,7 +33,13 @@ function Register-LocalActionMergeBranches([PSObject] $localActions) {
             }
         }
 
-        $mergeResult = Invoke-MergeTogether -source $source -commitishes $upstreamBranches -messageTemplate $mergeMessageTemplate -diagnostics $diagnostics -asWarnings:$(-not $errorOnFailure)
+        $mergeResult = Invoke-MergeTogether `
+            -source $source `
+            -commitishes $upstreamBranches `
+            -messageTemplate $mergeMessageTemplate `
+            -commitMappingOverride $commitMappingOverride `
+            -diagnostics $diagnostics `
+            -asWarnings:$(-not $errorOnFailure)
         $commit = $mergeResult.result
         if ($null -eq $commit) {
             if ($source -notin $mergeResult.failed) {

--- a/utils/actions/local/Register-LocalActionRecurse.md
+++ b/utils/actions/local/Register-LocalActionRecurse.md
@@ -47,6 +47,18 @@ The contents of the recursion script should be something like the following:
 If `depth-first`, recursion will be done via a depth-first strategy. Otherwise,
 recursion will be breadth-first.
 
+### `recursion.init`
+
+A powershell script that:
+- runs before any other scripts
+- receives the following variables:
+    - `$recursionContext` is an object scoped to the recursion script that will
+      remain persistent for the action's duration; additional properties may be
+      added.
+- the return value is unused
+
+The script may be an array, where each string is a separate line.
+
 ### `recursion.paramScript`
 
 A powershell script that:
@@ -54,7 +66,12 @@ A powershell script that:
 - receives the following variables:
     - `$params` contains the current input object of the recursive algorithm.
     - `$actions` is the result of the `prepare` actions
+    - `$recursionContext` is an object scoped to the recursion script that will
+      remain persistent for the action's duration; additional properties may be
+      added.
 - should return an array of new inputs for the recursive algorithm
+
+The script may be an array, where each string is a separate line.
 
 ### `recursion.map`
 
@@ -63,7 +80,12 @@ A powershell script that:
 - receives the following variables:
     - `$params` contains the current input object of the recursive algorithm.
     - `$actions` is the result of the `prepare` actions
+    - `$recursionContext` is an object scoped to the recursion script that will
+      remain persistent for the action's duration; additional properties may be
+      added.
 - should return a value to be reduced in the `recursion.reduceToOutput` script
+
+The script may be an array, where each string is a separate line.
 
 ### `recursion.reduceToOutput`
 
@@ -72,8 +94,13 @@ A powershell script that:
 - receives the following variables:
     - `$mapped` is an array containing the results of each previous
       `recursion.map` script
+    - `$recursionContext` is an object scoped to the recursion script that will
+      remain persistent for the action's duration; additional properties may be
+      added.
 - returns the value to be bound to the output of the `recurse` action that
   invoked the script
+
+The script may be an array, where each string is a separate line.
 
 ### `recursion.actCondition`
 
@@ -82,8 +109,13 @@ An optional powershell script that:
 - receives the following variables:
     - `$params` contains the current input object of the recursive algorithm.
     - `$actions` is the result of the `prepare` actions
+    - `$recursionContext` is an object scoped to the recursion script that will
+      remain persistent for the action's duration; additional properties may be
+      added.
 - returns a falsy value if the `act` actions should not be run for this
   recursive input
+
+The script may be an array, where each string is a separate line.
 
 ### `prepare`
 

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -4,12 +4,12 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../scripting/ConvertFrom-ParameterizedAnything.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.internal.psm1"
 
-function New-SafeScript([string] $header, [string] $script) {
+function New-SafeScript([string] $header, [string[]] $script) {
     return [ScriptBlock]::Create("
         $header
         Set-StrictMode -Version 3.0; 
         try {
-            $script
+            $($script -join "`n")
         } catch {
         }
     ")
@@ -29,6 +29,7 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
             config = $config
             diagnostics = $diagnostics
         }
+        $recursionContext = @{}
 
         $instructions = Get-Content "$PSScriptRoot/../../../$path" | ConvertFrom-Json
         $depthFirst = $instructions.recursion.mode -eq 'depth-first'
@@ -41,14 +42,18 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
         [System.Collections.ArrayList]$inputStack = @() + $inputParameters
         [System.Collections.ArrayList]$pendingAct = @()
 
-        $paramScript = New-SafeScript -header 'param($actions, $params, $previous)' `
+        $init = New-SafeScript -header 'param($recursionContext)' `
+            -script ($instructions.recursion.init ?? '$null')
+        $paramScript = New-SafeScript -header 'param($actions, $params, $previous, $recursionContext)' `
             -script $instructions.recursion.paramScript 
-        $canActScript = New-SafeScript -header 'param($actions, $params)' `
+        $canActScript = New-SafeScript -header 'param($actions, $params, $recursionContext)' `
             -script ($instructions.recursion.actCondition ?? '$true')
-        $mapScript = New-SafeScript -header 'param($actions, $params)' `
-            -script $instructions.recursion.map
-        $reduceToOutput = New-SafeScript -header 'param($mapped)' `
-            -script $instructions.recursion.reduceToOutput
+        $mapScript = New-SafeScript -header 'param($actions, $params, $recursionContext)' `
+            -script ($instructions.recursion.map ?? '$null')
+        $reduceToOutput = New-SafeScript -header 'param($mapped, $recursionContext)' `
+            -script ($instructions.recursion.reduceToOutput ?? '$null')
+
+        (& $init -recursionContext $recursionContext) > $null
 
         while ($inputStack.Count -gt 0) {
             $params = $inputStack[0];
@@ -57,13 +62,14 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
             $inputs = @{
                 params = $params;
                 actions = $actions;
+                recursionContext = $recursionContext;
             }
             $inputs.actions = Invoke-Prepare -prepareScripts $instructions.prepare @inputs @commonParams
-            [array]$newParams = (& $paramScript -actions $inputs.actions -params $inputs.params -previous $allInputs)
+            [array]$newParams = (& $paramScript -actions $inputs.actions -params $inputs.params -previous $allInputs -recursionContext $recursionContext)
             if ($addDepthParam -AND $null -ne $newParams) {
                 [array]$newParams = $newParams | ForEach-Object { (ConvertTo-Hashtable $_) + @{ depth = $params.depth + 1 } }
             }
-            $canAct = (& $canActScript -actions $inputs.actions -params $inputs.params)
+            $canAct = (& $canActScript -actions $inputs.actions -params $inputs.params -recursionContext $recursionContext)
             if ($depthFirst) {
                 if ($canAct) {
                     $pendingAct.Insert(0, $inputs)
@@ -95,14 +101,14 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
             $inputs = $pendingAct[0]
             $pendingAct.RemoveAt(0);
             $inputs.actions = Invoke-Act -actScripts $instructions.act @inputs @commonParams
-            $mapResult = & $mapScript -actions $inputs.actions -params $inputs.params
+            $mapResult = & $mapScript -actions $inputs.actions -params $inputs.params -recursionContext $recursionContext
             $mapped.Add($mapResult) > $null
             if (Get-HasErrorDiagnostic $diagnostics) {
                 return $null
             }
         }
 
-        return & $reduceToOutput -mapped $mapped
+        return & $reduceToOutput -mapped $mapped -recursionContext $recursionContext
     }
 }
 
@@ -111,13 +117,14 @@ function Invoke-Prepare(
     $prepareScripts,
     $params,
     $actions,
+    $recursionContext,
 
     [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
 ) {
     
     for ($i = 0; $i -lt $prepareScripts.Count; $i++) {
         $name = $prepareScripts[$i].id ?? "#$($i + 1) (1-based)";
-        $variables = @{ config=$config; params=$params; actions=$actions }
+        $variables = @{ config=$config; params=$params; actions=$actions; recursionContext=$recursionContext }
         $local = ConvertFrom-ParameterizedAnything -script $prepareScripts[$i] -variables $variables -diagnostics $diagnostics
         if ($local.fail) {
             Add-ErrorDiagnostic $diagnostics "Could not apply parameters to recursive prepare (local) action $name; see above errors. Evaluation below:"
@@ -147,13 +154,14 @@ function Invoke-Act(
     $actScripts,
     $params,
     $actions,
+    $recursionContext,
 
     [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
 ) {
     
     for ($i = 0; $i -lt $actScripts.Count; $i++) {
         $name = $actScripts[$i].id ?? "#$($i + 1) (1-based)";
-        $variables = @{ config=$config; params=$params; actions=$actions }
+        $variables = @{ config=$config; params=$params; actions=$actions; recursionContext=$recursionContext }
         $local = ConvertFrom-ParameterizedAnything -script $actScripts[$i] -variables $variables -diagnostics $diagnostics
         if ($local.fail) {
             Add-ErrorDiagnostic $diagnostics "Could not apply parameters to recursive act (local) action $name; see above errors. Evaluation below:"

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -117,7 +117,8 @@ function Invoke-Prepare(
     
     for ($i = 0; $i -lt $prepareScripts.Count; $i++) {
         $name = $prepareScripts[$i].id ?? "#$($i + 1) (1-based)";
-        $local = ConvertFrom-ParameterizedAnything -script $prepareScripts[$i] -config $config -params $params -actions $actions -diagnostics $diagnostics
+        $variables = @{ config=$config; params=$params; actions=$actions }
+        $local = ConvertFrom-ParameterizedAnything -script $prepareScripts[$i] -variables $variables -diagnostics $diagnostics
         if ($local.fail) {
             Add-ErrorDiagnostic $diagnostics "Could not apply parameters to recursive prepare (local) action $name; see above errors. Evaluation below:"
             Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
@@ -152,7 +153,8 @@ function Invoke-Act(
     
     for ($i = 0; $i -lt $actScripts.Count; $i++) {
         $name = $actScripts[$i].id ?? "#$($i + 1) (1-based)";
-        $local = ConvertFrom-ParameterizedAnything -script $actScripts[$i] -config $config -params $params -actions $actions -diagnostics $diagnostics
+        $variables = @{ config=$config; params=$params; actions=$actions }
+        $local = ConvertFrom-ParameterizedAnything -script $actScripts[$i] -variables $variables -diagnostics $diagnostics
         if ($local.fail) {
             Add-ErrorDiagnostic $diagnostics "Could not apply parameters to recursive act (local) action $name; see above errors. Evaluation below:"
             Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -42,6 +42,10 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
         [System.Collections.ArrayList]$inputStack = @() + $inputParameters
         [System.Collections.ArrayList]$pendingAct = @()
 
+        if ($depthFirst) {
+            $inputStack.Reverse()
+        }
+
         $init = New-SafeScript -header 'param($recursionContext)' `
             -script ($instructions.recursion.init ?? '$null')
         $paramScript = New-SafeScript -header 'param($actions, $params, $previous, $recursionContext)' `
@@ -75,6 +79,8 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
                     $pendingAct.Insert(0, $inputs)
                 }
                 if ($null -ne $newParams) {
+                    [array]$newParams = @() + [array]$newParams
+                    [array]::Reverse($newParams)
                     $inputStack.InsertRange(0, $newParams)
                 }
             } else {
@@ -94,9 +100,6 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
         }
 
         [System.Collections.ArrayList]$mapped = @()
-        if ($depthFirst) {
-            $pendingAct.Reverse()
-        }
         while ($pendingAct.Count -gt 0) {
             $inputs = $pendingAct[0]
             $pendingAct.RemoveAt(0);

--- a/utils/actions/local/Register-LocalActionRecurse.tests.ps1
+++ b/utils/actions/local/Register-LocalActionRecurse.tests.ps1
@@ -78,12 +78,12 @@ Describe 'local action "recurse"' {
             } 
             Initialize-FakeLocalAction "handle-target" {
                 param($target)
-                if ($target -eq '10') { return '1' }
-                if ($target -eq '11') { return '2' }
-                if ($target -eq '12') { return '3' }
-                if ($target -eq '20') { return '4' }
-                if ($target -eq '21') { return '5' }
-                if ($target -eq '22') { return '6' }
+                if ($target -eq '11') { return '1' }
+                if ($target -eq '12') { return '2' }
+                if ($target -eq '10') { return '3' }
+                if ($target -eq '21') { return '4' }
+                if ($target -eq '22') { return '5' }
+                if ($target -eq '20') { return '6' }
             }
 
             $output = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics

--- a/utils/actions/local/Register-LocalActionRecurse.tests.ps1
+++ b/utils/actions/local/Register-LocalActionRecurse.tests.ps1
@@ -31,7 +31,11 @@ Describe 'local action "recurse"' {
             return '{
                 "recursion": {
                     "mode": "' + $mode + '",
-                    "paramScript": "$actions.children.outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_ } }",
+                    "paramScript": [
+                        "$actions.children.outputs | ",
+                        "    Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } |",
+                        "    ForEach-Object { @{ target = $_ } }"
+                    ],
                     "map": "$actions.handled.outputs",
                     "reduceToOutput": "$mapped -join \" \""
                 },
@@ -119,5 +123,59 @@ Describe 'local action "recurse"' {
             Invoke-FlushAssertDiagnostic $fw.diagnostics
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
         }
+    }
+
+    It 'has a recursion context for a scratch pad' {
+        Initialize-LocalActionRecurseSuccess -ScriptName "mock-script" -ScriptContents '{
+            "recursion": {
+                "mode": "depth-first",
+                "paramScript": [
+                    "$actions.children.outputs | ",
+                    "    Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } |",
+                    "    ForEach-Object { @{ target = $_ } }"
+                ],
+                "init": "$recursionContext.current = 0",
+                "reduceToOutput": "$recursionContext.current"
+            },
+            "prepare": [{
+                "id": "children",
+                "type": "get-children",
+                "parameters": {
+                    "target": "$params.target"
+                }
+            }],
+            "act": [{
+                "id": "handled",
+                "type": "handle-target",
+                "parameters": {
+                    "target": "$params.target"
+                }
+            }, {
+                "type": "evaluate",
+                "parameters": {
+                    "result": "$recursionContext.current = $recursionContext.current + $actions.handled.outputs"
+                }
+            }]
+        }'
+        Initialize-FakeLocalAction "get-children" {
+            param($target)
+            if ($target -eq '10') { return @('11', '12') }
+            if ($target -eq '20') { return @('21', '22') }
+        } 
+        Initialize-FakeLocalAction "handle-target" {
+            param($target)
+            if ($target -eq '10') { return '1' }
+            if ($target -eq '11') { return '2' }
+            if ($target -eq '12') { return '3' }
+            if ($target -eq '20') { return '4' }
+            if ($target -eq '21') { return '5' }
+            if ($target -eq '22') { return '6' }
+        }
+
+        $output = Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        $output | Should -Be 21
     }
 }

--- a/utils/git/Invoke-MergeTogether.psm1
+++ b/utils/git/Invoke-MergeTogether.psm1
@@ -6,8 +6,19 @@ function Invoke-MergeTogether(
     [Parameter()][AllowNull()][string] $source = $null,
     [Parameter()][string] $messageTemplate = "Merge {}",
     [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
+    [Parameter()][hashtable] $commitMappingOverride = @{},
     [switch] $asWarnings
 ) {
+    function ResolveCommit($commitish) {
+        if ($commitMappingOverride[$commitish]) {
+            return $commitMappingOverride[$commitish]
+        }
+        $result = Invoke-ProcessLogs "git rev-parse --verify $target" {
+            git rev-parse --verify $target
+        } -allowSuccessOutput
+        if ($global:LASTEXITCODE -ne 0) { return $null }
+        return $result
+    }
 
     [String[]]$remaining = $commitishes
     [String[]]$failed = @()
@@ -18,10 +29,8 @@ function Invoke-MergeTogether(
     if ($null -ne $source -AND '' -ne $source) {
         $target = $source
 
-        $currentCommit = Invoke-ProcessLogs "git rev-parse --verify $target" {
-            git rev-parse --verify $target
-        } -allowSuccessOutput
-        if ($global:LASTEXITCODE -ne 0) {
+        $currentCommit = ResolveCommit $target
+        if ($null -eq $currentCommit) {
             $remaining = $remaining | Where-Object { $_ -ne $target }
             $failed += $target
             Add-ErrorDiagnostic $diagnostics "Could not resolve '$($target)' for source of merge"
@@ -39,10 +48,8 @@ function Invoke-MergeTogether(
     while ($remaining.Count -gt 0) {
         $target = $remaining[0]
         if ($null -eq $currentCommit) {
-            $parsedCommitish = Invoke-ProcessLogs "git rev-parse --verify $target" {
-                git rev-parse --verify $target
-            } -allowSuccessOutput
-            if ($global:LASTEXITCODE -eq 0) {
+            $parsedCommitish = ResolveCommit $target
+            if ($null -ne $parsedCommitish) {
                 $currentCommit = $parsedCommitish
                 $remaining = $remaining | Where-Object { $_ -ne $target }
                 $parentCommits += $currentCommit
@@ -60,10 +67,8 @@ function Invoke-MergeTogether(
             $allFailed = $true
             for ($i = 0; $i -lt $remaining.Count; $i++) {
                 $target = $remaining[$i]
-                $targetCommit = Invoke-ProcessLogs "git rev-parse --verify $target" {
-                    git rev-parse --verify $target
-                } -allowSuccessOutput
-                if ($global:LASTEXITCODE -ne 0) {
+                $targetCommit = ResolveCommit $target
+                if ($null -eq $targetCommit) {
                     # If we can't resolve the commit, it'll never resolve
                     $remaining = $remaining | Where-Object { $_ -ne $target }
                     $failed += $target

--- a/utils/git/Invoke-MergeTogether.tests.ps1
+++ b/utils/git/Invoke-MergeTogether.tests.ps1
@@ -174,6 +174,33 @@ Describe 'Invoke-MergeTogether' {
         Invoke-VerifyMock $mocks -Times 1
     }
     
+    It 'can allow for overrides on commit resolution' {
+        $mocks = Initialize-MergeTogether @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `
+            -successfulBranches @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `
+            -initialCommits @{
+                'feature/FOO-1' = '1'
+                'feature/FOO-2' = '2'
+                'feature/FOO-3' = '3'
+            } `
+            -skipRevParse @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `
+            -resultCommitish 'result-commitish'
+
+        $result = Invoke-MergeTogether @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3') `
+            -commitMappingOverride @{
+                'feature/FOO-1' = '1'
+                'feature/FOO-2' = '2'
+                'feature/FOO-3' = '3'
+            } `
+            -diagnostics $fw.diagnostics
+
+        $result.result | Should -Be 'result-commitish'
+        $result.failed | Should -Be @()
+        $result.successful | Should -Be @('feature/FOO-1', 'feature/FOO-2', 'feature/FOO-3')
+        $result.hasChanges | Should -Be $true
+        $fw.diagnostics | Should -BeNullOrEmpty
+        Invoke-VerifyMock $mocks -Times 1
+    }
+    
     It 'succeeds with no changes if only one branch is provided' {
         $mocks = Initialize-MergeTogether @('feature/FOO-1') -successfulBranches @('feature/FOO-1') -resultCommitish 'result-commitish'
 

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
@@ -1,4 +1,5 @@
 Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/New-Closure.psm1"
 Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedString.psm1"
 Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedArray.psm1"
 Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedObject.psm1"
@@ -22,14 +23,14 @@ function ConvertFrom-ParameterizedAnything(
         return @{ result = $script; fail = $false }
     } elseif ($script -is [string] -AND $script[0] -eq '$' -AND $script[1] -ne '(') {
         try {
-            $targetScript = [ScriptBlock]::Create('
+            $targetScript = New-Closure ([ScriptBlock]::Create('
                 Set-StrictMode -Version 3.0; 
                 try {
                     @{ result = ' + $script.replace('`', '``').replace('{', '`{').replace('}', '`}').replace(';', '`;') + '; fail = $false }
                 } catch {
                     $null
                 }
-            ')
+            ')) -variables @{ config = $config; params = $params; actions = $actions }
             $entry = Invoke-Command -ScriptBlock $targetScript
         } catch {
             $entry = $null

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
@@ -11,9 +11,7 @@ Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedObject.psm1"
 #>
 function ConvertFrom-ParameterizedAnything(
     [Parameter(Mandatory)][AllowNull()][PSCustomObject] $script,
-    [Parameter(Mandatory)][PSObject] $config,
-    [Parameter(Mandatory)][PSObject] $params,
-    [Parameter(Mandatory)][PSObject] $actions,
+    [Parameter(Mandatory)][PSObject] $variables,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [switch] $failOnError
 ) {
@@ -30,7 +28,7 @@ function ConvertFrom-ParameterizedAnything(
                 } catch {
                     $null
                 }
-            ')) -variables @{ config = $config; params = $params; actions = $actions }
+            ')) -variables $variables
             $entry = Invoke-Command -ScriptBlock $targetScript
         } catch {
             $entry = $null

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.tests.ps1
@@ -11,7 +11,8 @@ Describe 'ConvertFrom-ParameterizedAnything' {
     It 'can evaluate parameters in objects nested in arrays' {
         $target = @('foo', @{ '$($params.foo)' = '$($params.baz)' })
         $params = @{ foo = 'bar'; baz = 'woot' }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result.Count | Should -Be 2
         $result.result[0] | Should -Be 'foo'
         $result.result[1] | Assert-ShouldBeObject @{ 'bar'= 'woot' }
@@ -20,7 +21,8 @@ Describe 'ConvertFrom-ParameterizedAnything' {
     It 'can evaluate parameters in objects nested in arrays without extra syntax' {
         $target = @('foo', @{ '$params.foo' = '$params.baz' })
         $params = @{ foo = 'bar'; baz = 'woot' }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result.Count | Should -Be 2
         $result.result[0] | Should -Be 'foo'
         $result.result[1] | Assert-ShouldBeObject @{ 'bar'= 'woot' }
@@ -29,35 +31,40 @@ Describe 'ConvertFrom-ParameterizedAnything' {
     It 'can evaluate parameters in arrays nested in objects' {
         $target = @{ 'foo' = @('$($params.foo -join ",")', '$($params.banter)'); 'baz' = '$($params.banter)' }
         $params = @{ foo = @('bar', 'baz'); banter = @('woot') }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }
     }
     
     It 'can evaluate parameters in arrays nested in objects without extra syntax' {
         $target = @{ 'foo' = @('$params.foo', '$params.banter'); 'baz' = '$params.banter' }
         $params = @{ foo = @('bar', 'baz'); banter = @('woot') }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }
     }
     
     It 'can evaluate parameters in single-element-arrays nested in objects without extra syntax' {
         $target = @{ 'foo' = @('$params.foo'); 'baz' = '$params.banter' }
         $params = @{ foo = @('bar'); banter = @('woot') }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar'); 'baz' = 'woot' }
     }
     
     It 'can evaluate parameters in empty arrays nested in objects without extra syntax' {
         $target = @{ 'foo' = @('$params.foo'); 'baz' = '$params.banter' }
         $params = @{ foo = @(); banter = @('woot') }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result | Assert-ShouldBeObject @{ 'foo' = @(); 'baz' = 'woot' }
     }
     
     It 'can evaluate single-element arrays as arrays' {
         $target = @('$params.foo')
         $params = @{ foo = @('bar'); banter = @('woot') }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result.Count | Should -Be 1
         Should -ActualValue $result.result -Be @('bar')
     }
@@ -66,7 +73,8 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $target = '$($params.foo) and $($params.baz)'
         $target = $target | ConvertTo-Json | ConvertFrom-Json
         $params = @{ foo = 'bar'; baz = 'woot' }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result | Should -Be 'bar and woot'
     }
     
@@ -74,14 +82,16 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $target = '$params.foo and $params.baz'
         $target = $target | ConvertTo-Json | ConvertFrom-Json
         $params = @{ foo = 'bar'; baz = 'woot' }
-        { ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError } | Should -Throw
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        { ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError } | Should -Throw
     }
     
     It 'can evaluate basic strings' {
         $target = '$params.foo'
         $target = $target | ConvertTo-Json | ConvertFrom-Json
         $params = @{ foo = 'bar'; baz = 'woot' }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result | Should -Be 'bar'
     }
     
@@ -89,7 +99,8 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $target = @('foo', @{ '$($params.foo)' = '$($params.baz)' })
         $target = $target | ConvertTo-Json | ConvertFrom-Json
         $params = @{ foo = 'bar'; baz = 'woot' }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result.Count | Should -Be 2
         $result.result[0] | Should -Be 'foo'
         $result.result[1] | Assert-ShouldBeObject @{ 'bar'= 'woot' }
@@ -99,7 +110,8 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $target = @{ 'foo' = @('$($params.foo -join ",")', '$($params.banter)'); 'baz' = '$($params.banter)' }
         $target = $target | ConvertTo-Json | ConvertFrom-Json
         $params = @{ foo = @('bar', 'baz'); banter = @('woot') }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result | Assert-ShouldBeObject @{ 'foo' = @('bar', 'baz', 'woot'); 'baz' = 'woot' }
     }
     
@@ -107,7 +119,8 @@ Describe 'ConvertFrom-ParameterizedAnything' {
         $target = @{ 'foo' = $true; 'bar' = $false }
         $target = $target | ConvertTo-Json | ConvertFrom-Json
         $params = @{ }
-        $result = ConvertFrom-ParameterizedAnything $target -config @{} -params $params -actions @{} -failOnError
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedAnything $target -variables $variables -failOnError
         $result.result | Assert-ShouldBeObject @{ 'foo' = $true; 'bar' = $false }
     }
     

--- a/utils/scripting/ConvertFrom-ParameterizedArray.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedArray.psm1
@@ -3,9 +3,7 @@ Import-Module -Scope Local "$PSScriptRoot/../input.psm1"
 
 function ConvertFrom-ParameterizedArray(
     [Parameter(Mandatory)][object[]] $script,
-    [Parameter(Mandatory)][PSObject] $config,
-    [Parameter(Mandatory)][PSObject] $params,
-    [Parameter(Mandatory)][PSObject] $actions, 
+    [Parameter(Mandatory)][PSObject] $variables,
     [Parameter(Mandatory)][scriptblock] $convertFromParameterized,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [switch] $failOnError
@@ -16,7 +14,7 @@ function ConvertFrom-ParameterizedArray(
         if ($null -eq $_) {
             $converted.Add($null) *> $null
         } else {
-            $entry = & $convertFromParameterized -script $_ -config $config -params $params -actions $actions -diagnostics $diagnostics -failOnError:$failOnError
+            $entry = & $convertFromParameterized -script $_ -variables $variables -diagnostics $diagnostics -failOnError:$failOnError
             $fail = $fail -or $entry.fail
             if ($entry.result -is [array]) {
                 foreach ($item in $entry.result) {

--- a/utils/scripting/ConvertFrom-ParameterizedArray.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedArray.tests.ps1
@@ -13,27 +13,31 @@ Describe 'ConvertFrom-ParameterizedArray' {
 
     It 'can evaluate single parameters' {
         $params = @{ foo = 'bar' }
-        $result = ConvertFrom-ParameterizedArray @('foo', '$($params.foo)', 'baz') -config @{} -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedArray @('foo', '$($params.foo)', 'baz') -variables $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Should -Be @('foo', 'bar', 'baz')
         $result.fail | Should -Be $false
     }
 
     It 'can evaluate array parameters' {
         $params = @{ foo = @('bar', 'baz') }
-        $result = ConvertFrom-ParameterizedArray @('foo', '$($params.foo -join ",")') -config @{} -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedArray @('foo', '$($params.foo -join ",")') -variables $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Should -Be @('foo', 'bar', 'baz')
         $result.fail | Should -Be $false
     }
 
     It 'reports errors' {
         $params = @{ foo = @('bar', 'baz') }
-        $result = ConvertFrom-ParameterizedArray @('foo', '$($config.upstreamBranch)') -config @{} -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedArray @('foo', '$($config.upstreamBranch)') -variables $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true
     }
 
     It 'reports warnings if diagnostics are provided' {
         $params = @{ foo = @('bar', 'baz') }
-        $result = ConvertFrom-ParameterizedArray @('foo', '$($config.upstreamBranch)') -config @{} -params $params -actions @{} -diagnostics $diag -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedArray @('foo', '$($config.upstreamBranch)') -variables $variables -diagnostics $diag -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true
 
         $output = Register-Diagnostics -throwInsteadOfExit
@@ -43,7 +47,8 @@ Describe 'ConvertFrom-ParameterizedArray' {
 
     It 'reports errors if diagnostics are provided and flagged to fail on error' {
         $params = @{ foo = @('bar', 'baz') }
-        $result = ConvertFrom-ParameterizedArray @('foo', '$($config.upstreamBranch)') -config @{} -params $params -actions @{} -diagnostics $diag -failOnError -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedArray @('foo', '$($config.upstreamBranch)') -variables $variables -diagnostics $diag -failOnError -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true
 
         $output = Register-Diagnostics -throwInsteadOfExit

--- a/utils/scripting/ConvertFrom-ParameterizedObject.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedObject.psm1
@@ -5,9 +5,7 @@ Import-Module -Scope Local "$PSScriptRoot/ConvertFrom-ParameterizedString.psm1"
 
 function ConvertFrom-ParameterizedObject(
     [Parameter(Mandatory)][PSObject] $script,
-    [Parameter(Mandatory)][PSObject] $config,
-    [Parameter(Mandatory)][PSObject] $params,
-    [Parameter(Mandatory)][PSObject] $actions,
+    [Parameter(Mandatory)][PSObject] $variables,
     [Parameter(Mandatory)][scriptblock] $convertFromParameterized,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [switch] $failOnError
@@ -18,7 +16,7 @@ function ConvertFrom-ParameterizedObject(
 
     $converted = @{}
     foreach ($_ in $ht.Keys) {
-        $entry = & $convertFromParameterized -script $_ -config $config -params $params -actions $actions -diagnostics $diagnostics -failOnError:$failOnError
+        $entry = & $convertFromParameterized -script $_ -variables $variables -diagnostics $diagnostics -failOnError:$failOnError
         if ($entry.result -isnot [string]) {
             $fail = $true
             continue
@@ -26,7 +24,7 @@ function ConvertFrom-ParameterizedObject(
         $fail = $fail -or $entry.fail
 
         $target = $ht[$_]
-        $entryValue = & $convertFromParameterized -script $target -config $config -params $params -actions $actions -diagnostics $diagnostics -failOnError:$failOnError
+        $entryValue = & $convertFromParameterized -script $target -variables $variables -diagnostics $diagnostics -failOnError:$failOnError
         $fail = $fail -or $entryValue.fail
         
         $converted += @{ $entry.result = $entryValue.result }

--- a/utils/scripting/ConvertFrom-ParameterizedObject.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedObject.tests.ps1
@@ -15,7 +15,8 @@ Describe 'ConvertFrom-ParameterizedObject' {
     It 'ignores non-parameterized objects' {
         $target = @{ 'foo' = 'bar'; 'baz' = 'woot' }
         $params = @{ foo = 'bar' }
-        $result = ConvertFrom-ParameterizedObject $target -config @{} -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedObject $target $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Assert-ShouldBeObject @{ 'foo' = 'bar'; 'baz' = 'woot' }
         $result.fail | Should -Be $false
     }
@@ -23,7 +24,8 @@ Describe 'ConvertFrom-ParameterizedObject' {
     It 'can evaluate value parameters' {
         $params = @{ foo = @('bar', 'baz') }
         $target = @{ 'foo' = '$($params.foo)'; 'baz' = 'woot' }
-        $result = ConvertFrom-ParameterizedObject $target -config @{} -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedObject $target $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Assert-ShouldBeObject @{ 'foo' = 'bar baz'; 'baz' = 'woot' }
         $result.fail | Should -Be $false
     }
@@ -31,7 +33,8 @@ Describe 'ConvertFrom-ParameterizedObject' {
     It 'can evaluate key parameters' {
         $target = @{ 'foo' = 'bar baz'; '$($params.banter)' = 'woot' }
         $params = @{ banter = 'baz' }
-        $result = ConvertFrom-ParameterizedObject $target -config @{} -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedObject $target $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Assert-ShouldBeObject @{ 'foo' = 'bar baz'; 'baz' = 'woot' }
         $result.fail | Should -Be $false
     }
@@ -39,7 +42,8 @@ Describe 'ConvertFrom-ParameterizedObject' {
     It 'can evaluate key and value parameters' {
         $target = @{ 'foo' = '$($params.foo)'; '$($params.banter)' = 'woot' }
         $params = @{ foo = @('bar', 'baz'); banter = 'baz' }
-        $result = ConvertFrom-ParameterizedObject $target -config @{} -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedObject $target $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Assert-ShouldBeObject @{ 'foo' = 'bar baz'; 'baz' = 'woot' }
         $result.fail | Should -Be $false
     }
@@ -47,20 +51,23 @@ Describe 'ConvertFrom-ParameterizedObject' {
     It 'can evaluate key and value parameters when loaded from JSON' {
         $target = @{ 'foo' = '$($params.foo)'; '$($params.banter)' = 'woot' } | ConvertTo-Json | ConvertFrom-Json
         $params = @{ foo = @('bar', 'baz'); banter = 'baz' }
-        $result = ConvertFrom-ParameterizedObject $target -config @{} -params $params -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=$params; actions=@{} }
+        $result = ConvertFrom-ParameterizedObject $target $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.result | Assert-ShouldBeObject @{ 'foo' = 'bar baz'; 'baz' = 'woot' }
         $result.fail | Should -Be $false
     }
 
     It 'reports errors' {
         $target = @{ 'foo' = '$($params.foo)'; 'baz' = '$($params.banter)' }
-        $result = ConvertFrom-ParameterizedObject $target -config @{} -params @{} -actions @{} -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=@{}; actions=@{} }
+        $result = ConvertFrom-ParameterizedObject $target -variables $variables -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true
     }
     
     It 'reports warnings if diagnostics are provided' {
         $target = @{ 'foo' = '$($params.foo)'; 'baz' = '$($params.banter)' }
-        $result = ConvertFrom-ParameterizedObject $target -config @{} -params @{} -actions @{} -diagnostics $diag -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=@{}; actions=@{} }
+        $result = ConvertFrom-ParameterizedObject $target -variables $variables -diagnostics $diag -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true
 
         $output = Register-Diagnostics -throwInsteadOfExit
@@ -72,7 +79,8 @@ Describe 'ConvertFrom-ParameterizedObject' {
 
     It 'reports errors if diagnostics are provided and flagged to fail on error' {
         $target = @{ 'foo' = '$($params.foo)'; 'baz' = '$($params.banter)' }
-        $result = ConvertFrom-ParameterizedObject $target -config @{} -params @{} -actions @{} -diagnostics $diag -failOnError -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
+        $variables = @{ config=@{}; params=@{}; actions=@{} }
+        $result = ConvertFrom-ParameterizedObject $target -variables $variables -diagnostics $diag -failOnError -convertFromParameterized ${function:ConvertFrom-ParameterizedString}
         $result.fail | Should -Be $true
 
         $output = Register-Diagnostics -throwInsteadOfExit

--- a/utils/scripting/ConvertFrom-ParameterizedString.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedString.psm1
@@ -1,4 +1,5 @@
 Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/New-Closure.psm1"
 
 function ConvertFrom-ParameterizedString(
     [string] $script, 
@@ -8,14 +9,14 @@ function ConvertFrom-ParameterizedString(
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [switch] $failOnError
 ) {
-    $targetScript = [ScriptBlock]::Create('
+    $targetScript = New-Closure ([ScriptBlock]::Create('
     Set-StrictMode -Version 3.0; 
     try {
         "' + $script.replace('`', '``').replace('"', '`"') + '"
     } catch {
         $null
     }
-    ')
+    ')) -variables @{ config = $config; params = $params; actions = $actions }
     $entry = Invoke-Command -ScriptBlock $targetScript
     if ($null -eq $entry) {
         if ($failOnError) {

--- a/utils/scripting/ConvertFrom-ParameterizedString.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedString.psm1
@@ -3,9 +3,7 @@ Import-Module -Scope Local "$PSScriptRoot/New-Closure.psm1"
 
 function ConvertFrom-ParameterizedString(
     [string] $script, 
-    [PSObject] $config,
-    [PSObject] $params,
-    [PSObject] $actions,
+    [Parameter(Mandatory)][PSObject] $variables,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [switch] $failOnError
 ) {
@@ -16,7 +14,7 @@ function ConvertFrom-ParameterizedString(
     } catch {
         $null
     }
-    ')) -variables @{ config = $config; params = $params; actions = $actions }
+    ')) -variables $variables
     $entry = Invoke-Command -ScriptBlock $targetScript
     if ($null -eq $entry) {
         if ($failOnError) {

--- a/utils/scripting/ConvertFrom-ParameterizedString.tests.ps1
+++ b/utils/scripting/ConvertFrom-ParameterizedString.tests.ps1
@@ -12,7 +12,7 @@ Describe 'ConvertFrom-ParameterizedString' {
 
     It 'can evaluate from params' {
         $params = @{ foo = 'bar' }
-        $result = ConvertFrom-ParameterizedString -script '$($params.foo)' -config @{} -params $params -actions @{}
+        $result = ConvertFrom-ParameterizedString -script '$($params.foo)' -variables @{ config=@{}; params=$params; actions=@{} }
         $result.result | Should -Be 'bar'
         $result.fail | Should -Be $false
     }
@@ -25,25 +25,25 @@ Describe 'ConvertFrom-ParameterizedString' {
                 }
             }
         }
-        $result = ConvertFrom-ParameterizedString -script '$($actions["create-branch"].outputs["commit"])' -config @{} -params @{} -actions $actions
+        $result = ConvertFrom-ParameterizedString -script '$($actions["create-branch"].outputs["commit"])' -variables @{ config=@{}; params=@{}; actions=$actions }
         $result.result | Should -Be 'baadf00d'
         $result.fail | Should -Be $false
     }
 
     It 'returns null if accessing an action that does not exist' {
-        $result = ConvertFrom-ParameterizedString -script '$($actions["create-branch"].outputs["commit"])' -config @{} -params @{} -actions @{}
+        $result = ConvertFrom-ParameterizedString -script '$($actions["create-branch"].outputs["commit"])' -variables @{ config=@{}; params=@{}; actions=@{} }
         $result.result | Should -Be $null
         $result.fail | Should -Be $true
     }
 
     It 'returns null if an error occurs' {
-        $result = ConvertFrom-ParameterizedString -script '$($config.upstreamBranch)' -config @{} -params @{} -actions @{}
+        $result = ConvertFrom-ParameterizedString -script '$($config.upstreamBranch)' -variables @{ config=@{}; params=@{}; actions=@{} }
         $result.result | Should -Be $null
         $result.fail | Should -Be $true
     }
 
     It 'reports warnings if diagnostics are provided' {
-        $result = ConvertFrom-ParameterizedString -script '$($config.upstreamBranch)' -config @{} -params @{} -actions @{} -diagnostics $diag
+        $result = ConvertFrom-ParameterizedString -script '$($config.upstreamBranch)' -variables @{ config=@{}; params=@{}; actions=@{} } -diagnostics $diag
         $result.result | Should -Be $null
         $result.fail | Should -Be $true
 
@@ -53,7 +53,7 @@ Describe 'ConvertFrom-ParameterizedString' {
     }
 
     It 'reports errors if diagnostics are provided and flagged to fail on error' {
-        $result = ConvertFrom-ParameterizedString -script '$($config.upstreamBranch)' -config @{} -params @{} -actions @{} -diagnostics $diag -failOnError
+        $result = ConvertFrom-ParameterizedString -script '$($config.upstreamBranch)' -variables @{ config=@{}; params=@{}; actions=@{} } -diagnostics $diag -failOnError
         $result.result | Should -Be $null
         $result.fail | Should -Be $true
 

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -17,7 +17,8 @@ function Invoke-Script(
 
         for ($i = 0; $i -lt $script.local.Count; $i++) {
             $name = $script.local[$i].id ?? "#$($i + 1) (1-based)";
-            $local = ConvertFrom-ParameterizedAnything -script $script.local[$i] -config $config -params $params -actions $actions -diagnostics $diagnostics
+            $variables = @{ config=$config; params=$params; actions=$actions }
+            $local = ConvertFrom-ParameterizedAnything -script $script.local[$i] -variables $variables -diagnostics $diagnostics
             if ($local.fail) {
                 Add-ErrorDiagnostic $diagnostics "Could not apply parameters to local action $name; see above errors. Evaluation below:"
                 Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
@@ -37,7 +38,8 @@ function Invoke-Script(
         }
 
         if ($script.finalize) {
-            $allFinalize = ConvertFrom-ParameterizedAnything -script $script.finalize -config $config -params $params -actions $actions -diagnostics $diagnostics
+            $variables = @{ config=$config; params=$params; actions=$actions }
+            $allFinalize = ConvertFrom-ParameterizedAnything -script $script.finalize -variables $variables -diagnostics $diagnostics
             if ($allFinalize.fail) {
                 Add-ErrorDiagnostic $diagnostics "Could not apply parameters for finalize actions; see above errors."
                 Assert-Diagnostics $diagnostics
@@ -68,7 +70,8 @@ function Invoke-Script(
         }
         
         if ($null -ne $script.output -AND -not $dryRun) {
-            $allOutput = ConvertFrom-ParameterizedAnything -script $script.output -config $config -params $params -actions $actions -diagnostics $diagnostics
+            $variables = @{ config=$config; params=$params; actions=$actions }
+            $allOutput = ConvertFrom-ParameterizedAnything -script $script.output -variables $variables -diagnostics $diagnostics
             $allOutput.result | Write-Output
         }
     } catch {

--- a/utils/scripting/New-Closure.psm1
+++ b/utils/scripting/New-Closure.psm1
@@ -1,0 +1,16 @@
+function New-Closure(
+    [scriptblock] $sourceScript,
+    [hashtable] $variables
+) {
+    # The nested function allows us to control what variables are in scope very
+    # carefully; even $sourceScript and $variables will not be in scope here
+    function Nested() {
+        foreach ($key in $variables.Keys) {
+            Set-Variable -Name $key -Value $variables[$key]
+        }
+        return $sourceScript.GetNewClosure()
+    }
+    return Nested
+}
+
+Export-ModuleMember -Function New-Closure

--- a/utils/scripting/New-Closure.tests.ps1
+++ b/utils/scripting/New-Closure.tests.ps1
@@ -1,0 +1,42 @@
+Describe 'New-Closure' {
+    BeforeAll {
+        . "$PSScriptRoot/../testing.ps1"
+    }
+
+    It 'allows a script to bind custom variables' {
+        $resultScript = New-Closure { $one + $two } -variables @{ one = 1; two = 2 }
+        $actual = Invoke-Command $resultScript
+        $actual | Should -Be 3
+    }
+    
+    It 'allows a script to bind custom variables, even nested' {
+        $resultScript = New-Closure { $one.deep + $two } -variables @{ one = @{ deep = 1 }; two = 2 }
+        $actual = Invoke-Command $resultScript
+        $actual | Should -Be 3
+    }
+    
+    It 'allows a script to update the original object references, if nested' {
+        $data = @{ one = 1; two = 2 }
+        $resultScript = New-Closure { $data.three = $data.one + $data.two } -variables @{ data = $data }
+        $actual = Invoke-Command $resultScript
+        $data.three | Should -Be 3
+        $actual | Should -Be $null
+    }
+    
+    It 'disallows access to the root variables' {
+        $resultScript = New-Closure {
+            Set-StrictMode -Version 3.0;
+            $variables.one
+        } -variables @{ one = 1; two = 2 }
+        { Invoke-Command $resultScript } | Should -Throw "The variable '`$variables' cannot be retrieved because it has not been set."
+    }
+    
+    It 'disallows access to the root script' {
+        $resultScript = New-Closure {
+            Set-StrictMode -Version 3.0;
+            $sourceScript
+        } -variables @{ one = 1; two = 2 }
+        { Invoke-Command $resultScript } | Should -Throw "The variable '`$sourceScript' cannot be retrieved because it has not been set."
+    }
+    
+}


### PR DESCRIPTION
Add support for `git pull-upstream -recurse`

- Converts pull-upstream to using recurse functionality
- Adds an "evaluate" script for creating extra "variables" during script processing
- Adds support for `Invoke-MergeTogether` to support commit overrides, such as when a previous merge has already been performed but not pushed
- Adjusts parameterization functions to allow any set of variables instead of just those predefined by the scripting utilities