### PR TITLE
Add `git refactor-upstream` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Note: if you have an older version installed, such as .NET 7, you can [install a
 
 [`git pull-upstream`](./docs/pull-upstream.md)
 
+[`git show-downstream`](./docs/show-downstream.md)
+
 [`git show-upstream`](./docs/show-upstream.md)
 
 [`git add-upstream`](./docs/add-upstream.md)
@@ -48,8 +50,9 @@ Note: if you have an older version installed, such as .NET 7, you can [install a
 
 [`git verify-updated`](./docs/verify-updated.md)
 
-[`git release`](./docs/release.md)
+[`git refactor-upstream`](./docs/refactor-upstream.md)
 
+[`git release`](./docs/release.md)
 
 ## Development
 

--- a/docs/refactor-upstream.md
+++ b/docs/refactor-upstream.md
@@ -5,7 +5,7 @@ Refactor upstream branches to redirect upstreams from "source" to "target".
 Usage:
 
     git-refactor-upstream.ps1 [-source] <string> [-target] <string>
-        (-remove|-rename) [-comment <string>] [-dryRun]
+        (-remove|-rename|-combine) [-comment <string>] [-dryRun]
 
 ## Parameters
 
@@ -24,7 +24,10 @@ Either `-remove` or `-replace` must be specified.
 * `-remove` indicates that the source branch should be removed and old upstream
   branches can be ignored.
 * `-rename` indicates that upstreams from the source branch should be
-  transferred to the target branch.
+  transferred to the target branch; any upstreams of the target should be
+  overwritten.
+* `-combine` indicates that upstreams from both source and target should be
+  combined into upstreams of the target branch.
 
 The source and target branches _will not_ be updated as part of this command.
 

--- a/docs/refactor-upstream.md
+++ b/docs/refactor-upstream.md
@@ -5,7 +5,7 @@ Refactor upstream branches to redirect upstreams from "source" to "target".
 Usage:
 
     git-refactor-upstream.ps1 [-source] <string> [-target] <string>
-        (-remove|-rename) [-dryRun]
+        (-remove|-rename) [-comment <string>] [-dryRun]
 
 ## Parameters
 
@@ -27,6 +27,13 @@ Either `-remove` or `-replace` must be specified.
   transferred to the target branch.
 
 The source and target branches _will not_ be updated as part of this command.
+
+### `-comment <string>` (Optional)
+
+_Aliases: -m, -message_
+
+If specified, include this comment in the commit message for the upstream
+tracking branch when pushing changes.
 
 ### `-dryRun` (Optional)
 

--- a/docs/refactor-upstream.md
+++ b/docs/refactor-upstream.md
@@ -17,9 +17,9 @@ The name of the old upstream branch.
 
 The name of the new upstream branch.
 
-### `(-remove|-replace)`
+### `(-remove|-replace|-combine)`
 
-Either `-remove` or `-replace` must be specified.
+One of -rename, -remove, or -combine must be specfied.
 
 * `-remove` indicates that the source branch should be removed and old upstream
   branches can be ignored.

--- a/docs/refactor-upstream.md
+++ b/docs/refactor-upstream.md
@@ -1,6 +1,9 @@
 # `git refactor-upstream`
 
-Refactor upstream branches to redirect upstreams from "source" to "target".
+Refactor upstream branches to redirect upstreams from "source" to "target". This
+command only alters the upstream configuration of branches; put another way, it
+does not merge any changes from new upstreams, etc. into affected branches, nor
+does it actually delete a "removed" source.
 
 Usage:
 
@@ -28,8 +31,6 @@ One of -rename, -remove, or -combine must be specfied.
   overwritten.
 * `-combine` indicates that upstreams from both source and target should be
   combined into upstreams of the target branch.
-
-The source and target branches _will not_ be updated as part of this command.
 
 ### `-comment <string>` (Optional)
 

--- a/docs/refactor-upstream.md
+++ b/docs/refactor-upstream.md
@@ -1,0 +1,34 @@
+# `git refactor-upstream`
+
+Refactor upstream branches to redirect upstreams from "source" to "target".
+
+Usage:
+
+    git-refactor-upstream.ps1 [-source] <string> [-target] <string>
+        (-remove|-rename) [-dryRun]
+
+## Parameters
+
+### `[-source] <string>`
+
+The name of the old upstream branch.
+
+### `[-target] <string>`
+
+The name of the new upstream branch.
+
+### `(-remove|-replace)`
+
+Either `-remove` or `-replace` must be specified.
+
+* `-remove` indicates that the source branch should be removed and old upstream
+  branches can be ignored.
+* `-rename` indicates that upstreams from the source branch should be
+  transferred to the target branch.
+
+The source and target branches _will not_ be updated as part of this command.
+
+### `-dryRun` (Optional)
+
+If specified, only test merging, do not push the updates.
+

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -1,0 +1,36 @@
+{
+    "local": [
+        {
+            "type": "validate-branch-names",
+            "parameters": {
+                "branches": ["$params.source", "$params.target"]
+            }
+        },
+        {
+            "type": "add-diagnostic",
+            "condition": "$true -AND -not $params.rename -AND -not $params.remove",
+            "parameters": {
+                "message": "Either -rename or -remove must be specfied."
+            }
+        },
+        {
+            "type": "add-diagnostic",
+            "parameters": {
+                "message": "TODO"
+            }
+        }
+    ],
+    "finalize": [
+        {
+            "type": "set-branches",
+            "parameters": {
+                "force": true,
+                "branches": {
+                    "$config.upstreamBranch": "$actions['set-upstream'].outputs['commit']"
+                }
+            }
+        }
+    ],
+    "output": [
+    ]
+}

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -42,11 +42,35 @@
             }
         },
         {
+            "id": "filterRename",
+            "type": "filter-branches",
+            "condition": "$params.rename",
+            "parameters": {
+                "include": ["$actions.originalUpstreams.outputs[$params.target]", "$actions.originalUpstreams.outputs[$params.source]"],
+                "exclude": ["$params.source", "$params.target"]
+            }
+        },
+        {
+            "id": "alteredUpstreams",
+            "type": "evaluate",
+            "parameters": {
+                "result": "$actions.originalUpstreams.outputs + @{}"
+            }
+        },
+        {
+            "id": "rename",
+            "type": "evaluate",
+            "condition": "$params.rename",
+            "parameters": {
+                "result": "$actions.alteredUpstreams.outputs[$params.target] = [string[]]$actions.filterRename.outputs"
+            }
+        },
+        {
             "id": "upstreamResult",
             // This is not truly a recursive script, but a loop to compute the upstream branches that should change
             "type": "recurse",
             "parameters": {
-                "inputParameters": "$actions.originalUpstreams.outputs.Keys | ForEach-Object { @{ target = $params.target; source = $params.source; current = $_; upstream = $actions.originalUpstreams.outputs[$_] } }",
+                "inputParameters": "$actions.alteredUpstreams.outputs.Keys | ForEach-Object { @{ target = $params.target; source = $params.source; current = $_; upstream = $actions.alteredUpstreams.outputs[$_] } }",
                 "path": "git-refactor-upstream.loop.1.json"
             }
         },
@@ -54,7 +78,7 @@
             "type": "evaluate",
             "id": "affected",
             "parameters": {
-                "result": ["$params.target", "$actions.sourceDownstreams.outputs", "$actions.targetDownstreams.outputs"]
+                "result": ["$params.target", "$actions.sourceDownstreams.outputs", "$params.rename ? $actions.targetDownstreams.outputs : @()"]
             }
         },
         {
@@ -62,22 +86,22 @@
             // This is not truly a recursive script, but a loop to compute the upstream branches that should change
             "type": "recurse",
             "parameters": {
-                "inputParameters": "$actions.affected.outputs | Where-Object { $_ } | ForEach-Object { @{ current = $_; original = $actions.originalUpstreams.outputs[$_]; upstream = $actions.upstreamResult.outputs[$_] ?? $actions.originalUpstreams.outputs[$_]; override = $actions.upstreamResult.outputs } }",
+                "inputParameters": "$actions.affected.outputs | Where-Object { $_ } | ForEach-Object { @{ current = $_; original = $actions.originalUpstreams.outputs[$_]; upstream = $actions.upstreamResult.outputs[$_] ?? $actions.alteredUpstreams.outputs[$_]; override = $actions.upstreamResult.outputs } }",
                 "path": "git-refactor-upstream.loop.2.json"
             }
         },
         {
-            "id": "removeRename",
+            "id": "remove",
             "type": "evaluate",
             "parameters": {
-                "result": "$actions.simplifyAll.outputs + @{ $params.source = $null } + ($params.rename ? @{ $params.target = $actions.originalUpstreams.outputs[$params.source] } : @{})"
+                "result": "$actions.simplifyAll.outputs[$params.source] = $null"
             }
         },
         {
             "id": "upstreamHash",
             "type": "set-upstream",
             "parameters": {
-                "upstreamBranches": "$actions.removeRename.outputs",
+                "upstreamBranches": "$actions.simplifyAll.outputs",
                 "message": "Rewrite $($params.source) to $($params.target)$($params.comment -eq '' ? '' : \" for $($params.comment)\")"
             }
         }

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -2,16 +2,16 @@
     "local": [
         {
             "type": "add-diagnostic",
-            "condition": "$true -AND -not $params.rename -AND -not $params.remove",
+            "condition": "$true -AND -not $params.rename -AND -not $params.remove -AND -not $params.combine",
             "parameters": {
-                "message": "Either -rename or -remove must be specfied."
+                "message": "One of -rename, -remove, or -combine must be specfied."
             }
         },
         {
             "type": "add-diagnostic",
-            "condition": "$params.rename -AND $params.remove",
+            "condition": "$true -AND ($params.rename ? 1 : 0) + ($params.remove ? 1 : 0) + ($params.combine ? 1 : 0) -gt 1",
             "parameters": {
-                "message": "Only one of -rename and -remove may be specified."
+                "message": "Only one of -rename, -remove, and -combine may be specified."
             }
         },
         {
@@ -44,9 +44,9 @@
         {
             "id": "filterRename",
             "type": "filter-branches",
-            "condition": "$params.rename",
+            "condition": "$params.rename -OR $params.combine",
             "parameters": {
-                "include": ["$actions.originalUpstreams.outputs[$params.target]", "$actions.originalUpstreams.outputs[$params.source]"],
+                "include": ["$params.combine ? $actions.originalUpstreams.outputs[$params.target] : @()", "$actions.originalUpstreams.outputs[$params.source]"],
                 "exclude": ["$params.source", "$params.target"]
             }
         },
@@ -60,7 +60,7 @@
         {
             "id": "rename",
             "type": "evaluate",
-            "condition": "$params.rename",
+            "condition": "$params.rename -OR $params.combine",
             "parameters": {
                 "result": "$actions.alteredUpstreams.outputs[$params.target] = [string[]]$actions.filterRename.outputs"
             }
@@ -78,7 +78,7 @@
             "type": "evaluate",
             "id": "affected",
             "parameters": {
-                "result": ["$params.target", "$actions.sourceDownstreams.outputs", "$params.rename ? $actions.targetDownstreams.outputs : @()"]
+                "result": ["$params.target", "$actions.sourceDownstreams.outputs", "$params.rename -OR $params.combine ? $actions.targetDownstreams.outputs : @()"]
             }
         },
         {

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -14,9 +14,25 @@
             }
         },
         {
-            "type": "add-diagnostic",
+            "type": "get-all-upstreams",
+            "id": "originalUpstreams",
+            "parameters": {}
+        },
+        {
+            "id": "upstreamResult",
+            // This is not truly a recursive script, but a loop to compute the upstream branches that should change
+            "type": "recurse",
             "parameters": {
-                "message": "TODO"
+                "inputParameters": "$actions.originalUpstreams.outputs.Keys | ForEach-Object { @{ target = $params.target; source = $params.source; current = $_; upstream = $actions.originalUpstreams.outputs[$_] } }",
+                "path": "git-refactor-upstream.loop.json"
+            }
+        },
+        {
+            "id": "upstreamHash",
+            "type": "set-upstream",
+            "parameters": {
+                "upstreamBranches": "$actions.upstreamResult.outputs",
+                "message": "Rewrite $($params.source) to $($params.target)$($params.comment -eq '' ? '' : \" for $($params.comment)\")"
             }
         }
     ],
@@ -24,13 +40,13 @@
         {
             "type": "set-branches",
             "parameters": {
-                "force": true,
                 "branches": {
-                    "$config.upstreamBranch": "$actions['set-upstream'].outputs['commit']"
+                    "$config.upstreamBranch": "$actions.upstreamHash.outputs.commit"
                 }
             }
         }
     ],
     "output": [
+        "$($params.source) has been replaced with $(params.target) in the following branches: $($actions.upstreamResult.outputs.Keys)"
     ]
 }

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -26,6 +26,22 @@
             "parameters": {}
         },
         {
+            "type": "get-downstream",
+            "id": "sourceDownstreams",
+            "parameters": {
+                "target": "$params.source",
+                "recurse": true
+            }
+        },
+        {
+            "type": "get-downstream",
+            "id": "targetDownstreams",
+            "parameters": {
+                "target": "$params.target",
+                "recurse": true
+            }
+        },
+        {
             "id": "upstreamResult",
             // This is not truly a recursive script, but a loop to compute the upstream branches that should change
             "type": "recurse",
@@ -35,11 +51,18 @@
             }
         },
         {
+            "type": "evaluate",
+            "id": "affected",
+            "parameters": {
+                "result": ["$params.target", "$actions.sourceDownstreams.outputs", "$actions.targetDownstreams.outputs"]
+            }
+        },
+        {
             "id": "simplifyAll",
             // This is not truly a recursive script, but a loop to compute the upstream branches that should change
             "type": "recurse",
             "parameters": {
-                "inputParameters": "$actions.originalUpstreams.outputs.Keys | ForEach-Object { @{ current = $_; original = $actions.originalUpstreams.outputs[$_]; upstream = $actions.upstreamResult.outputs[$_] ?? $actions.originalUpstreams.outputs[$_]; override = $actions.upstreamResult.outputs } }",
+                "inputParameters": "$actions.affected.outputs | Where-Object { $_ } | ForEach-Object { @{ current = $_; original = $actions.originalUpstreams.outputs[$_]; upstream = $actions.upstreamResult.outputs[$_] ?? $actions.originalUpstreams.outputs[$_]; override = $actions.upstreamResult.outputs } }",
                 "path": "git-refactor-upstream.loop.2.json"
             }
         },

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -1,16 +1,23 @@
 {
     "local": [
         {
-            "type": "validate-branch-names",
-            "parameters": {
-                "branches": ["$params.source", "$params.target"]
-            }
-        },
-        {
             "type": "add-diagnostic",
             "condition": "$true -AND -not $params.rename -AND -not $params.remove",
             "parameters": {
                 "message": "Either -rename or -remove must be specfied."
+            }
+        },
+        {
+            "type": "add-diagnostic",
+            "condition": "$params.rename -AND $params.remove",
+            "parameters": {
+                "message": "Only one of -rename and -remove may be specified."
+            }
+        },
+        {
+            "type": "validate-branch-names",
+            "parameters": {
+                "branches": ["$params.source", "$params.target"]
             }
         },
         {

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -28,10 +28,17 @@
             }
         },
         {
+            "id": "removeRename",
+            "type": "evaluate",
+            "parameters": {
+                "result": "$actions.upstreamResult.outputs + @{ $params.source = $null } + ($params.rename ? @{ $params.target = $actions.originalUpstreams.outputs[$params.source] } : @{})"
+            }
+        },
+        {
             "id": "upstreamHash",
             "type": "set-upstream",
             "parameters": {
-                "upstreamBranches": "$actions.upstreamResult.outputs",
+                "upstreamBranches": "$actions.removeRename.outputs",
                 "message": "Rewrite $($params.source) to $($params.target)$($params.comment -eq '' ? '' : \" for $($params.comment)\")"
             }
         }

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -78,7 +78,11 @@
             "type": "evaluate",
             "id": "affected",
             "parameters": {
-                "result": ["$params.target", "$actions.sourceDownstreams.outputs", "$params.rename -OR $params.combine ? $actions.targetDownstreams.outputs : @()"]
+                "result": [
+                    "$params.target",
+                    "$actions.sourceDownstreams.outputs",
+                    "$params.rename -OR $params.combine ? $actions.targetDownstreams.outputs : @()"
+                ]
             }
         },
         {

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -31,14 +31,23 @@
             "type": "recurse",
             "parameters": {
                 "inputParameters": "$actions.originalUpstreams.outputs.Keys | ForEach-Object { @{ target = $params.target; source = $params.source; current = $_; upstream = $actions.originalUpstreams.outputs[$_] } }",
-                "path": "git-refactor-upstream.loop.json"
+                "path": "git-refactor-upstream.loop.1.json"
+            }
+        },
+        {
+            "id": "simplifyAll",
+            // This is not truly a recursive script, but a loop to compute the upstream branches that should change
+            "type": "recurse",
+            "parameters": {
+                "inputParameters": "$actions.originalUpstreams.outputs.Keys | ForEach-Object { @{ current = $_; original = $actions.originalUpstreams.outputs[$_]; upstream = $actions.upstreamResult.outputs[$_] ?? $actions.originalUpstreams.outputs[$_]; override = $actions.upstreamResult.outputs } }",
+                "path": "git-refactor-upstream.loop.2.json"
             }
         },
         {
             "id": "removeRename",
             "type": "evaluate",
             "parameters": {
-                "result": "$actions.upstreamResult.outputs + @{ $params.source = $null } + ($params.rename ? @{ $params.target = $actions.originalUpstreams.outputs[$params.source] } : @{})"
+                "result": "$actions.simplifyAll.outputs + @{ $params.source = $null } + ($params.rename ? @{ $params.target = $actions.originalUpstreams.outputs[$params.source] } : @{})"
             }
         },
         {

--- a/git-refactor-upstream.json
+++ b/git-refactor-upstream.json
@@ -70,7 +70,9 @@
             // This is not truly a recursive script, but a loop to compute the upstream branches that should change
             "type": "recurse",
             "parameters": {
-                "inputParameters": "$actions.alteredUpstreams.outputs.Keys | ForEach-Object { @{ target = $params.target; source = $params.source; current = $_; upstream = $actions.alteredUpstreams.outputs[$_] } }",
+                "inputParameters": [
+                    "$actions.alteredUpstreams.outputs.Keys | ForEach-Object { @{ target = $params.target; source = $params.source; current = $_; upstream = $actions.alteredUpstreams.outputs[$_] } }"
+                ],
                 "path": "git-refactor-upstream.loop.1.json"
             }
         },
@@ -90,7 +92,9 @@
             // This is not truly a recursive script, but a loop to compute the upstream branches that should change
             "type": "recurse",
             "parameters": {
-                "inputParameters": "$actions.affected.outputs | Where-Object { $_ } | ForEach-Object { @{ current = $_; original = $actions.originalUpstreams.outputs[$_]; upstream = $actions.upstreamResult.outputs[$_] ?? $actions.alteredUpstreams.outputs[$_]; override = $actions.upstreamResult.outputs } }",
+                "inputParameters": [
+                    "$actions.affected.outputs | Where-Object { $_ } | ForEach-Object { @{ current = $_; original = $actions.originalUpstreams.outputs[$_]; upstream = $actions.upstreamResult.outputs[$_] ?? $actions.alteredUpstreams.outputs[$_]; override = $actions.upstreamResult.outputs } }"
+                ],
                 "path": "git-refactor-upstream.loop.2.json"
             }
         },

--- a/git-refactor-upstream.loop.1.json
+++ b/git-refactor-upstream.loop.1.json
@@ -16,16 +16,9 @@
             }
         },
         {
-            "id": "simplify",
-            "type": "simplify-upstream",
-            "parameters": {
-                "upstreamBranches": ["$actions.filter.outputs ?? @()"]
-            }
-        },
-        {
             "type": "evaluate",
             "parameters": {
-                "result": "$recursionContext.result.changes[$params.current] = $actions.simplify.outputs"
+                "result": "$recursionContext.result.changes[$params.current] = $actions.filter.outputs"
             }
         }
     ]

--- a/git-refactor-upstream.loop.1.json
+++ b/git-refactor-upstream.loop.1.json
@@ -3,7 +3,7 @@
         "paramScript": ["@()"],
         "init": "$recursionContext.result = @{ changes = @{} }",
         "reduceToOutput": "$recursionContext.result.changes",
-        "actCondition": "[string[]]($params.upstream) -contains $params.source"
+        "actCondition": "$true"
     },
     "prepare": [],
     "act": [
@@ -18,7 +18,7 @@
         {
             "type": "evaluate",
             "parameters": {
-                "result": "$recursionContext.result.changes[$params.current] = $actions.filter.outputs"
+                "result": "$recursionContext.result.changes[$params.current] = ([string[]]($params.upstream) -contains $params.source) ? $actions.filter.outputs : $params.upstream"
             }
         }
     ]

--- a/git-refactor-upstream.loop.2.json
+++ b/git-refactor-upstream.loop.2.json
@@ -1,0 +1,27 @@
+{
+    "recursion": {
+        "paramScript": ["@()"],
+        "init": "$recursionContext.result = @{ changes = @{} }",
+        "reduceToOutput": "$recursionContext.result.changes",
+        "actCondition": "$true"
+    },
+    "prepare": [],
+    "act": [
+        {
+            "id": "simplify",
+            "type": "simplify-upstream",
+            "parameters": {
+                "upstreamBranches": ["$params.upstream"],
+                "overrideUpstreams": "$params.override",
+                "branchName": "$params.current"
+            }
+        },
+        {
+            "type": "evaluate",
+            "condition": "$true -AND ([string[]]$params.original -join ',') -ne ([string[]]$actions.simplify.outputs -join ',')",
+            "parameters": {
+                "result": "$recursionContext.result.changes[$params.current] = $actions.simplify.outputs"
+            }
+        }
+    ]
+}

--- a/git-refactor-upstream.loop.2.json
+++ b/git-refactor-upstream.loop.2.json
@@ -18,7 +18,7 @@
         },
         {
             "type": "evaluate",
-            "condition": "$true -AND ([string[]]$params.original -join ',') -ne ([string[]]$actions.simplify.outputs -join ',')",
+            "condition": "$params.upstream -AND ([string[]]$params.original -join ',') -ne ([string[]]$actions.simplify.outputs -join ',')",
             "parameters": {
                 "result": "$recursionContext.result.changes[$params.current] = $actions.simplify.outputs"
             }

--- a/git-refactor-upstream.loop.json
+++ b/git-refactor-upstream.loop.json
@@ -1,0 +1,32 @@
+{
+    "recursion": {
+        "paramScript": ["@()"],
+        "init": "$recursionContext.result = @{ changes = @{} }",
+        "reduceToOutput": "$recursionContext.result.changes",
+        "actCondition": "[string[]]($params.upstream) -contains $params.source"
+    },
+    "prepare": [],
+    "act": [
+        {
+            "id": "filter",
+            "type": "filter-branches",
+            "parameters": {
+                "include": ["$params.upstream", "$params.target"],
+                "exclude": ["$params.source", "$params.current"]
+            }
+        },
+        {
+            "id": "simplify",
+            "type": "simplify-upstream",
+            "parameters": {
+                "upstreamBranches": ["$actions.filter.outputs ?? @()"]
+            }
+        },
+        {
+            "type": "evaluate",
+            "parameters": {
+                "result": "$recursionContext.result.changes[$params.current] = $actions.simplify.outputs"
+            }
+        }
+    ]
+}

--- a/git-refactor-upstream.ps1
+++ b/git-refactor-upstream.ps1
@@ -5,6 +5,7 @@ Param(
     [Parameter(Mandatory)][string] $target,
     [switch] $rename,
     [switch] $remove,
+    [Parameter()][Alias('message')][Alias('m')][string] $comment,
     [switch] $dryRun
 )
 
@@ -16,4 +17,5 @@ Invoke-JsonScript -scriptPath "$PSScriptRoot/git-refactor-upstream.json" -params
     target = $target;
     rename = $rename;
     remove = $remove;
+    comment = $comment ?? '';
 } -dryRun:$dryRun

--- a/git-refactor-upstream.ps1
+++ b/git-refactor-upstream.ps1
@@ -4,6 +4,7 @@ Param(
     [Parameter(Mandatory)][string] $source,
     [Parameter(Mandatory)][string] $target,
     [switch] $rename,
+    [switch] $combine,
     [switch] $remove,
     [Parameter()][Alias('message')][Alias('m')][string] $comment,
     [switch] $dryRun
@@ -16,6 +17,7 @@ Invoke-JsonScript -scriptPath "$PSScriptRoot/git-refactor-upstream.json" -params
     source = $source;
     target = $target;
     rename = $rename;
+    combine = $combine;
     remove = $remove;
     comment = $comment ?? '';
 } -dryRun:$dryRun

--- a/git-refactor-upstream.ps1
+++ b/git-refactor-upstream.ps1
@@ -1,0 +1,19 @@
+#!/usr/bin/env pwsh
+
+Param(
+    [Parameter(Mandatory)][string] $source,
+    [Parameter(Mandatory)][string] $target,
+    [switch] $rename,
+    [switch] $remove,
+    [switch] $dryRun
+)
+
+Import-Module -Scope Local "$PSScriptRoot/utils/input.psm1"
+Import-Module -Scope Local "$PSScriptRoot/utils/scripting.psm1"
+
+Invoke-JsonScript -scriptPath "$PSScriptRoot/git-refactor-upstream.json" -params @{
+    source = $source;
+    target = $target;
+    rename = $rename;
+    remove = $remove;
+} -dryRun:$dryRun

--- a/git-refactor-upstream.tests.ps1
+++ b/git-refactor-upstream.tests.ps1
@@ -15,6 +15,20 @@ Describe 'git-refactor-upstream' {
         Initialize-UpdateGitRemote
     }
 
+    It 'prevents running if neither remove nor rename are provided' {
+        { & $PSScriptRoot/git-refactor-upstream.ps1 -source 'feature/FOO-123' -target 'main' } | Should -Throw
+
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  Either -rename or -remove must be specfied.'
+        Invoke-VerifyMock $mocks -Times 1
+    }
+
+    It 'prevents running if both remove and rename are provided' {
+        { & $PSScriptRoot/git-refactor-upstream.ps1 -source 'feature/FOO-123' -target 'main' -remove -rename } | Should -Throw
+
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  Only one of -rename and -remove may be specified.'
+        Invoke-VerifyMock $mocks -Times 1
+    }
+
     It 'can consolidate a released branch (feature/FOO-123) into main' {
         $mocks = @(
             Initialize-AllUpstreamBranches @{

--- a/git-refactor-upstream.tests.ps1
+++ b/git-refactor-upstream.tests.ps1
@@ -1,0 +1,42 @@
+Describe 'git-refactor-upstream' {
+    BeforeAll {
+        . "$PSScriptRoot/utils/testing.ps1"
+        Import-Module -Scope Local "$PSScriptRoot/utils/framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/utils/input.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/utils/query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/utils/actions.mocks.psm1"
+    }
+    
+    BeforeEach {
+        Initialize-ToolConfiguration
+    }
+
+    It 'can consolidate a released branch (feature/FOO-123) into main' {
+        Initialize-AllUpstreamBranches @{
+            'integrate/FOO-123_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
+            'feature/FOO-124' = @("integrate/FOO-123_XYZ-1")
+            'feature/FOO-123' = @("main")
+            'feature/XYZ-1-services' = @("main")
+            'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
+        }
+    } -Pending
+
+    It 'can consolidate an integration branch (integrate/FOO-123_XYZ-1) into its remaining upstream' {
+        Initialize-AllUpstreamBranches @{
+            'integrate/FOO-123_XYZ-1' = @("feature/XYZ-1-services")
+            'feature/FOO-124' = @("integrate/FOO-123_XYZ-1")
+            'feature/XYZ-1-services' = @("main")
+            'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
+        }
+    } -Pending
+
+    It 'can rename an incorrectly named branch' {
+        Initialize-AllUpstreamBranches @{
+            'integrate/FOO-100_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
+            'feature/FOO-124' = @("integrate/FOO-100_XYZ-1")
+            'feature/FOO-100' = @("main")
+            'feature/XYZ-1-services' = @("main")
+            'rc/1.1.0' = @("integrate/FOO-100_XYZ-1")
+        }
+    } -Pending
+}

--- a/git-refactor-upstream.tests.ps1
+++ b/git-refactor-upstream.tests.ps1
@@ -28,6 +28,7 @@ Describe 'git-refactor-upstream' {
             Initialize-AssertValidBranchName 'main'
             Initialize-LocalActionSimplifyUpstreamBranchesSuccess @('feature/XYZ-1-services', 'main') @('feature/XYZ-1-services')
             Initialize-LocalActionSetUpstream @{
+                'feature/FOO-123' = $null
                 'integrate/FOO-123_XYZ-1' = @("feature/XYZ-1-services")
             } -commitish 'new-commit'
             Initialize-FinalizeActionSetBranches @{
@@ -55,6 +56,7 @@ Describe 'git-refactor-upstream' {
             Initialize-LocalActionSetUpstream @{
                 'feature/FOO-124' = @("feature/XYZ-1-services")
                 'rc/1.1.0' = @("feature/XYZ-1-services")
+                'integrate/FOO-123_XYZ-1' = @()
             } -commitish 'new-commit'
             Initialize-FinalizeActionSetBranches @{
                 _upstream = 'new-commit'
@@ -80,6 +82,8 @@ Describe 'git-refactor-upstream' {
             Initialize-AssertValidBranchName 'integrate/FOO-123_XYZ-1'
             Initialize-LocalActionSimplifyUpstreamBranchesSuccess @('integrate/FOO-123_XYZ-1') @('integrate/FOO-123_XYZ-1')
             Initialize-LocalActionSetUpstream @{
+                'integrate/FOO-123_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
+                'integrate/FOO-100_XYZ-1' = @()
                 'feature/FOO-124' = @("integrate/FOO-123_XYZ-1")
                 'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
             } -commitish 'new-commit'

--- a/git-refactor-upstream.tests.ps1
+++ b/git-refactor-upstream.tests.ps1
@@ -6,7 +6,7 @@ Describe 'git-refactor-upstream' {
         Import-Module -Scope Local "$PSScriptRoot/utils/query-state.mocks.psm1"
         Import-Module -Scope Local "$PSScriptRoot/utils/actions.mocks.psm1"
     }
-    
+
     BeforeEach {
         Initialize-ToolConfiguration
     }
@@ -19,6 +19,11 @@ Describe 'git-refactor-upstream' {
             'feature/XYZ-1-services' = @("main")
             'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
         }
+
+        & $PSScriptRoot/git-refactor-upstream.ps1 -source 'feature/FOO-123' -target 'main' -remove
+
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        # Invoke-VerifyMock $mocks -Times 1
     } -Pending
 
     It 'can consolidate an integration branch (integrate/FOO-123_XYZ-1) into its remaining upstream' {
@@ -28,15 +33,25 @@ Describe 'git-refactor-upstream' {
             'feature/XYZ-1-services' = @("main")
             'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
         }
+
+        & $PSScriptRoot/git-refactor-upstream.ps1 -source 'integrate/FOO-123_XYZ-1' -target 'feature/XYZ-1-services' -remove
+        
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        # Invoke-VerifyMock $mocks -Times 1
     } -Pending
 
     It 'can rename an incorrectly named branch' {
         Initialize-AllUpstreamBranches @{
             'integrate/FOO-100_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
             'feature/FOO-124' = @("integrate/FOO-100_XYZ-1")
-            'feature/FOO-100' = @("main")
+            'feature/FOO-123' = @("main")
             'feature/XYZ-1-services' = @("main")
             'rc/1.1.0' = @("integrate/FOO-100_XYZ-1")
         }
+
+        & $PSScriptRoot/git-refactor-upstream.ps1 -source 'integrate/FOO-100_XYZ-1' -target 'integrate/FOO-123_XYZ-1' -rename
+        
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        # Invoke-VerifyMock $mocks -Times 1
     } -Pending
 }

--- a/git-refactor-upstream.tests.ps1
+++ b/git-refactor-upstream.tests.ps1
@@ -95,9 +95,6 @@ Describe 'git-refactor-upstream' {
             }
             Initialize-AssertValidBranchName 'integrate/FOO-100_XYZ-1'
             Initialize-AssertValidBranchName 'integrate/FOO-123_XYZ-1'
-            Initialize-AssertValidBranchName 'main'
-            Initialize-AssertValidBranchName 'feature/FOO-123'
-            Initialize-AssertValidBranchName 'feature/XYZ-1-services'
             Initialize-LocalActionSetUpstream @{
                 'integrate/FOO-123_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
                 'integrate/FOO-100_XYZ-1' = @()
@@ -116,7 +113,7 @@ Describe 'git-refactor-upstream' {
     }
 
     Describe 'Advanced use-cases' {
-        It 'simplifies other branches' {
+        It 'simplifies other downstream branches' {
             $mocks = @(
                 Initialize-AllUpstreamBranches @{
                     'feature/FOO-125' = @("feature/FOO-124", "main")
@@ -138,31 +135,6 @@ Describe 'git-refactor-upstream' {
             & $PSScriptRoot/git-refactor-upstream.ps1 -source 'feature/FOO-123' -target 'main' -remove
             
             $fw.assertDiagnosticOutput | Should -Contain "WARN: Removing 'main' from upstream branches of 'feature/FOO-125'; it is redundant via the following: feature/FOO-124"
-            Invoke-VerifyMock $mocks -Times 1
-        }
-
-        It 'works if an upstream is registered but empty' {
-            $mocks = @(
-                Initialize-AllUpstreamBranches @{
-                    'feature/FOO-123' = @("main")
-                    'feature/FOO-124' = @("feature/FOO-123")
-                    'other' = @()
-                }
-                Initialize-AssertValidBranchName 'feature/FOO-123'
-                Initialize-AssertValidBranchName 'main'
-                Initialize-LocalActionSetUpstream @{
-                    'feature/FOO-123' = $null
-                    'feature/FOO-124' = @("main")
-                    'other' = @("main")
-                } -commitish 'new-commit'
-                Initialize-FinalizeActionSetBranches @{
-                    _upstream = 'new-commit'
-                }
-            )
-
-            & $PSScriptRoot/git-refactor-upstream.ps1 -source 'feature/FOO-123' -target 'main' -remove
-            
-            $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
             Invoke-VerifyMock $mocks -Times 1
         }
 

--- a/git-refactor-upstream.tests.ps1
+++ b/git-refactor-upstream.tests.ps1
@@ -8,50 +8,89 @@ Describe 'git-refactor-upstream' {
     }
 
     BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+
         Initialize-ToolConfiguration
+        Initialize-UpdateGitRemote
     }
 
     It 'can consolidate a released branch (feature/FOO-123) into main' {
-        Initialize-AllUpstreamBranches @{
-            'integrate/FOO-123_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
-            'feature/FOO-124' = @("integrate/FOO-123_XYZ-1")
-            'feature/FOO-123' = @("main")
-            'feature/XYZ-1-services' = @("main")
-            'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
-        }
+        $mocks = @(
+            Initialize-AllUpstreamBranches @{
+                'integrate/FOO-123_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
+                'feature/FOO-124' = @("integrate/FOO-123_XYZ-1")
+                'feature/FOO-123' = @("main")
+                'feature/XYZ-1-services' = @("main")
+                'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
+            }
+            Initialize-AssertValidBranchName 'feature/FOO-123'
+            Initialize-AssertValidBranchName 'main'
+            Initialize-LocalActionSimplifyUpstreamBranchesSuccess @('feature/XYZ-1-services', 'main') @('feature/XYZ-1-services')
+            Initialize-LocalActionSetUpstream @{
+                'integrate/FOO-123_XYZ-1' = @("feature/XYZ-1-services")
+            } -commitish 'new-commit'
+            Initialize-FinalizeActionSetBranches @{
+                _upstream = 'new-commit'
+            }
+        )
 
         & $PSScriptRoot/git-refactor-upstream.ps1 -source 'feature/FOO-123' -target 'main' -remove
 
         $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
-        # Invoke-VerifyMock $mocks -Times 1
-    } -Pending
+        Invoke-VerifyMock $mocks -Times 1
+    }
 
     It 'can consolidate an integration branch (integrate/FOO-123_XYZ-1) into its remaining upstream' {
-        Initialize-AllUpstreamBranches @{
-            'integrate/FOO-123_XYZ-1' = @("feature/XYZ-1-services")
-            'feature/FOO-124' = @("integrate/FOO-123_XYZ-1")
-            'feature/XYZ-1-services' = @("main")
-            'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
-        }
+        $mocks = @(
+            Initialize-AllUpstreamBranches @{
+                'integrate/FOO-123_XYZ-1' = @("feature/XYZ-1-services")
+                'feature/FOO-124' = @("integrate/FOO-123_XYZ-1")
+                'feature/XYZ-1-services' = @("main")
+                'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
+            }
+            Initialize-AssertValidBranchName 'integrate/FOO-123_XYZ-1'
+            Initialize-AssertValidBranchName 'feature/XYZ-1-services'
+            Initialize-LocalActionSimplifyUpstreamBranchesSuccess @('feature/XYZ-1-services') @('feature/XYZ-1-services')
+            Initialize-LocalActionSetUpstream @{
+                'feature/FOO-124' = @("feature/XYZ-1-services")
+                'rc/1.1.0' = @("feature/XYZ-1-services")
+            } -commitish 'new-commit'
+            Initialize-FinalizeActionSetBranches @{
+                _upstream = 'new-commit'
+            }
+        )
 
         & $PSScriptRoot/git-refactor-upstream.ps1 -source 'integrate/FOO-123_XYZ-1' -target 'feature/XYZ-1-services' -remove
         
         $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
-        # Invoke-VerifyMock $mocks -Times 1
-    } -Pending
+        Invoke-VerifyMock $mocks -Times 1
+    }
 
     It 'can rename an incorrectly named branch' {
-        Initialize-AllUpstreamBranches @{
-            'integrate/FOO-100_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
-            'feature/FOO-124' = @("integrate/FOO-100_XYZ-1")
-            'feature/FOO-123' = @("main")
-            'feature/XYZ-1-services' = @("main")
-            'rc/1.1.0' = @("integrate/FOO-100_XYZ-1")
-        }
+        $mocks = @(
+            Initialize-AllUpstreamBranches @{
+                'integrate/FOO-100_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
+                'feature/FOO-124' = @("integrate/FOO-100_XYZ-1")
+                'feature/FOO-123' = @("main")
+                'feature/XYZ-1-services' = @("main")
+                'rc/1.1.0' = @("integrate/FOO-100_XYZ-1")
+            }
+            Initialize-AssertValidBranchName 'integrate/FOO-100_XYZ-1'
+            Initialize-AssertValidBranchName 'integrate/FOO-123_XYZ-1'
+            Initialize-LocalActionSimplifyUpstreamBranchesSuccess @('integrate/FOO-123_XYZ-1') @('integrate/FOO-123_XYZ-1')
+            Initialize-LocalActionSetUpstream @{
+                'feature/FOO-124' = @("integrate/FOO-123_XYZ-1")
+                'rc/1.1.0' = @("integrate/FOO-123_XYZ-1")
+            } -commitish 'new-commit'
+            Initialize-FinalizeActionSetBranches @{
+                _upstream = 'new-commit'
+            }
+        )
 
         & $PSScriptRoot/git-refactor-upstream.ps1 -source 'integrate/FOO-100_XYZ-1' -target 'integrate/FOO-123_XYZ-1' -rename
         
         $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
-        # Invoke-VerifyMock $mocks -Times 1
-    } -Pending
+        Invoke-VerifyMock $mocks -Times 1
+    }
 }

--- a/init.ps1
+++ b/init.ps1
@@ -38,6 +38,9 @@ git config alias.rebuild-rc "!$dir/git-rebuild-rc.ps1"
 # Verify that a branch has all of its upstream up-to-date
 git config alias.verify-updated "!$dir/git-verify-updated.ps1"
 
+# Refactor upstream branches to redirect upstreams from "source" to "target"
+git config alias.refactor-upstream "!$dir/git-refactor-upstream.ps1"
+
 # Release an RC branch to a service line
 git config alias.release "!$dir/git-release.ps1"
 

--- a/reset.ps1
+++ b/reset.ps1
@@ -1,6 +1,9 @@
 # Useful for development to reset all of our modules
 
-Get-Module -All | Where-Object { $_.Path.StartSwith($PSScriptRoot) } | ForEach-Object {
-    Write-Host "Unloading $($_.Name)..."
-    Remove-Module $_.Name -Force
+Get-Module -All | Where-Object { $_.Path.StartsWith($PSScriptRoot) } | ForEach-Object {
+    $current = $_
+    if ($null -ne (Get-Module -All | Where-Object { $_.Name -eq $current.Name })) {
+        Write-Host "Unloading $($_.Name)..."
+        Remove-Module $_.Name -Force
+    }
 }

--- a/utils/actions/local/Register-LocalActionEvaluate.psm1
+++ b/utils/actions/local/Register-LocalActionEvaluate.psm1
@@ -5,7 +5,7 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 function Register-LocalActionEvaluate([PSObject] $localActions) {
     $localActions['evaluate'] = {
         param(
-            [Parameter(Mandatory)][object] $result,
+            [Parameter(Mandatory)][AllowNull()][object] $result,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
         

--- a/utils/actions/local/Register-LocalActionFilterBranches.psm1
+++ b/utils/actions/local/Register-LocalActionFilterBranches.psm1
@@ -12,7 +12,7 @@ function Register-LocalActionFilterBranches([PSObject] $localActions) {
         )
 
         
-        [string[]]$result = $include | Where-Object { $_ -notin $exclude }
+        [string[]]$result = $include | Where-Object { $_ -notin $exclude } | Get-Unique
         
         return $result
     }

--- a/utils/actions/local/Register-LocalActionFilterBranches.psm1
+++ b/utils/actions/local/Register-LocalActionFilterBranches.psm1
@@ -12,7 +12,7 @@ function Register-LocalActionFilterBranches([PSObject] $localActions) {
         )
 
         
-        [string[]]$result = $include | Where-Object { $_ -notin $exclude } | Get-Unique
+        [string[]]$result = $include | Where-Object { $_ } | Where-Object { $_ -notin $exclude } | Get-Unique
         
         return $result
     }

--- a/utils/actions/local/Register-LocalActionGetAllUpstreams.psm1
+++ b/utils/actions/local/Register-LocalActionGetAllUpstreams.psm1
@@ -5,10 +5,11 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 function Register-LocalActionGetAllUpstreams([PSObject] $localActions) {
     $localActions['get-all-upstreams'] = {
         param(
+            [Parameter()][AllowNull()] $overrideUpstreams,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
         
-        return Select-AllUpstreamBranches
+        return Select-AllUpstreamBranches -overrideUpstreams:$overrideUpstreams
     }
 }
 

--- a/utils/actions/local/Register-LocalActionGetAllUpstreams.tests.ps1
+++ b/utils/actions/local/Register-LocalActionGetAllUpstreams.tests.ps1
@@ -49,4 +49,45 @@ Describe 'local action "get-all-upstreams"' {
         $results['rc/1.1.0'] | Should -Contain "feature/FOO-123"
         $results['rc/1.1.0'] | Should -Contain "feature/XYZ-1-services"
     }
+    
+    It 'can override upstreams' {
+        Initialize-AllUpstreamBranches @{
+            'integrate/FOO-123_XYZ-1' = @("feature/FOO-123", "feature/XYZ-1-services")
+            'feature/FOO-124' = @("feature/FOO-123")
+            'feature/FOO-123' = @("main")
+            'feature/XYZ-1-services' = @("main")
+            'rc/1.1.0' = @("feature/FOO-123", "feature/XYZ-1-services")
+
+            'bad-recursive-branch-1' = @('bad-recursive-branch-2')
+            'bad-recursive-branch-2' = @('bad-recursive-branch-1')
+        }
+        $script = ('{ 
+            "type": "get-all-upstreams", 
+            "parameters": {
+                "overrideUpstreams": {
+                    "feature/FOO-123": "infra/new",
+                    "infra/new": "main"
+                }
+            }
+        }' | ConvertFrom-Json)
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+
+        $results = Invoke-LocalAction $script -diagnostics $fw.diagnostics
+
+        $results.Keys | Should -Contain 'integrate/FOO-123_XYZ-1'
+        $results.Keys | Should -Contain 'feature/FOO-124'
+        $results.Keys | Should -Contain 'feature/FOO-123'
+        $results.Keys | Should -Contain 'feature/XYZ-1-services'
+        $results.Keys | Should -Contain 'rc/1.1.0'
+        $results.Keys | Should -Contain 'bad-recursive-branch-1'
+        $results.Keys | Should -Contain 'bad-recursive-branch-2'
+        $results.Keys | Should -Contain 'infra/new'
+        $results['rc/1.1.0'] | Should -Contain "feature/FOO-123"
+        $results['rc/1.1.0'] | Should -Contain "feature/XYZ-1-services"
+        $results['feature/FOO-123'] | Should -Contain "infra/new"
+        $results['feature/FOO-123'] | Should -Not -Contain "main"
+        $results['infra/new'] | Should -Contain "main"
+    }
 }

--- a/utils/actions/local/Register-LocalActionGetDownstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetDownstream.psm1
@@ -6,11 +6,12 @@ function Register-LocalActionGetDownstream([PSObject] $localActions) {
     $localActions['get-downstream'] = {
         param(
             [Parameter(Mandatory)][string] $target,
+            [Parameter()][AllowNull()] $overrideUpstreams,
             [switch] $recurse,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
-        [string[]]$result = Select-DownstreamBranches -branchName $target -recurse:$recurse
+        [string[]]$result = Select-DownstreamBranches -branchName $target -recurse:$recurse -overrideUpstreams:$overrideUpstreams
 
         return $result
     }

--- a/utils/actions/local/Register-LocalActionGetDownstream.tests.ps1
+++ b/utils/actions/local/Register-LocalActionGetDownstream.tests.ps1
@@ -58,4 +58,22 @@ Describe 'local action "get-downstream"' {
         $result | Should -Contain 'feature/FOO-124'
         $result | Should -Contain 'rc/1.1.0'
     }
+
+    It 'gets downstream branches with overrides' {
+        [string[]]$result = Invoke-LocalAction ('{
+            "type": "get-downstream", 
+            "parameters": {
+                "target": "infra/new",
+                "overrideUpstreams": {
+                    "feature/FOO-123": "infra/new",
+                    "infra/new": "main"
+                }
+            }
+        }' | ConvertFrom-Json) -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+        $result.Length | Should -Be 1
+        $result | Should -Contain 'feature/FOO-123'
+    }
 }

--- a/utils/actions/local/Register-LocalActionGetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.psm1
@@ -6,12 +6,13 @@ function Register-LocalActionGetUpstream([PSObject] $localActions) {
     $localActions['get-upstream'] = {
         param(
             [Parameter(Mandatory)][string] $target,
+            [Parameter()][AllowNull()] $overrideUpstreams,
             [switch] $recurse,
             [switch] $includeRemote,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
-        [string[]]$result = Select-UpstreamBranches -branchName $target -recurse:$recurse -includeRemote:$includeRemote
+        [string[]]$result = Select-UpstreamBranches -branchName $target -recurse:$recurse -includeRemote:$includeRemote -overrideUpstreams:$overrideUpstreams
         
         return $result
     }

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -134,6 +134,12 @@ function Invoke-Prepare(
     for ($i = 0; $i -lt $prepareScripts.Count; $i++) {
         $name = $prepareScripts[$i].id ?? "#$($i + 1) (1-based)";
         $variables = @{ config=$config; params=$params; actions=$actions; recursionContext=$recursionContext }
+        if ($prepareScripts[$i].condition) {
+            $condition = ConvertFrom-ParameterizedAnything -script $prepareScripts[$i].condition -variables $variables -diagnostics $diagnostics
+            if (-not $condition.fail -AND -not $condition.result) {
+                continue;
+            }
+        }
         $local = ConvertFrom-ParameterizedAnything -script $prepareScripts[$i] -variables $variables -diagnostics $diagnostics
         if ($local.fail) {
             Add-ErrorDiagnostic $diagnostics "Could not apply parameters to recursive prepare (local) action $name; see above errors. Evaluation below:"
@@ -171,6 +177,12 @@ function Invoke-Act(
     for ($i = 0; $i -lt $actScripts.Count; $i++) {
         $name = $actScripts[$i].id ?? "#$($i + 1) (1-based)";
         $variables = @{ config=$config; params=$params; actions=$actions; recursionContext=$recursionContext }
+        if ($actScripts[$i].condition) {
+            $condition = ConvertFrom-ParameterizedAnything -script $actScripts[$i].condition -variables $variables -diagnostics $diagnostics
+            if (-not $condition.fail -AND -not $condition.result) {
+                continue;
+            }
+        }
         $local = ConvertFrom-ParameterizedAnything -script $actScripts[$i] -variables $variables -diagnostics $diagnostics
         if ($local.fail) {
             Add-ErrorDiagnostic $diagnostics "Could not apply parameters to recursive act (local) action $name; see above errors. Evaluation below:"

--- a/utils/actions/local/Register-LocalActionSetUpstream.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.mocks.psm1
@@ -15,7 +15,7 @@ function Initialize-LocalActionSetUpstream([PSObject] $upstreamBranches, [string
         $null -ne $upstreamBranches ? @(
             "`$files.Keys.Count -eq $($upstreamBranches.Keys.Count)"
             ($upstreamBranches.Keys | ForEach-Object {
-                if ($null -eq $upstreamBranches[$_]) {
+                if ($null -eq $upstreamBranches[$_] -OR $upstreamBranches[$_].length -eq 0) {
                     "`$files['$_'] -eq `$null"
                 } else {
                     "`$files['$_'].split(`"``n`").Count -eq $($upstreamBranches[$_].Count + 1)"

--- a/utils/actions/local/Register-LocalActionSetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.psm1
@@ -13,6 +13,7 @@ function Register-LocalActionSetUpstream([PSObject] $localActions) {
         $upstreamBranch = Get-UpstreamBranch
         $ht = ConvertTo-Hashtable $upstreamBranches
         $contents = $ht.Keys | ConvertTo-HashMap -getValue {
+            if ($null -eq $ht[$_] -OR $ht[$_].length -eq 0) { return $null }
             "$(($ht[$_] | Where-Object { $_ }) -join "`n")`n"
         }
         

--- a/utils/actions/local/Register-LocalActionSetUpstream.tests.ps1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.tests.ps1
@@ -115,6 +115,22 @@ Describe 'local action "set-upstream"' {
             $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
             Invoke-VerifyMock $mock -Times 1
         }
+
+        It 'allows a branch to be removed from configuration' {
+            $mock = Initialize-LocalActionSetUpstream  @{ 'foobar' = $null } -message 'Remove foobar' -commitish 'new-COMMIT'
+
+            $result = Invoke-LocalAction ('{ 
+                "type": "set-upstream", 
+                "parameters": {
+                    "message": "Remove foobar",
+                    "upstreamBranches": {
+                        "foobar": null
+                    }
+                }
+            }' | ConvertFrom-Json) -diagnostics $diag
+            $result | Assert-ShouldBeObject @{ commit = 'new-COMMIT' }
+            Invoke-VerifyMock $mock -Times 1
+        }
     }
 
     Context 'without remote' {

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -8,6 +8,7 @@ function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) 
         param(
             [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $upstreamBranches,
             [Parameter()][AllowNull()] $overrideUpstreams,
+            [Parameter()][AllowNull()][string] $branchName,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
         
@@ -23,7 +24,7 @@ function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) 
             return @( $config.defaultServiceLine )
         }
 
-        $result = Compress-UpstreamBranches $upstreamBranches -diagnostics $diagnostics -overrideUpstreams:$overrideUpstreams
+        $result = Compress-UpstreamBranches $upstreamBranches -diagnostics:$diagnostics -overrideUpstreams:$overrideUpstreams -branchName:$branchName
         return $result
     }
 }

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -6,13 +6,16 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) {
     $localActions['simplify-upstream'] = {
         param(
-            [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $upstreamBranches,
+            [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][string[]] $upstreamBranches,
             [Parameter()][AllowNull()] $overrideUpstreams,
             [Parameter()][AllowNull()][string] $branchName,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
-        
-        $upstreamBranches | Assert-ValidBranchName -diagnostics $diagnostics
+
+        $upstreamBranches = $upstreamBranches | Where-Object { $_ }
+        if ($upstreamBranches.Count -ne 0) {
+            $upstreamBranches | Assert-ValidBranchName -diagnostics $diagnostics
+        }
         if (Get-HasErrorDiagnostic $diagnostics) { return $null }
 
         if ($upstreamBranches.Count -eq 0) {

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -7,6 +7,7 @@ function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) 
     $localActions['simplify-upstream'] = {
         param(
             [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $upstreamBranches,
+            [Parameter()][AllowNull()] $overrideUpstreams,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
         
@@ -22,7 +23,7 @@ function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) 
             return @( $config.defaultServiceLine )
         }
 
-        $result = Compress-UpstreamBranches $upstreamBranches -diagnostics $diagnostics
+        $result = Compress-UpstreamBranches $upstreamBranches -diagnostics $diagnostics -overrideUpstreams:$overrideUpstreams
         return $result
     }
 }

--- a/utils/actions/local/Register-LocalActionUpstreamsUpdated.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionUpstreamsUpdated.mocks.psm1
@@ -11,8 +11,13 @@ function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
 function Initialize-LocalActionUpstreamsUpdated(
     [Parameter()][AllowEmptyCollection()][string[]] $upToDate,
     [Parameter()][Hashtable] $outOfDate,
+    [Parameter()][AllowNull()] $overrideUpstreams,
     [switch] $recurse
 ) {
+    $selectStandardParams = @{
+        recurse = $recurse
+        overrideUpstreams = $overrideUpstreams
+    }
 
     $config = Get-Configuration
     $prefix = $config.remote ? "refs/remotes/$($config.remote)" : "refs/heads/"
@@ -20,7 +25,7 @@ function Initialize-LocalActionUpstreamsUpdated(
     $branches = ($upToDate + $outOfDate.Keys) | Where-Object { $_ }
     if ($null -eq $branches) { return }
     foreach ($branch in $branches) {
-        $upstreams = Select-UpstreamBranches -branch $branch -recurse:$recurse
+        $upstreams = Select-UpstreamBranches -branch $branch @selectStandardParams
         $target = "$prefix/$branch"
         $fullyQualifiedUpstreams = $upstreams | ForEach-Object { "$prefix/$_" }
 

--- a/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
@@ -3,13 +3,19 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionUpstreamsUpdated([PSObject] $localActions) {
+    # Checks to see if the upstreams are up-to-date
     $localActions['upstreams-updated'] = {
         param(
             [Parameter()][AllowEmptyCollection()][string[]] $branches,
+            [Parameter()][AllowNull()] $overrideUpstreams,
             [Parameter()][bool] $recurse = $false,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
+        $selectStandardParams = @{
+            recurse = $recurse
+            overrideUpstreams = $overrideUpstreams
+        }
         $config = Get-Configuration
         $prefix = $config.remote ? "refs/remotes/$($config.remote)" : "refs/heads/"
 
@@ -17,7 +23,7 @@ function Register-LocalActionUpstreamsUpdated([PSObject] $localActions) {
         $isUpdated = @()
         $noUpstreams = @()
         foreach ($branch in $branches) {
-            $upstreams = Select-UpstreamBranches -branch $branch -recurse:$recurse
+            $upstreams = Select-UpstreamBranches -branch $branch @selectStandardParams
             if (-not $upstreams) {
                 $noUpstreams += $branch
                 continue

--- a/utils/query-state/Compress-UpstreamBranches.psm1
+++ b/utils/query-state/Compress-UpstreamBranches.psm1
@@ -4,10 +4,11 @@ Import-Module -Scope Local "$PSScriptRoot/Select-UpstreamBranches.psm1"
 
 function Compress-UpstreamBranches(
     [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $originalUpstream,
+    [Parameter()][AllowNull()] $overrideUpstreams,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
 ) {
     $allUpstream = $originalUpstream | ConvertTo-HashMap -getValue {
-        return ([string[]](Select-UpstreamBranches $_ -recurse))
+        return ([string[]](Select-UpstreamBranches $_ -recurse -overrideUpstreams:$overrideUpstreams))
     }
     $resultUpstream = [System.Collections.ArrayList]$originalUpstream
     for ($i = 0; $i -lt $resultUpstream.Count; $i++) {

--- a/utils/query-state/Compress-UpstreamBranches.psm1
+++ b/utils/query-state/Compress-UpstreamBranches.psm1
@@ -5,6 +5,7 @@ Import-Module -Scope Local "$PSScriptRoot/Select-UpstreamBranches.psm1"
 function Compress-UpstreamBranches(
     [Parameter(Mandatory)][AllowEmptyCollection()][string[]] $originalUpstream,
     [Parameter()][AllowNull()] $overrideUpstreams,
+    [Parameter()][AllowNull()][string] $branchName,
     [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
 ) {
     $allUpstream = $originalUpstream | ConvertTo-HashMap -getValue {
@@ -15,7 +16,11 @@ function Compress-UpstreamBranches(
         $branch = $resultUpstream[$i]
         $alreadyContainedBy = ($resultUpstream | Where-Object { $_ -ne $branch -AND $allUpstream[$_] -contains $branch })
         if ($alreadyContainedBy -ne $nil) {
-            Add-WarningDiagnostic $diagnostics "Removing '$branch' from branches; it is redundant via the following: $alreadyContainedBy"
+            if (-not $branchName) {
+                Add-WarningDiagnostic $diagnostics "Removing '$branch' from branches; it is redundant via the following: $alreadyContainedBy"
+            } else {
+                Add-WarningDiagnostic $diagnostics "Removing '$branch' from upstream branches of '$branchName'; it is redundant via the following: $alreadyContainedBy"
+            }
             # $branch is in the recursive upstream of at least one other branch
             $resultUpstream.Remove($branch)
             $i--

--- a/utils/query-state/Compress-UpstreamBranches.tests.ps1
+++ b/utils/query-state/Compress-UpstreamBranches.tests.ps1
@@ -69,6 +69,11 @@ Describe 'Compress-UpstreamBranches' {
             Should -ActualValue (Get-DiagnosticStrings -diagnostics:$diag) -Be @("WARN: Removing 'feature/XYZ-1-services' from branches; it is redundant via the following: my-branch")
         }
 
+        It 'reduces redundant branches with a named branch' {
+            Compress-UpstreamBranches @("my-branch", "feature/XYZ-1-services") -diagnostics:$diag -branchName:'feature/ABC' | Should -Be @("my-branch")
+            Should -ActualValue (Get-DiagnosticStrings -diagnostics:$diag) -Be @("WARN: Removing 'feature/XYZ-1-services' from upstream branches of 'feature/ABC'; it is redundant via the following: my-branch")
+        }
+
         It 'allows an empty list' {
             Compress-UpstreamBranches @() -diagnostics:$diag | Should -Be @()
             Should -ActualValue (Get-DiagnosticStrings $diag) -Be @()

--- a/utils/query-state/Compress-UpstreamBranches.tests.ps1
+++ b/utils/query-state/Compress-UpstreamBranches.tests.ps1
@@ -47,29 +47,35 @@ Describe 'Compress-UpstreamBranches' {
         Compress-UpstreamBranches @('bad-recursive-branch-1', 'bad-recursive-branch-2') | Should -Be @('bad-recursive-branch-2')
     }
 
+    It 'allows overrides' {
+        Compress-UpstreamBranches @("feature/FOO-123", "feature/XYZ-1-services") -overrideUpstreams @{
+            'feature/FOO-123' = 'feature/XYZ-1-services'
+        } | Should -Be @("feature/FOO-123")
+    }
+
     Context 'with diagnostics' {
         It 'can handle a flat string' {
-            Compress-UpstreamBranches my-branch $diag | Should -Be @( 'my-branch' )
+            Compress-UpstreamBranches my-branch -diagnostics:$diag | Should -Be @( 'my-branch' )
             Should -ActualValue (Get-DiagnosticStrings $diag) -Be @()
         }
 
         It 'does not reduce any if none can be reduced' {
-            Compress-UpstreamBranches @("feature/FOO-123", "feature/XYZ-1-services") $diag | Should -Be @("feature/FOO-123", "feature/XYZ-1-services")
+            Compress-UpstreamBranches @("feature/FOO-123", "feature/XYZ-1-services") -diagnostics:$diag | Should -Be @("feature/FOO-123", "feature/XYZ-1-services")
             Should -ActualValue (Get-DiagnosticStrings $diag) -Be @()
         }
 
         It 'reduces redundant branches' {
-            Compress-UpstreamBranches @("my-branch", "feature/XYZ-1-services") $diag | Should -Be @("my-branch")
-            Should -ActualValue (Get-DiagnosticStrings $diag) -Be @("WARN: Removing 'feature/XYZ-1-services' from branches; it is redundant via the following: my-branch")
+            Compress-UpstreamBranches @("my-branch", "feature/XYZ-1-services") -diagnostics:$diag | Should -Be @("my-branch")
+            Should -ActualValue (Get-DiagnosticStrings -diagnostics:$diag) -Be @("WARN: Removing 'feature/XYZ-1-services' from branches; it is redundant via the following: my-branch")
         }
 
         It 'allows an empty list' {
-            Compress-UpstreamBranches @() $diag | Should -Be @()
+            Compress-UpstreamBranches @() -diagnostics:$diag | Should -Be @()
             Should -ActualValue (Get-DiagnosticStrings $diag) -Be @()
         }
 
         It 'does not eliminate all recursive branches' {
-            Compress-UpstreamBranches @('bad-recursive-branch-1', 'bad-recursive-branch-2') $diag | Should -Be @('bad-recursive-branch-2')
+            Compress-UpstreamBranches @('bad-recursive-branch-1', 'bad-recursive-branch-2') -diagnostics:$diag | Should -Be @('bad-recursive-branch-2')
             Should -ActualValue (Get-DiagnosticStrings $diag) -Be @("WARN: Removing 'bad-recursive-branch-1' from branches; it is redundant via the following: bad-recursive-branch-2")
         }
 

--- a/utils/query-state/Select-AllUpstreamBranches.psm1
+++ b/utils/query-state/Select-AllUpstreamBranches.psm1
@@ -7,12 +7,23 @@ Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
 # allUpstreams is a hashmap where the key is the git working directory and 
 $allUpstreams = @{}
 
-function Select-AllUpstreamBranches([switch]$refresh) {
+function Select-Override(
+	[Parameter(Mandatory)][System.Collections.Hashtable] $first,
+	[Parameter(Mandatory)][System.Collections.Hashtable] $second) {
+
+	$result = $first + @{}
+	foreach ($key in $second.Keys) {
+		$result[$key] = $second[$key]
+	}
+	return $result
+}
+
+function Select-AllUpstreamBranches([switch]$refresh, [Parameter()][AllowNull()] $overrideUpstreams) {
 	$workDir = Invoke-ProcessLogs "git rev-parse --show-toplevel" {
 		git rev-parse --show-toplevel
 	} -allowSuccessOutput
 	if ($allUpstreams[$workDir] -AND -not $refresh) {
-		return $allUpstreams[$workDir]
+		return $overrideUpstreams ? (Select-Override -first $allUpstreams[$workDir] -second (ConvertTo-Hashtable $overrideUpstreams)) : $allUpstreams[$workDir]
 	}
 
 	$nodes = $allUpstreams[$workDir] = @{}
@@ -52,7 +63,7 @@ function Select-AllUpstreamBranches([switch]$refresh) {
 		}
 	}
 
-	return $nodes
+	return $overrideUpstreams ? (Select-Override -first $nodes -second (ConvertTo-Hashtable $overrideUpstreams)) : $nodes
 }
 
 function Clear-AllUpstreamBranchCache([string] $workDir) {

--- a/utils/query-state/Select-AllUpstreamBranches.tests.ps1
+++ b/utils/query-state/Select-AllUpstreamBranches.tests.ps1
@@ -64,4 +64,27 @@ Describe 'Select-AllUpstreamBranches' {
             Invoke-VerifyMock $mocks -Times 1
         }
     }
+
+    Describe 'at an alternate commit' {
+        BeforeEach {
+            Initialize-ToolConfiguration
+        }
+
+        It 'handles deep folders' {
+            $mocks = Initialize-AllUpstreamBranches @{
+                'rc/1.1.0' = @("feature/FOO-123", "feature/XYZ-1-services")
+                'feature/XYZ-1-services' = @("infra/some-service")
+                'infra/some-service' = @("line/1.0")
+            }
+            $overrideUpstreams = @{
+                'feature/FOO-123' = @("line/1.0")
+                'infra/some-service' = @('main')
+            };
+
+            (Select-AllUpstreamBranches -overrideUpstreams $overrideUpstreams)['feature/FOO-123'] | Should -Be @("line/1.0")
+            (Select-AllUpstreamBranches -overrideUpstreams $overrideUpstreams)['feature/XYZ-1-services'] | Should -Be @("infra/some-service")
+            (Select-AllUpstreamBranches -overrideUpstreams $overrideUpstreams)['infra/some-service'] | Should -Be @("main")
+            Invoke-VerifyMock $mocks -Times 1
+        }
+    }
 }

--- a/utils/query-state/Select-DownstreamBranches.psm1
+++ b/utils/query-state/Select-DownstreamBranches.psm1
@@ -1,8 +1,12 @@
 Import-Module -Scope Local "$PSScriptRoot/Select-AllUpstreamBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
 
-function Select-DownstreamBranches([String]$branchName, [switch] $recurse, [string[]] $exclude) {
-    $all = Select-AllUpstreamBranches
+function Select-DownstreamBranches(
+    [String]$branchName,
+    [switch] $recurse,
+    [string[]] $exclude, 
+    [Parameter()][AllowNull()] $overrideUpstreams) {
+    $all = Select-AllUpstreamBranches -overrideUpstreams:$overrideUpstreams
     $parentBranches = $all.Keys | Where-Object {
         $exclude -notcontains $_
     } | Where-Object {

--- a/utils/query-state/Select-DownstreamBranches.tests.ps1
+++ b/utils/query-state/Select-DownstreamBranches.tests.ps1
@@ -58,4 +58,9 @@ Describe 'Select-DownstreamBranches' {
         $results = Select-DownstreamBranches bad-recursive-branch-1 -recurse
         $results | Should -Be @( 'bad-recursive-branch-2' )
     }
+
+    It 'allows overrides' {
+        $results = Select-DownstreamBranches infra/next -overrideUpstreams @{ 'feature/FOO-123' = 'infra/next' }
+        $results | Should -Be @( 'feature/FOO-123' )
+    }
 }

--- a/utils/query-state/Select-UpstreamBranches.psm1
+++ b/utils/query-state/Select-UpstreamBranches.psm1
@@ -1,9 +1,15 @@
 Import-Module -Scope Local "$PSScriptRoot/Select-AllUpstreamBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
 
-function Select-UpstreamBranches([String]$branchName, [switch] $includeRemote, [switch] $recurse, [string[]] $exclude) {
+function Select-UpstreamBranches(
+    [String]$branchName, 
+    [switch] $includeRemote, 
+    [switch] $recurse, 
+    [string[]] $exclude, 
+    [Parameter()][AllowNull()] $overrideUpstreams
+) {
     $config = Get-Configuration
-    $all = Select-AllUpstreamBranches
+    $all = Select-AllUpstreamBranches -overrideUpstreams:$overrideUpstreams
     $parentBranches = [string[]]($all[$branchName])
 
     $parentBranches = $parentBranches | Where-Object { $exclude -notcontains $_ }

--- a/utils/query-state/Select-UpstreamBranches.tests.ps1
+++ b/utils/query-state/Select-UpstreamBranches.tests.ps1
@@ -73,4 +73,13 @@ Describe 'Select-UpstreamBranches' {
         $results = Select-UpstreamBranches bad-recursive-branch-1 -recurse
         $results | Should -Be @( 'bad-recursive-branch-2' )
     }
+
+    It 'allows overrides' {
+        Initialize-ToolConfiguration
+        Initialize-UpstreamBranches @{
+            'feature/FOO-123' = @("line/1.0")
+        }
+        $results = Select-UpstreamBranches 'feature/FOO-123' -overrideUpstreams @{ 'feature/FOO-123' = @('infra/next') }
+        $results | Should -Be @( 'infra/next' )
+    }
 }

--- a/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
+++ b/utils/scripting/ConvertFrom-ParameterizedAnything.psm1
@@ -24,7 +24,7 @@ function ConvertFrom-ParameterizedAnything(
             $targetScript = New-Closure ([ScriptBlock]::Create('
                 Set-StrictMode -Version 3.0; 
                 try {
-                    @{ result = ' + $script.replace('`', '``').replace('{', '`{').replace('}', '`}').replace(';', '`;') + '; fail = $false }
+                    @{ result = ' + $script + '; fail = $false }
                 } catch {
                     $null
                 }

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -22,7 +22,7 @@ function Invoke-Script(
             if ($local.fail) {
                 Add-ErrorDiagnostic $diagnostics "Could not apply parameters to local action $name; see above errors. Evaluation below:"
                 Add-ErrorDiagnostic $diagnostics "$(ConvertTo-Json $local.result -Depth 10)"
-                break
+                Assert-Diagnostics $diagnostics
             }
             try {
                 $outputs = Invoke-LocalAction $local.result -diagnostics $diagnostics

--- a/utils/scripting/Invoke-Script.psm1
+++ b/utils/scripting/Invoke-Script.psm1
@@ -18,6 +18,12 @@ function Invoke-Script(
         for ($i = 0; $i -lt $script.local.Count; $i++) {
             $name = $script.local[$i].id ?? "#$($i + 1) (1-based)";
             $variables = @{ config=$config; params=$params; actions=$actions }
+            if ($script.local[$i].condition) {
+                $condition = ConvertFrom-ParameterizedAnything -script $script.local[$i].condition -variables $variables -diagnostics $diagnostics
+                if (-not $condition.fail -AND -not $condition.result) {
+                    continue;
+                }
+            }
             $local = ConvertFrom-ParameterizedAnything -script $script.local[$i] -variables $variables -diagnostics $diagnostics
             if ($local.fail) {
                 Add-ErrorDiagnostic $diagnostics "Could not apply parameters to local action $name; see above errors. Evaluation below:"


### PR DESCRIPTION
Adds a `git refactor-upstream` command for adjusting single branches (and their related branches) at a time.

This needed a few other alterations, listed from largest to smallest... these could each be infrastructure branches, but since only one developer works on this repo at a time, I did not go through that effort. I can if that helps with the peer review process:
- Allows the upstream-detecting powershell commands to be overridden via parameters, which allows the JSON scripts to write full-repo refactorings
- Added `condition` checks in scripting before evaluating parameters; some of the `evaluate` blocks have intentional side effects that need to be conditional
- Removed some escaping in `ConvertFrom-ParameterizeAnything` which could allow scripts to return unexpected values... this is already an evaluate and the unexpected values could already be returned.
- Update `filter-branches` to remove false-y branch names and handle uniqueness
- Allow `$null` results in `evaluate` scripts; relevant when pipelines result in empty arrays

And... a few unrelated changes that could be their own PR:
- Fixes the "reset" script to reduce error messages when running it
- Add link to `show-downstream` docs in README