### PR TITLE
Pull Upstream messaging fixes

### DIFF
--- a/git-add-upstream.json
+++ b/git-add-upstream.json
@@ -59,12 +59,20 @@
             }
         },
         {
-            "id": "merge-branches",
+            "id": "mergeBranches",
             "type": "merge-branches",
             "parameters": {
                 "source": "$($params.target)",
                 "upstreamBranches": ["$actions['filtered-upstream'].outputs"],
                 "mergeMessageTemplate": "Merge '{}' to $($params.target)"
+            }
+        },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions.mergeBranches.outputs.failed -ne $null",
+            "parameters": {
+                "isWarning": true,
+                "message": "$($params.target) has incoming conflicts from $($actions.mergeBranches.outputs.failed). Be sure to manually merge."
             }
         }
     ],
@@ -74,7 +82,7 @@
             "parameters": {
                 "branches": {
                     "$config.upstreamBranch": "$actions['set-upstream'].outputs['commit']",
-                    "$params.target": "$actions['merge-branches'].outputs['commit']"
+                    "$params.target": "$actions.mergeBranches.outputs['commit']"
                 }
             }
         },

--- a/git-add-upstream.tests.ps1
+++ b/git-add-upstream.tests.ps1
@@ -338,7 +338,7 @@ Describe 'git-add-upstream' {
             )
 
             & ./git-add-upstream.ps1 'feature/FOO-76' -m ""
-            $fw.assertDiagnosticOutput | Should -Be @('WARN: Could not merge the following branches: origin/feature/FOO-76')
+            $fw.assertDiagnosticOutput | Should -Be @('WARN: rc/2022-07-14 has incoming conflicts from feature/FOO-76. Be sure to manually merge.')
             Invoke-VerifyMock $mocks -Times 1
         }
 

--- a/git-new.json
+++ b/git-new.json
@@ -38,11 +38,19 @@
             }
         },
         {
-            "id": "create-branch",
+            "id": "createBranch",
             "type": "merge-branches",
             "parameters": {
                 "upstreamBranches": ["$actions['simplify-upstream'].outputs"],
                 "mergeMessageTemplate": "Merge '{}' for creation of $($params.branchName)"
+            }
+        },
+        { 
+            "type": "add-diagnostic",
+            "condition": "$actions.createBranch.outputs.failed -ne $null",
+            "parameters": {
+                "isWarning": true,
+                "message": "$($params.branchName) has incoming conflicts from $($actions.createBranch.outputs.failed). Be sure to manually merge."
             }
         }
     ],
@@ -52,7 +60,7 @@
             "parameters": {
                 "branches": {
                     "$config.upstreamBranch": "$actions['set-upstream'].outputs['commit']",
-                    "$params.branchName": "$actions['create-branch'].outputs['commit']"
+                    "$params.branchName": "$actions.createBranch.outputs['commit']"
                 }
             }
         },

--- a/git-new.tests.ps1
+++ b/git-new.tests.ps1
@@ -304,7 +304,7 @@ Describe 'git-new' {
             )
 
             { & $PSScriptRoot/git-new.ps1 feature/PS-100-some-work -u 'feature/homepage-redesign,infra/update-dependencies' -m 'some work' } | Should -Not -Throw
-            $fw.assertDiagnosticOutput | Should -Contain 'WARN: Could not merge the following branches: origin/infra/update-dependencies'
+            $fw.assertDiagnosticOutput | Should -Contain 'WARN: feature/PS-100-some-work has incoming conflicts from infra/update-dependencies. Be sure to manually merge.'
             Invoke-VerifyMock $mocks -Times 1
         }
     }

--- a/git-pull-upstream.json
+++ b/git-pull-upstream.json
@@ -26,7 +26,7 @@
         },
         {
             "type": "add-diagnostic",
-            "condition": "$actions['merge-recurse'].outputs.hasChanges ? $false : $true",
+            "condition": "$actions['merge-recurse'].outputs.hasChanges -OR $actions['merge-recurse'].outputs.hasFailures ? $false : $true",
             "parameters": {
                 "isWarning": true,
                 "message": "No updates found."
@@ -50,6 +50,6 @@
         }
     ],
     "output": [
-        "$($params.target) has been updated with its upstream branches"
+        "$($actions['merge-recurse'].outputs.hasFailures ? \"$($params.target) requires manual merges from $($actions['merge-recurse'].outputs.failures[$params.target])\" : \"$($params.target) has been updated with its upstream branches\")"
     ]
 }

--- a/git-pull-upstream.recurse.json
+++ b/git-pull-upstream.recurse.json
@@ -5,7 +5,7 @@
             "if (-not $params.recurse) { return @() }",
             "($actions['get-upstream'].outputs | Where-Object { $null -ne $_ -AND $_ -notin ($previous | ForEach-Object { $_.target }) } | ForEach-Object { @{ target = $_; recurse = $params.recurse } })"
         ],
-        "init": "$recursionContext.result = @{ hasChanges = $false; push = @{}; override = @{}; track = @(); failures = @{} }",
+        "init": "$recursionContext.result = @{ hasChanges = $false; hasFailures = $false; push = @{}; override = @{}; track = @(); failures = @{} }",
         "reduceToOutput": "$recursionContext.result",
         "actCondition": "$null -ne $actions['get-upstream'].outputs"
     },
@@ -37,8 +37,9 @@
         },
         { 
             "type": "add-diagnostic",
-            "condition": "$actions.mergeBranches.outputs.failed -AND $params.depth -ne 0",
+            "condition": "$actions.mergeBranches.outputs.failed -ne $null",
             "parameters": {
+                "isWarning": "$params.depth -eq 0",
                 "message": "$($params.target) has incoming conflicts from $($actions.mergeBranches.outputs.failed). Resolve them before continuing."
             }
         },
@@ -48,6 +49,7 @@
             "parameters": {
                 "result": {
                     "hasChanges": "$actions.mergeBranches.outputs.hasChanges",
+                    "hasFailures": "$actions.mergeBranches.outputs.failed -ne $null",
                     "push": {
                         "$params.target": "$actions.mergeBranches.outputs['commit']"
                     },
@@ -67,6 +69,7 @@
             "parameters": {
                 "result": {
                     "hasChanges": "$recursionContext.result.hasChanges -OR $actions.iterationResult.outputs.hasChanges",
+                    "hasFailures": "$recursionContext.result.hasFailures -OR $actions.iterationResult.outputs.hasFailures",
                     "push": "$actions.mergeBranches.outputs.hasChanges ? ($recursionContext.result.push + $actions.iterationResult.outputs.push) : $recursionContext.result.push",
                     "override": "$actions.mergeBranches.outputs.hasChanges ? ($recursionContext.result.override + $actions.iterationResult.outputs.override) : $recursionContext.result.override",
                     "track": "$recursionContext.result.track + $actions.iterationResult.outputs.track",

--- a/git-pull-upstream.tests.ps1
+++ b/git-pull-upstream.tests.ps1
@@ -66,9 +66,6 @@ Describe 'git-pull-upstream' {
         }
 
         It "merges upstream branches for the specified branch when an upstream branch cannot be merged" {
-            $remote = $(Get-Configuration).remote
-            $remotePrefix = $remote ? "$remote/" : ""
-
             $mocks = @(
                 Initialize-AssertValidBranchName 'feature/FOO-456'
                 Initialize-CurrentBranch 'feature/FOO-456'
@@ -87,7 +84,6 @@ Describe 'git-pull-upstream' {
 
             & $PSScriptRoot/git-pull-upstream.ps1
             $fw.assertDiagnosticOutput | Should -Be @(
-                "WARN: Could not merge the following branches: $($remotePrefix)infra/refactor-api"
                 "WARN: feature/FOO-456 has incoming conflicts from infra/refactor-api. Resolve them before continuing."
             )
             Invoke-VerifyMock $mocks -Times 1

--- a/git-pull-upstream.tests.ps1
+++ b/git-pull-upstream.tests.ps1
@@ -88,6 +88,7 @@ Describe 'git-pull-upstream' {
             & $PSScriptRoot/git-pull-upstream.ps1
             $fw.assertDiagnosticOutput | Should -Be @(
                 "WARN: Could not merge the following branches: $($remotePrefix)infra/refactor-api"
+                "WARN: feature/FOO-456 has incoming conflicts from infra/refactor-api. Resolve them before continuing."
             )
             Invoke-VerifyMock $mocks -Times 1
         }

--- a/git-verify-updated.tests.ps1
+++ b/git-verify-updated.tests.ps1
@@ -193,8 +193,7 @@ Describe 'git-verify-updated' {
             )
 
             { & $PSScriptRoot/git-verify-updated.ps1 -target feature/PS-2 -recurse }
-                | Should -Throw "WARN: Could not merge the following branches: $($remotePrefix)infra/ts-update
-ERR:  infra/build-improvements has incoming conflicts from infra/ts-update."
+                | Should -Throw "ERR:  infra/build-improvements has incoming conflicts from infra/ts-update."
             Invoke-VerifyMock $mocks -Times 1
         }
     }

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -39,7 +39,7 @@ function Register-LocalActionMergeBranches([PSObject] $localActions) {
             -messageTemplate $mergeMessageTemplate `
             -commitMappingOverride $commitMappingOverride `
             -diagnostics $diagnostics `
-            -asWarnings:$(-not $errorOnFailure)
+            -noFailureMessages:$(-not $errorOnFailure)
         $commit = $mergeResult.result
         if ($null -eq $commit) {
             if ($source -notin $mergeResult.failed) {

--- a/utils/actions/local/Register-LocalActionMergeBranches.tests.ps1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.tests.ps1
@@ -172,7 +172,7 @@ Describe 'local action "merge-branches"' {
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
             { Assert-Diagnostics $diag } | Should -Not -Throw
-            $output | Should -contain 'WARN: Could not merge the following branches: barbaz'
+            $output | Should -BeNullOrEmpty
             $result | Assert-ShouldBeObject @{
                 commit = 'new-COMMIT'
                 hasChanges = $false
@@ -210,7 +210,7 @@ Describe 'local action "merge-branches"' {
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
             { Assert-Diagnostics $diag } | Should -Not -Throw
-            $output | Should -contain 'WARN: Could not merge the following branches: origin/barbaz'
+            $output | Should -BeNullOrEmpty
             $result | Assert-ShouldBeObject @{
                 commit = 'new-COMMIT'
                 hasChanges = $false
@@ -236,7 +236,7 @@ Describe 'local action "merge-branches"' {
                 }
             }' | ConvertFrom-Json) -diagnostics $diag
             { Assert-Diagnostics $diag } | Should -Not -Throw
-            $output | Should -contain 'WARN: Could not merge the following branches: origin/barbaz'
+            $output | Should -BeNullOrEmpty
             $result | Assert-ShouldBeObject @{
                 commit = 'new-COMMIT'
                 hasChanges = $false

--- a/utils/git/Invoke-MergeTogether.psm1
+++ b/utils/git/Invoke-MergeTogether.psm1
@@ -7,7 +7,8 @@ function Invoke-MergeTogether(
     [Parameter()][string] $messageTemplate = "Merge {}",
     [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
     [Parameter()][hashtable] $commitMappingOverride = @{},
-    [switch] $asWarnings
+    [switch] $asWarnings,
+    [switch] $noFailureMessages
 ) {
     function ResolveCommit($commitish) {
         if ($commitMappingOverride[$commitish]) {
@@ -57,7 +58,9 @@ function Invoke-MergeTogether(
             } else {
                 $remaining = $remaining | Where-Object { $_ -ne $target }
                 $failed += $target
-                if ($asWarnings) {
+                if ($noFailureMessages) {
+                    # Intentionally blank
+                } elseif ($asWarnings) {
                     Add-WarningDiagnostic $diagnostics "Could not resolve '$($target)'"
                 } else {
                     Add-ErrorDiagnostic $diagnostics "Could not resolve '$($target)'"
@@ -72,7 +75,9 @@ function Invoke-MergeTogether(
                     # If we can't resolve the commit, it'll never resolve
                     $remaining = $remaining | Where-Object { $_ -ne $target }
                     $failed += $target
-                    if ($asWarnings) {
+                    if ($noFailureMessages) {
+                        # Intentionally blank
+                    } elseif ($asWarnings) {
                         Add-WarningDiagnostic $diagnostics "Could not resolve '$($target)'"
                     } else {
                         Add-ErrorDiagnostic $diagnostics "Could not resolve '$($target)'"
@@ -109,7 +114,9 @@ function Invoke-MergeTogether(
                 break;
             }
             if ($allFailed -AND $remaining.Count -gt 0) {
-                if ($asWarnings) {
+                if ($noFailureMessages) {
+                    # Intentionally blank
+                } elseif ($asWarnings) {
                     Add-WarningDiagnostic $diagnostics "Could not merge the following branches: $remaining"
                 } else {
                     Add-ErrorDiagnostic $diagnostics "Could not merge the following branches: $remaining"


### PR DESCRIPTION
Frequent confusion has been occurring around `pull-upstream` messaging:

```
% git pull-upstream          
Working on 'git fetch origin'...
End 'git fetch origin'. (0.8s)
WARN: Could not merge the following branches: origin/story/psu-340
WARN: No updates found.
story/psu-341 has been updated with its upstream branches
```

The above messaging meant that there were conflicts merging `story/psu-340` into `story/psu-341`, but all other merges succeeded. This PR resolves that, replacing the output to:

```
WARN: story/psu-341 has incoming conflicts from story/psu-340. Be sure to manually merge.
story/psu-341 requires manual merges from story/psu-340
```