### PR TITLE
Refactor `release` function

### DIFF
--- a/docs/release.md
+++ b/docs/release.md
@@ -2,12 +2,12 @@
 
 Usage:
 
-    git-release.ps1 [-sourceBranch] <string> [-target] <string>
+    git-release.ps1 [-source] <string> [-target] <string>
         [-comment <string>] [-preserve <string[]>] [-dryRun] [-cleanupOnly]
 
 ## Parameters
 
-### `[-sourceBranch] <string>` (Mandatory)
+### `[-source] <string>` (Mandatory)
 
 The name of the branch to "release".
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,7 +3,8 @@
 Usage:
 
     git-release.ps1 [-source] <string> [-target] <string>
-        [-comment <string>] [-preserve <string[]>] [-noFetch] [-dryRun] [-quiet] [-cleanupOnly]
+        [-comment <string>] [-preserve <string[]>] [-cleanupOnly] [-force]
+        [-noFetch] [-dryRun] [-quiet]
 
 ## Parameters
 
@@ -30,6 +31,11 @@ A comma delimited list of branches to preserve in addition to those upstream
 
 Use this flag when the released branch (from `-branchName`) was already merged
 to the target branch (`-target`) to clean up the included branches.
+
+### `-force` (Optional)
+
+Bypasses up-to-date checks for the source, target, and all branches being
+removed.
 
 ## `-noFetch` (Optional)
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -3,7 +3,7 @@
 Usage:
 
     git-release.ps1 [-source] <string> [-target] <string>
-        [-comment <string>] [-preserve <string[]>] [-dryRun] [-cleanupOnly]
+        [-comment <string>] [-preserve <string[]>] [-noFetch] [-dryRun] [-quiet] [-cleanupOnly]
 
 ## Parameters
 
@@ -26,12 +26,22 @@ branch.
 
 A comma delimited list of branches to preserve in addition to those upstream
 
+### `-cleanupOnly` (Optional)
+
+Use this flag when the released branch (from `-branchName`) was already merged
+to the target branch (`-target`) to clean up the included branches.
+
+## `-noFetch` (Optional)
+
+By default, all scripts fetch the latest before processing. To skip this (which
+was the old behavior), include `-noFetch`.
+
 ### `-dryRun` (Optional)
 
 If specified, changes to branches will be displayed but no actual changes will
 be applied.
 
-### `-cleanupOnly` (Optional)
+## `-quiet` (Optional)
 
-Use this flag when the released branch (from `-branchName`) was already merged
-to the target branch (`-target`) to clean up the included branches.
+Suppress unnecessary output. Useful when a tool is designed to consume the
+output of this script via git rather than via PowerShell.

--- a/git-release.ps1
+++ b/git-release.ps1
@@ -108,8 +108,8 @@ $sourceHash = Get-BranchCommit (Get-RemoteBranchRef $source)
 
 # Finalize:
 #    1. Push the following:
-#        - Delete $toRemove branches
 #        - Update _upstream
+#        - Delete $toRemove branches
 #        - If not $cleanupOnly, push $source commitish to $target
 
 $commonParams = @{
@@ -119,6 +119,9 @@ $commonParams = @{
 
 $resultBranches = @{
     "$($config.upstreamBranch)" = $upstreamHash.commit
+}
+foreach ($branch in $toRemove) {
+    $resultBranches[$branch] = $null
 }
 if (-not $cleanupOnly) {
     $resultBranches[$target] = $sourceHash

--- a/git-release.ps1
+++ b/git-release.ps1
@@ -1,8 +1,8 @@
 #!/usr/bin/env pwsh
 
 Param(
-    [Parameter(Mandatory)][String] $sourceBranch,
-    [Parameter(Mandatory)][String] $target,
+    [Parameter(Mandatory)][Alias('sourceBranch')][String] $source,
+    [Parameter(Mandatory)][Alias('targetBranch')][String] $target,
     [Parameter()][Alias('message')][Alias('m')][string] $comment,
     [Parameter()][String[]] $preserve,
     [switch] $cleanupOnly,
@@ -11,108 +11,158 @@ Param(
     [switch] $dryRun
 )
 
-. $PSScriptRoot/config/core/coalesce.ps1
-. $PSScriptRoot/config/core/ArrayToHash.ps1
 Import-Module -Scope Local "$PSScriptRoot/utils/query-state.psm1"
-Import-Module -Scope Local "$PSScriptRoot/config/git/Get-GitFileNames.psm1"
-Import-Module -Scope Local "$PSScriptRoot/config/git/Set-MultipleUpstreamBranches.psm1"
+Import-Module -Scope Local "$PSScriptRoot/utils/framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/utils/actions.psm1"
 
 $diagnostics = New-Diagnostics
 if (-not $noFetch) {
     Update-GitRemote -quiet:$quiet
 }
 
+$commonParams = @{
+    diagnostics = $diagnostics
+}
+
 # Assert up-to-date
 # a) if $cleanupOnly, ensure no commits are in source that are not in target
 # b) otherwise, ensure no commits are in target that are not in source
-#
+Invoke-LocalAction @commonParams @{
+    type = 'assert-updated'
+    parameters = $cleanupOnly `
+        ? @{ downstream = $target; upstream = $source }
+        : @{ downstream = $source; upstream = $target }
+}
+Assert-Diagnostics $diagnostics
+
 # $toRemove = (git show-upstream $source -recurse) without ($target, git show-upstream $target -recurse)
-#
+$sourceUpstream = Invoke-LocalAction @commonParams @{
+    type = 'get-upstream'
+    parameters = @{ target = $source; recurse = $true }
+}
+Assert-Diagnostics $diagnostics
+
+$targetUpstream = Invoke-LocalAction @commonParams @{
+    type = 'get-upstream'
+    parameters = @{ target = $target; recurse = $true }
+}
+Assert-Diagnostics $diagnostics
+
+$keep = @($target) + $targetUpstream
+[string[]]$toRemove = (@($source) + $sourceUpstream) | Where-Object { $_ -notin $keep }
+
 # For all branches:
 #    1. Replace $toRemove branches with $target
 #    2. Simplify (new)
-#
+
+$originalUpstreams = Invoke-LocalAction @commonParams @{
+    type = 'get-all-upstreams'
+    parameters= @{}
+}
+Assert-Diagnostics $diagnostics
+
+$resultUpstreams = @{}
+foreach ($branch in $originalUpstreams.Keys) {
+    if ($branch -in $toRemove) {
+        $resultUpstreams[$branch] = $null
+        continue
+    }
+    
+    if ($originalUpstreams[$branch] | Where-Object { $_ -in $toRemove }) {
+        $resultUpstreams = Invoke-LocalAction @commonParams @{
+            type = 'filter-branches'
+            parameters = @{
+                include = @($target) + $originalUpstreams[$branch]
+                exclude = $toRemove
+            }
+        }
+    }
+}
+
+Write-Host (ConvertTo-Json $resultUpstreams)
+
+
 # Finalize:
 #    1. Push the following:
 #        - Delete $toRemove branches
 #        - Update _upstream
 #        - If not $cleanupOnly, push $source commitish to $target
 
-if ($cleanupOnly) {
-    # Verify that $target already has all of $sourceBranch
-    $count = git rev-list ($config.remote -eq $nil ? $sourceBranch : "$($config.remote)/$($sourceBranch)") "^$($config.remote -eq $nil ? $target : "$($config.remote)/$($target)")" --count
-    if ($count -ne 0) {
-        throw "Found $count commits in $sourceBranch that were not included in $target"
-    }
-} else {
-    $count = git rev-list ($config.remote -eq $nil ? $target : "$($config.remote)/$($target)") "^$($config.remote -eq $nil ? $sourceBranch : "$($config.remote)/$($sourceBranch)")" --count
-    if ($count -ne 0) {
-        throw "Could not fast-forward $target to $sourceBranch; $count commits in $target that were not included in $sourceBranch"
-    }
-}
+# if ($cleanupOnly) {
+#     # Verify that $target already has all of $sourceBranch
+#     $count = git rev-list ($config.remote -eq $nil ? $sourceBranch : "$($config.remote)/$($sourceBranch)") "^$($config.remote -eq $nil ? $target : "$($config.remote)/$($target)")" --count
+#     if ($count -ne 0) {
+#         throw "Found $count commits in $sourceBranch that were not included in $target"
+#     }
+# } else {
+#     $count = git rev-list ($config.remote -eq $nil ? $target : "$($config.remote)/$($target)") "^$($config.remote -eq $nil ? $sourceBranch : "$($config.remote)/$($sourceBranch)")" --count
+#     if ($count -ne 0) {
+#         throw "Could not fast-forward $target to $sourceBranch; $count commits in $target that were not included in $sourceBranch"
+#     }
+# }
 
-$allPreserve = [String[]](@($target, $preserve) | ForEach-Object { $_ } | Select-Object -uniq)
+# $allPreserve = [String[]](@($target, $preserve) | ForEach-Object { $_ } | Select-Object -uniq)
 
-$allUpstream = Select-UpstreamBranches $sourceBranch -recurse
+# $allUpstream = Select-UpstreamBranches $sourceBranch -recurse
 
-$upstreamCache = @($allUpstream, $allPreserve) | ForEach-Object { $_ } | ArrayToHash -getValue { Select-UpstreamBranches $_ -recurse }
+# $upstreamCache = @($allUpstream, $allPreserve) | ForEach-Object { $_ } | ArrayToHash -getValue { Select-UpstreamBranches $_ -recurse }
 
-$preservedUpstream = [String[]]($allPreserve
-    | ForEach-Object { $_; $upstreamCache[$_] }
-    | ForEach-Object { $_ }
-    | Select-Object -uniq)
+# $preservedUpstream = [String[]]($allPreserve
+#     | ForEach-Object { $_; $upstreamCache[$_] }
+#     | ForEach-Object { $_ }
+#     | Select-Object -uniq)
 
-$toRemove = @($allUpstream, $sourceBranch) | ForEach-Object { $_ } | Select-Object -uniq | Where-Object { $preservedUpstream -notcontains $_ }
+# $toRemove = @($allUpstream, $sourceBranch) | ForEach-Object { $_ } | Select-Object -uniq | Where-Object { $preservedUpstream -notcontains $_ }
 
-function Invoke-RemoveBranches($branch) {
-    if ($toRemove -contains $branch) {
-        return $upstreamCache[$branch] | ForEach-Object { Invoke-RemoveBranches $_ } | Foreach-Object { $_ } | Select-Object -uniq
-    }
-    return $branch
-}
+# function Invoke-RemoveBranches($branch) {
+#     if ($toRemove -contains $branch) {
+#         return $upstreamCache[$branch] | ForEach-Object { Invoke-RemoveBranches $_ } | Foreach-Object { $_ } | Select-Object -uniq
+#     }
+#     return $branch
+# }
 
-$updates = Get-GitFileNames -branchName $config.upstreamBranch -remote $config.remote | ForEach-Object {
-    if ($toRemove -contains $_) { return $nil }
-    $upstream = Select-UpstreamBranches $_
-    if (($upstream | Where-Object { $toRemove -contains $_ })) {
-        # Needs to change
-        return @{
-            branch = $_
-            newUpstream = [string[]]($upstream | ForEach-Object { Invoke-RemoveBranches $_ } | ForEach-Object { $_ } | Select-Object -uniq)
-        }
-    }
-    return $nil
-} | Where-Object { $_ -ne $nil }
+# $updates = Get-GitFileNames -branchName $config.upstreamBranch -remote $config.remote | ForEach-Object {
+#     if ($toRemove -contains $_) { return $nil }
+#     $upstream = Select-UpstreamBranches $_
+#     if (($upstream | Where-Object { $toRemove -contains $_ })) {
+#         # Needs to change
+#         return @{
+#             branch = $_
+#             newUpstream = [string[]]($upstream | ForEach-Object { Invoke-RemoveBranches $_ } | ForEach-Object { $_ } | Select-Object -uniq)
+#         }
+#     }
+#     return $nil
+# } | Where-Object { $_ -ne $nil }
 
-if ($dryRun) {
-    if (-not $cleanupOnly) {
-        Write-Host "Would push $sourceBranch to $target"
-    }
-    Write-Host "Would remove $toRemove"
-    Write-Host "Would perform updates: $(ConvertTo-Json $updates)"
-} else {
-    $commitMessage = "Release $sourceBranch to $target$($comment -eq $nil -or $comment -eq '' ? '' : "`n`n$comment")"
-    $upstreamContents = $updates | ArrayToHash -getKey { $_.branch } -getValue { $_.newUpstream }
-    $upstreamContents[$sourceBranch] = $nil
-    $toRemove | ForEach-Object {
-        $upstreamContents[$_] = $nil
-    }
-    $commitish = Set-MultipleUpstreamBranches $upstreamContents -m $commitMessage
+# if ($dryRun) {
+#     if (-not $cleanupOnly) {
+#         Write-Host "Would push $sourceBranch to $target"
+#     }
+#     Write-Host "Would remove $toRemove"
+#     Write-Host "Would perform updates: $(ConvertTo-Json $updates)"
+# } else {
+#     $commitMessage = "Release $sourceBranch to $target$($comment -eq $nil -or $comment -eq '' ? '' : "`n`n$comment")"
+#     $upstreamContents = $updates | ArrayToHash -getKey { $_.branch } -getValue { $_.newUpstream }
+#     $upstreamContents[$sourceBranch] = $nil
+#     $toRemove | ForEach-Object {
+#         $upstreamContents[$_] = $nil
+#     }
+#     $commitish = Set-MultipleUpstreamBranches $upstreamContents -m $commitMessage
 
-    if ($config.remote -ne $nil) {
-        $gitDeletions = [String[]]($toRemove | ForEach-Object { ":$_" })
+#     if ($config.remote -ne $nil) {
+#         $gitDeletions = [String[]]($toRemove | ForEach-Object { ":$_" })
 
-        $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
-        $releasePart = $cleanupOnly ? @() : @("$($config.remote)/$($sourceBranch):$target")
+#         $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
+#         $releasePart = $cleanupOnly ? @() : @("$($config.remote)/$($sourceBranch):$target")
 
-        git push @atomicPart $config.remote @releasePart @gitDeletions "$($commitish):refs/heads/$($config.upstreamBranch)"
-    } else {
-        git branch -f $config.upstreamBranch $commitish
-        if (-not $cleanupOnly) {
-            git branch -f $sourceBranch $target
-        }
-        $toRemove | ForEach-Object {
-            git branch -D $_
-        }
-    }
-}
+#         git push @atomicPart $config.remote @releasePart @gitDeletions "$($commitish):refs/heads/$($config.upstreamBranch)"
+#     } else {
+#         git branch -f $config.upstreamBranch $commitish
+#         if (-not $cleanupOnly) {
+#             git branch -f $sourceBranch $target
+#         }
+#         $toRemove | ForEach-Object {
+#             git branch -D $_
+#         }
+#     }
+# }

--- a/git-release.ps1
+++ b/git-release.ps1
@@ -16,6 +16,7 @@ Import-Module -Scope Local "$PSScriptRoot/utils/framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/utils/actions.psm1"
 
 $diagnostics = New-Diagnostics
+$config = Get-Configuration
 if (-not $noFetch) {
     Update-GitRemote -quiet:$quiet
 }
@@ -76,10 +77,32 @@ foreach ($branch in $originalUpstreams.Keys) {
                 exclude = $toRemove
             }
         }
+        Assert-Diagnostics $diagnostics
     }
 }
 
-Write-Host (ConvertTo-Json $resultUpstreams)
+foreach ($branch in $resultUpstreams.Keys) {
+    if (-not $resultUpstreams[$branch]) { continue }
+    $resultUpstreams[$branch] = Invoke-LocalAction @commonParams @{
+        type = 'simplify-upstream'
+        parameters = @{
+            upstreamBranches = $resultUpstreams[$branch]
+            overrideUpstreams = $resultUpstreams
+            branchName = $branch
+        }
+    }
+    Assert-Diagnostics $diagnostics
+}
+
+$upstreamHash = Invoke-LocalAction @commonParams @{
+    type = 'set-upstream'
+    parameters = @{
+        upstreamBranches = $resultUpstreams
+        message = "Release $($source) to $($target)$($comment -eq '' ? '' : " for $($params.comment)")"
+    }
+}
+
+$sourceHash = Get-BranchCommit (Get-RemoteBranchRef $source)
 
 
 # Finalize:
@@ -88,81 +111,22 @@ Write-Host (ConvertTo-Json $resultUpstreams)
 #        - Update _upstream
 #        - If not $cleanupOnly, push $source commitish to $target
 
-# if ($cleanupOnly) {
-#     # Verify that $target already has all of $sourceBranch
-#     $count = git rev-list ($config.remote -eq $nil ? $sourceBranch : "$($config.remote)/$($sourceBranch)") "^$($config.remote -eq $nil ? $target : "$($config.remote)/$($target)")" --count
-#     if ($count -ne 0) {
-#         throw "Found $count commits in $sourceBranch that were not included in $target"
-#     }
-# } else {
-#     $count = git rev-list ($config.remote -eq $nil ? $target : "$($config.remote)/$($target)") "^$($config.remote -eq $nil ? $sourceBranch : "$($config.remote)/$($sourceBranch)")" --count
-#     if ($count -ne 0) {
-#         throw "Could not fast-forward $target to $sourceBranch; $count commits in $target that were not included in $sourceBranch"
-#     }
-# }
+$commonParams = @{
+    diagnostics = $diagnostics
+    dryRun = $dryRun
+}
 
-# $allPreserve = [String[]](@($target, $preserve) | ForEach-Object { $_ } | Select-Object -uniq)
+$resultBranches = @{
+    "$($config.upstreamBranch)" = $upstreamHash.commit
+}
+if (-not $cleanupOnly) {
+    $resultBranches[$target] = $sourceHash
+}
 
-# $allUpstream = Select-UpstreamBranches $sourceBranch -recurse
-
-# $upstreamCache = @($allUpstream, $allPreserve) | ForEach-Object { $_ } | ArrayToHash -getValue { Select-UpstreamBranches $_ -recurse }
-
-# $preservedUpstream = [String[]]($allPreserve
-#     | ForEach-Object { $_; $upstreamCache[$_] }
-#     | ForEach-Object { $_ }
-#     | Select-Object -uniq)
-
-# $toRemove = @($allUpstream, $sourceBranch) | ForEach-Object { $_ } | Select-Object -uniq | Where-Object { $preservedUpstream -notcontains $_ }
-
-# function Invoke-RemoveBranches($branch) {
-#     if ($toRemove -contains $branch) {
-#         return $upstreamCache[$branch] | ForEach-Object { Invoke-RemoveBranches $_ } | Foreach-Object { $_ } | Select-Object -uniq
-#     }
-#     return $branch
-# }
-
-# $updates = Get-GitFileNames -branchName $config.upstreamBranch -remote $config.remote | ForEach-Object {
-#     if ($toRemove -contains $_) { return $nil }
-#     $upstream = Select-UpstreamBranches $_
-#     if (($upstream | Where-Object { $toRemove -contains $_ })) {
-#         # Needs to change
-#         return @{
-#             branch = $_
-#             newUpstream = [string[]]($upstream | ForEach-Object { Invoke-RemoveBranches $_ } | ForEach-Object { $_ } | Select-Object -uniq)
-#         }
-#     }
-#     return $nil
-# } | Where-Object { $_ -ne $nil }
-
-# if ($dryRun) {
-#     if (-not $cleanupOnly) {
-#         Write-Host "Would push $sourceBranch to $target"
-#     }
-#     Write-Host "Would remove $toRemove"
-#     Write-Host "Would perform updates: $(ConvertTo-Json $updates)"
-# } else {
-#     $commitMessage = "Release $sourceBranch to $target$($comment -eq $nil -or $comment -eq '' ? '' : "`n`n$comment")"
-#     $upstreamContents = $updates | ArrayToHash -getKey { $_.branch } -getValue { $_.newUpstream }
-#     $upstreamContents[$sourceBranch] = $nil
-#     $toRemove | ForEach-Object {
-#         $upstreamContents[$_] = $nil
-#     }
-#     $commitish = Set-MultipleUpstreamBranches $upstreamContents -m $commitMessage
-
-#     if ($config.remote -ne $nil) {
-#         $gitDeletions = [String[]]($toRemove | ForEach-Object { ":$_" })
-
-#         $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
-#         $releasePart = $cleanupOnly ? @() : @("$($config.remote)/$($sourceBranch):$target")
-
-#         git push @atomicPart $config.remote @releasePart @gitDeletions "$($commitish):refs/heads/$($config.upstreamBranch)"
-#     } else {
-#         git branch -f $config.upstreamBranch $commitish
-#         if (-not $cleanupOnly) {
-#             git branch -f $sourceBranch $target
-#         }
-#         $toRemove | ForEach-Object {
-#             git branch -D $_
-#         }
-#     }
-# }
+Invoke-FinalizeAction @commonParams @{
+    type = 'set-branches'
+    parameters = @{
+        branches = $resultBranches
+    }
+}
+Assert-Diagnostics $diagnostics

--- a/git-release.ps1
+++ b/git-release.ps1
@@ -4,7 +4,7 @@ Param(
     [Parameter(Mandatory)][Alias('sourceBranch')][String] $source,
     [Parameter(Mandatory)][Alias('targetBranch')][String] $target,
     [Parameter()][Alias('message')][Alias('m')][string] $comment,
-    [Parameter()][String[]] $preserve,
+    [Parameter()][String[]] $preserve = @(),
     [switch] $cleanupOnly,
     [switch] $noFetch,
     [switch] $quiet,
@@ -50,7 +50,7 @@ $targetUpstream = Invoke-LocalAction @commonParams @{
 Assert-Diagnostics $diagnostics
 
 $keep = @($target) + $targetUpstream
-[string[]]$toRemove = (@($source) + $sourceUpstream) | Where-Object { $_ -notin $keep }
+[string[]]$toRemove = (@($source) + $sourceUpstream) | Where-Object { $_ -notin $keep -and $_ -notin $preserve }
 
 # For all branches:
 #    1. Replace $toRemove branches with $target

--- a/git-release.ps1
+++ b/git-release.ps1
@@ -39,7 +39,7 @@ if (-not $force) {
     Assert-Diagnostics $diagnostics
 }
 
-# $toRemove = (git show-upstream $source -recurse) without ($target, git show-upstream $target -recurse)
+# $toRemove = (git show-upstream $source -recurse) without ($target, git show-upstream $target -recurse, $preserve)
 $sourceUpstream = Invoke-LocalAction @commonParams @{
     type = 'get-upstream'
     parameters = @{ target = $source; recurse = $true }
@@ -52,8 +52,8 @@ $targetUpstream = Invoke-LocalAction @commonParams @{
 }
 Assert-Diagnostics $diagnostics
 
-$keep = @($target) + $targetUpstream
-[string[]]$toRemove = (@($source) + $sourceUpstream) | Where-Object { $_ -notin $keep -and $_ -notin $preserve }
+[string[]]$keep = @($target) + $targetUpstream + $preserve
+[string[]]$toRemove = (@($source) + $sourceUpstream) | Where-Object { $_ -notin $keep }
 
 # Assert all branches removed are up-to-date, unless $force is set
 if (-not $force) {

--- a/git-release.ps1
+++ b/git-release.ps1
@@ -63,8 +63,8 @@ if (-not $force) {
             type = 'assert-updated'
             parameters = @{ downstream = $cleanupOnly ? $target : $source; upstream = $branch }
         }
-        Assert-Diagnostics $diagnostics
     }
+    Assert-Diagnostics $diagnostics
 }
 
 # For all branches:

--- a/git-release.ps1
+++ b/git-release.ps1
@@ -70,7 +70,7 @@ foreach ($branch in $originalUpstreams.Keys) {
     }
     
     if ($originalUpstreams[$branch] | Where-Object { $_ -in $toRemove }) {
-        $resultUpstreams = Invoke-LocalAction @commonParams @{
+        $resultUpstreams[$branch] = Invoke-LocalAction @commonParams @{
             type = 'filter-branches'
             parameters = @{
                 include = @($target) + $originalUpstreams[$branch]
@@ -81,7 +81,8 @@ foreach ($branch in $originalUpstreams.Keys) {
     }
 }
 
-foreach ($branch in $resultUpstreams.Keys) {
+$keys = @() + $resultUpstreams.Keys
+foreach ($branch in $keys) {
     if (-not $resultUpstreams[$branch]) { continue }
     $resultUpstreams[$branch] = Invoke-LocalAction @commonParams @{
         type = 'simplify-upstream'
@@ -101,9 +102,9 @@ $upstreamHash = Invoke-LocalAction @commonParams @{
         message = "Release $($source) to $($target)$($comment -eq '' ? '' : " for $($params.comment)")"
     }
 }
+Assert-Diagnostics $diagnostics
 
 $sourceHash = Get-BranchCommit (Get-RemoteBranchRef $source)
-
 
 # Finalize:
 #    1. Push the following:

--- a/git-release.tests.ps1
+++ b/git-release.tests.ps1
@@ -74,10 +74,12 @@ Describe 'git-release' {
             } -initialCommits $initialCommits
             Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'main' -initialCommits $initialCommits
             Initialize-LocalActionAssertUpdatedFailure 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdatedFailure 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
 
             { & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main } | Should -Throw
-            $fw.assertDiagnosticOutput | Should -Be 'ERR:  The branch feature/XYZ-1-services has changes that are not in rc/2022-07-14'
+            $fw.assertDiagnosticOutput.Count | Should -Be 2
+            $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch feature/XYZ-1-services has changes that are not in rc/2022-07-14'
+            $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch feature/FOO-123 has changes that are not in rc/2022-07-14'
         }
         
         It 'allows forced removal even if an intermediate branches were not fully released' {

--- a/git-release.tests.ps1
+++ b/git-release.tests.ps1
@@ -82,7 +82,7 @@ Describe 'git-release' {
             $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch feature/FOO-123 has changes that are not in rc/2022-07-14'
         }
         
-        It 'allows forced removal even if an intermediate branches were not fully released' {
+        It 'allows forced removal even if a intermediate branches were not fully released' {
             Initialize-AllUpstreamBranches @{
                 'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services")
                 'feature/FOO-123' = @('main')

--- a/git-release.tests.ps1
+++ b/git-release.tests.ps1
@@ -37,9 +37,9 @@ Describe 'git-release' {
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125","feature/XYZ-1-services")
                 'main' = @()
             } -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'main' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'main' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
             Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
                 -from @("feature/FOO-124_FOO-125", "main") `
                 -to @("feature/FOO-124_FOO-125")
@@ -72,9 +72,9 @@ Describe 'git-release' {
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125","feature/XYZ-1-services")
                 'main' = @()
             } -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'main' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedFailure 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedFailure 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'main' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated -withChanges 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated -withChanges 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
 
             { & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main } | Should -Throw
             $fw.assertDiagnosticOutput.Count | Should -Be 2
@@ -93,9 +93,9 @@ Describe 'git-release' {
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125","feature/XYZ-1-services")
                 'main' = @()
             } -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedFailure 'rc/2022-07-14' 'main' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedFailure 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedFailure 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated -withChanges 'rc/2022-07-14' 'main' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated -withChanges 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated -withChanges 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
             Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
                 -from @("feature/FOO-124_FOO-125", "main") `
                 -to @("feature/FOO-124_FOO-125")
@@ -128,9 +128,9 @@ Describe 'git-release' {
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125","feature/XYZ-1-services")
                 'main' = @()
             } -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'main' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'main' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
             Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
                 -from @("feature/FOO-124_FOO-125", "main") `
                 -to @("feature/FOO-124_FOO-125")
@@ -160,12 +160,12 @@ Describe 'git-release' {
                 'main' = {}
                 'rc/2022-07-14' = @("feature/FOO-123", "integrate/FOO-125_XYZ-1")
             } -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'main' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/FOO-124-comment' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/FOO-124_FOO-125' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'integrate/FOO-125_XYZ-1' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'main' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/FOO-124-comment' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/FOO-124_FOO-125' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'integrate/FOO-125_XYZ-1' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
             Initialize-LocalActionSetUpstream @{
                 'feature/FOO-123' = $null
                 'integrate/FOO-125_XYZ-1' = $null
@@ -200,10 +200,10 @@ Describe 'git-release' {
                 'main' = {}
                 'rc/2022-07-14' = @("feature/FOO-123", "integrate/FOO-125_XYZ-1")
             } -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'main' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/FOO-124-comment' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'main' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/FOO-124-comment' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/XYZ-1-services' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'rc/2022-07-14' 'feature/FOO-123' -initialCommits $initialCommits
             Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
                 -from @("feature/FOO-124_FOO-125", "main") `
                 -to @("feature/FOO-124_FOO-125")
@@ -242,7 +242,7 @@ Describe 'git-release' {
                 'main' = {}
                 'rc/2022-07-14' = @("feature/XYZ-1-services")
             } -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'feature/FOO-123' 'main' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'feature/FOO-123' 'main' -initialCommits $initialCommits
             Initialize-LocalActionSetUpstream @{
                 'feature/FOO-123' = $null
             } -commitMessage 'Release feature/FOO-123 to main' -commitish 'new-commit'
@@ -257,7 +257,7 @@ Describe 'git-release' {
         }
 
         It 'aborts if not a fast-forward' {
-            Initialize-LocalActionAssertUpdatedFailure 'rc/2022-07-14' 'main'
+            Initialize-LocalActionAssertUpdated -withChanges 'rc/2022-07-14' 'main'
 
             { & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main } | Should -Throw
             $fw.assertDiagnosticOutput | Should -Be 'ERR:  The branch main has changes that are not in rc/2022-07-14'
@@ -274,8 +274,8 @@ Describe 'git-release' {
                 'main' = {}
                 'rc/2022-07-14' = @("feature/XYZ-1-services")
             } -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'main' 'rc/2022-07-14' -initialCommits $initialCommits
-            Initialize-LocalActionAssertUpdatedSuccess 'main' 'feature/XYZ-1-services' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'main' 'rc/2022-07-14' -initialCommits $initialCommits
+            Initialize-LocalActionAssertUpdated 'main' 'feature/XYZ-1-services' -initialCommits $initialCommits
             Initialize-LocalActionSetUpstream @{
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125")
                 'rc/2022-07-14' = $null
@@ -294,7 +294,7 @@ Describe 'git-release' {
         }
 
         It 'aborts clean up if not already released' {
-            Initialize-LocalActionAssertUpdatedFailure 'main' 'rc/2022-07-14'
+            Initialize-LocalActionAssertUpdated -withChanges 'main' 'rc/2022-07-14'
 
             { & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main -cleanupOnly } | Should -Throw
             $fw.assertDiagnosticOutput | Should -Be 'ERR:  The branch rc/2022-07-14 has changes that are not in main'

--- a/git-release.tests.ps1
+++ b/git-release.tests.ps1
@@ -41,6 +41,9 @@ Describe 'git-release' {
             Initialize-FinalizeActionSetBranches @{
                 '_upstream' = 'new-commit'
                 'main' = 'result-commitish'
+                'feature/FOO-123' = $null
+                'feature/XYZ-1-services' = $null
+                'rc/2022-07-14' = $null
             }
 
             & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main
@@ -72,6 +75,9 @@ Describe 'git-release' {
                 'feature/XYZ-1-services' = $null;
             } 'Release rc/2022-07-14 to main' 'new-commit'
             Initialize-AssertValidBranchName '_upstream'
+            Initialize-AssertValidBranchName 'feature/FOO-123'
+            Initialize-AssertValidBranchName 'feature/XYZ-1-services'
+            Initialize-AssertValidBranchName 'rc/2022-07-14'
 
             & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main -dryRun
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
@@ -103,6 +109,12 @@ Describe 'git-release' {
             Initialize-FinalizeActionSetBranches @{
                 '_upstream' = 'new-commit'
                 'main' = 'result-commitish'
+                'feature/FOO-123' = $null
+                'integrate/FOO-125_XYZ-1' = $null
+                'rc/2022-07-14' = $null
+                'feature/XYZ-1-services' = $null
+                'feature/FOO-124_FOO-125' = $null
+                'feature/FOO-124-comment' = $null
             }
 
             & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main
@@ -111,14 +123,14 @@ Describe 'git-release' {
 
         It 'can preserve some branches' {
             Initialize-AllUpstreamBranches @{
-                'rc/2022-07-14' = @("feature/FOO-123","feature/XYZ-1-services")
                 'feature/FOO-123' = @('main')
                 'feature/XYZ-1-services' = @('main')
                 'feature/FOO-124-comment' = @('main')
                 'feature/FOO-124_FOO-125' = @("feature/FOO-124-comment")
                 'feature/FOO-76' = @('main')
                 'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125","feature/XYZ-1-services")
-                'main' = @()
+                'main' = {}
+                'rc/2022-07-14' = @("feature/FOO-123", "integrate/FOO-125_XYZ-1")
             }
             Initialize-LocalActionAssertUpdatedSuccess 'rc/2022-07-14' 'main' -initialCommits @{
                 'rc/2022-07-14' = 'result-commitish'
@@ -127,16 +139,27 @@ Describe 'git-release' {
             Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
                 -from @("feature/FOO-124_FOO-125", "main") `
                 -to @("feature/FOO-124_FOO-125")
+            Initialize-LocalActionSimplifyUpstreamBranchesSuccess `
+                -from @("main") `
+                -to @("main")
             Initialize-LocalActionSetUpstream @{
-                'feature/FOO-123' = $null;
-                'rc/2022-07-14' = $null;
-            } 'Release rc/2022-07-14 to main' 'new-commit'
+                'feature/FOO-123' = $null
+                'rc/2022-07-14' = $null
+                'integrate/FOO-125_XYZ-1' = @("feature/FOO-124_FOO-125")
+                'feature/FOO-124_FOO-125' = @("main")
+                'feature/FOO-124-comment' = $null
+                'feature/XYZ-1-services' = $null
+            } -commitMessage 'Release rc/2022-07-14 to main' -commitish 'new-commit'
             Initialize-FinalizeActionSetBranches @{
                 '_upstream' = 'new-commit'
                 'main' = 'result-commitish'
+                'feature/FOO-123' = $null
+                'rc/2022-07-14' = $null
+                'feature/FOO-124-comment' = $null
+                'feature/XYZ-1-services' = $null
             }
 
-            & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main -preserve feature/XYZ-1-services
+            & $PSScriptRoot/git-release.ps1 rc/2022-07-14 main -preserve integrate/FOO-125_XYZ-1,feature/FOO-124_FOO-125
             $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
         }
 
@@ -161,6 +184,7 @@ Describe 'git-release' {
             Initialize-FinalizeActionSetBranches @{
                 '_upstream' = 'new-commit'
                 'main' = 'result-commitish'
+                'feature/FOO-123' = $null
             }
 
             & $PSScriptRoot/git-release.ps1 feature/FOO-123 main
@@ -196,6 +220,8 @@ Describe 'git-release' {
             } -commitMessage 'Release rc/2022-07-14 to main' -commitish 'new-commit'
             Initialize-FinalizeActionSetBranches @{
                 '_upstream' = 'new-commit'
+                'rc/2022-07-14' = $null
+                'feature/XYZ-1-services' = $null
             }
             Initialize-AssertValidBranchName 'main'
             Initialize-AssertValidBranchName 'feature/FOO-124_FOO-125'

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -4,6 +4,9 @@ Export-ModuleMember -Function Initialize-LocalActionAssertExistence
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAssertPushed.mocks.psm1"
 Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead
 
+Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAssertUpdated.mocks.psm1"
+Export-ModuleMember -Function Initialize-LocalActionAssertUpdatedSuccess, Initialize-LocalActionAssertUpdatedFailure
+
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionGetAllUpstreams.mocks.psm1"
 Export-ModuleMember -Function Initialize-AllUpstreamBranches
 

--- a/utils/actions.mocks.psm1
+++ b/utils/actions.mocks.psm1
@@ -5,7 +5,7 @@ Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAsse
 Export-ModuleMember -Function Initialize-LocalActionAssertPushedNotTracked, Initialize-LocalActionAssertPushedSuccess, Initialize-LocalActionAssertPushedAhead
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionAssertUpdated.mocks.psm1"
-Export-ModuleMember -Function Initialize-LocalActionAssertUpdatedSuccess, Initialize-LocalActionAssertUpdatedFailure
+Export-ModuleMember -Function Initialize-LocalActionAssertUpdated
 
 Import-Module -Scope Local "$PSScriptRoot/actions/local/Register-LocalActionGetAllUpstreams.mocks.psm1"
 Export-ModuleMember -Function Initialize-AllUpstreamBranches

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -1,6 +1,7 @@
 Import-Module -Scope Local "$PSScriptRoot/Invoke-LocalAction.internal.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAddDiagnostic.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertPushed.psm1"
+Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertUpdated.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionEvaluate.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionGetAllUpstreams.psm1"
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionGetUpstream.psm1"
@@ -17,6 +18,7 @@ Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertExiste
 $localActions = Get-LocalActionsRegistry
 Register-LocalActionAddDiagnostic $localActions
 Register-LocalActionAssertPushed $localActions
+Register-LocalActionAssertUpdated $localActions
 Register-LocalActionEvaluate $localActions
 Register-LocalActionGetAllUpstreams $localActions
 Register-LocalActionGetUpstream $localActions

--- a/utils/actions/local/Register-LocalActionAssertUpdated.mocks.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.mocks.psm1
@@ -1,0 +1,65 @@
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-LocalActionAssertUpdated.psm1"
+
+function Initialize-LocalActionAssertUpdatedSuccess(
+    [Parameter()][string] $downstream,
+    [Parameter()][string] $upstream
+) {
+    $config = Get-Configuration
+    if ($null -ne $config.remote) {
+        if ($null -ne $downstream -AND '' -ne $downstream) {
+            $downstream = "$($config.remote)/$downstream"
+        }
+        if ($null -ne $upstream -AND '' -ne $upstream) {
+            $upstream = "$($config.remote)/$upstream"
+        }
+    }
+
+    Initialize-MergeTogether `
+        -allBranches @($upstream) `
+        -successfulBranches @() `
+        -noChangeBranches @($upstream) `
+        -source $downstream `
+        -messageTemplate 'Verification Only' `
+        -resultCommitish 'result-commitish'
+}
+
+function Initialize-LocalActionAssertUpdatedFailure(
+    [Parameter()][string] $downstream,
+    [Parameter()][string] $upstream,
+    [switch] $withConflict
+) {
+    
+    $config = Get-Configuration
+    if ($null -ne $config.remote) {
+        if ($null -ne $downstream -AND '' -ne $downstream) {
+            $downstream = "$($config.remote)/$downstream"
+        }
+        if ($null -ne $upstream -AND '' -ne $upstream) {
+            $upstream = "$($config.remote)/$upstream"
+        }
+    }
+
+    if ($withConflict) {
+        Initialize-MergeTogether `
+            -allBranches @($upstream) `
+            -successfulBranches @() `
+            -noChangeBranches @() `
+            -source $downstream `
+            -messageTemplate 'Verification Only' `
+            -resultCommitish 'result-commitish'
+    } else {
+        Initialize-MergeTogether `
+            -allBranches @($upstream) `
+            -successfulBranches @($upstream) `
+            -noChangeBranches @() `
+            -source $downstream `
+            -messageTemplate 'Verification Only' `
+            -resultCommitish 'result-commitish'
+    }
+}
+
+Export-ModuleMember -Function Initialize-LocalActionAssertUpdatedSuccess, Initialize-LocalActionAssertUpdatedFailure

--- a/utils/actions/local/Register-LocalActionAssertUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.psm1
@@ -13,13 +13,10 @@ function Register-LocalActionAssertUpdated([PSObject] $localActions) {
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
-        $downstream = Get-RemoteBranchRef $downstream
-        $upstream = Get-RemoteBranchRef $upstream
-
         # Verifies that everything in "upstream" is in "downstream". Asserts if not.
         $mergeResult = Invoke-MergeTogether `
-            -source $downstream `
-            -commitishes @($upstream) `
+            -source (Get-RemoteBranchRef $downstream) `
+            -commitishes @(Get-RemoteBranchRef $upstream) `
             -messageTemplate 'Verification Only' `
             -commitMappingOverride $commitMappingOverride `
             -diagnostics $diagnostics `

--- a/utils/actions/local/Register-LocalActionAssertUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.psm1
@@ -32,9 +32,9 @@ function Register-LocalActionAssertUpdated([PSObject] $localActions) {
             -diagnostics $diagnostics `
             -noFailureMessages
         if ($mergeResult.failed) {
-            Add-ErrorDiagnostic $diagnostics "The branch $downstream conflicts with $upstream"
+            Add-ErrorDiagnostic $diagnostics "The branch $upstream conflicts with $downstream"
         } elseif ($mergeResult.hasChanges) {
-            Add-ErrorDiagnostic $diagnostics "The branch $downstream has changes that are not in $upstream"
+            Add-ErrorDiagnostic $diagnostics "The branch $upstream has changes that are not in $downstream"
         }
         
         return @{}

--- a/utils/actions/local/Register-LocalActionAssertUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.psm1
@@ -13,15 +13,8 @@ function Register-LocalActionAssertUpdated([PSObject] $localActions) {
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
 
-        $config = Get-Configuration
-        if ($null -ne $config.remote) {
-            if ($null -ne $downstream -AND '' -ne $downstream) {
-                $downstream = "$($config.remote)/$downstream"
-            }
-            if ($null -ne $upstream -AND '' -ne $upstream) {
-                $upstream = "$($config.remote)/$upstream"
-            }
-        }
+        $downstream = Get-RemoteBranchRef $downstream
+        $upstream = Get-RemoteBranchRef $upstream
 
         # Verifies that everything in "upstream" is in "downstream". Asserts if not.
         $mergeResult = Invoke-MergeTogether `

--- a/utils/actions/local/Register-LocalActionAssertUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.psm1
@@ -1,0 +1,44 @@
+Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
+
+function Register-LocalActionAssertUpdated([PSObject] $localActions) {
+    $localActions['assert-updated'] = {
+        param(
+            [Parameter()][string] $downstream,
+            [Parameter()][string] $upstream,
+            [hashtable] $commitMappingOverride = @{},
+
+            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+        )
+
+        $config = Get-Configuration
+        if ($null -ne $config.remote) {
+            if ($null -ne $downstream -AND '' -ne $downstream) {
+                $downstream = "$($config.remote)/$downstream"
+            }
+            if ($null -ne $upstream -AND '' -ne $upstream) {
+                $upstream = "$($config.remote)/$upstream"
+            }
+        }
+
+        # Verifies that everything in "upstream" is in "downstream". Asserts if not.
+        $mergeResult = Invoke-MergeTogether `
+            -source $downstream `
+            -commitishes @($upstream) `
+            -messageTemplate 'Verification Only' `
+            -commitMappingOverride $commitMappingOverride `
+            -diagnostics $diagnostics `
+            -noFailureMessages
+        if ($mergeResult.failed) {
+            Add-ErrorDiagnostic $diagnostics "The branch $downstream conflicts with $upstream"
+        } elseif ($mergeResult.hasChanges) {
+            Add-ErrorDiagnostic $diagnostics "The branch $downstream has changes that are not in $upstream"
+        }
+        
+        return @{}
+    }
+}
+
+Export-ModuleMember -Function Register-LocalActionAssertUpdated

--- a/utils/actions/local/Register-LocalActionAssertUpdated.tests.ps1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.tests.ps1
@@ -39,7 +39,7 @@ Describe 'local action "assert-updated"' {
         Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
 
         Invoke-FlushAssertDiagnostic $fw.diagnostics
-        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch origin/rc/next conflicts with origin/main'
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch origin/main conflicts with origin/rc/next'
     }
 
     It 'reports an error if there are changes' {
@@ -48,6 +48,6 @@ Describe 'local action "assert-updated"' {
         Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
 
         Invoke-FlushAssertDiagnostic $fw.diagnostics
-        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch origin/rc/next has changes that are not in origin/main'
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch origin/main has changes that are not in origin/rc/next'
     }
 }

--- a/utils/actions/local/Register-LocalActionAssertUpdated.tests.ps1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.tests.ps1
@@ -1,0 +1,53 @@
+Describe 'local action "assert-updated"' {
+    BeforeAll {
+        Import-Module -Scope Local "$PSScriptRoot/../../framework.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../git.mocks.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../Invoke-LocalAction.psm1"
+        Import-Module -Scope Local "$PSScriptRoot/../../actions.mocks.psm1"
+        . "$PSScriptRoot/../../testing.ps1"
+    }
+    
+    BeforeEach {
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $fw = Register-Framework
+
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Justification='This is put in scope and used in the tests below')]
+        $standardScript = ('{ 
+            "type": "assert-updated", 
+            "parameters": {
+                "downstream": "rc/next",
+                "upstream": "main",
+            }
+        }' | ConvertFrom-Json)
+
+        Initialize-ToolConfiguration
+    }
+
+    It 'handles successful cases' {
+        Initialize-LocalActionAssertUpdatedSuccess -downstream 'rc/next' -upstream 'main'
+
+        Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -BeNullOrEmpty
+    }
+
+    It 'reports an error for conflicts' {
+        Initialize-LocalActionAssertUpdatedFailure -downstream 'rc/next' -upstream 'main' -withConflict
+
+        Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch origin/rc/next conflicts with origin/main'
+    }
+
+    It 'reports an error if there are changes' {
+        Initialize-LocalActionAssertUpdatedFailure -downstream 'rc/next' -upstream 'main'
+
+        Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
+
+        Invoke-FlushAssertDiagnostic $fw.diagnostics
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch origin/rc/next has changes that are not in origin/main'
+    }
+}

--- a/utils/actions/local/Register-LocalActionAssertUpdated.tests.ps1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.tests.ps1
@@ -25,7 +25,7 @@ Describe 'local action "assert-updated"' {
     }
 
     It 'handles successful cases' {
-        Initialize-LocalActionAssertUpdatedSuccess -downstream 'rc/next' -upstream 'main'
+        Initialize-LocalActionAssertUpdated -downstream 'rc/next' -upstream 'main'
 
         Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
 
@@ -34,7 +34,7 @@ Describe 'local action "assert-updated"' {
     }
 
     It 'reports an error for conflicts' {
-        Initialize-LocalActionAssertUpdatedFailure -downstream 'rc/next' -upstream 'main' -withConflict
+        Initialize-LocalActionAssertUpdated -downstream 'rc/next' -upstream 'main' -withConflict
 
         Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
 
@@ -43,7 +43,7 @@ Describe 'local action "assert-updated"' {
     }
 
     It 'reports an error if there are changes' {
-        Initialize-LocalActionAssertUpdatedFailure -downstream 'rc/next' -upstream 'main'
+        Initialize-LocalActionAssertUpdated -downstream 'rc/next' -upstream 'main' -withChanges
 
         Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
 

--- a/utils/actions/local/Register-LocalActionAssertUpdated.tests.ps1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.tests.ps1
@@ -39,7 +39,7 @@ Describe 'local action "assert-updated"' {
         Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
 
         Invoke-FlushAssertDiagnostic $fw.diagnostics
-        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch origin/main conflicts with origin/rc/next'
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch main conflicts with rc/next'
     }
 
     It 'reports an error if there are changes' {
@@ -48,6 +48,6 @@ Describe 'local action "assert-updated"' {
         Invoke-LocalAction $standardScript -diagnostics $fw.diagnostics
 
         Invoke-FlushAssertDiagnostic $fw.diagnostics
-        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch origin/main has changes that are not in origin/rc/next'
+        $fw.assertDiagnosticOutput | Should -Contain 'ERR:  The branch main has changes that are not in rc/next'
     }
 }

--- a/utils/git/Invoke-MergeTogether.mocks.psm1
+++ b/utils/git/Invoke-MergeTogether.mocks.psm1
@@ -28,7 +28,7 @@ function Initialize-MergeTogetherAllFailed(
     [AllowEmptyCollection()][string[]] $allBranches
 ) {
     foreach ($branch in $allBranches) {
-        Invoke-MockGit "rev-parse --verify $branch" -MockWith { $global:LASTEXITCODE = 1 }
+        Initialize-GetBranchCommit $branch $null
     }
 }
 
@@ -75,7 +75,7 @@ function Initialize-MergeTogether(
 
         $currentCommit = $resultCommitishes[$initialSuccessfulBranch]
         if ($initialSuccessfulBranch -notin $skipRevParse) {
-            Invoke-MockGit "rev-parse --verify $initialSuccessfulBranch" -MockWith { $commitish[$initialSuccessfulBranch] }.GetNewClosure()
+            Initialize-GetBranchCommit $initialSuccessfulBranch $commitish[$initialSuccessfulBranch]
         }
     }
 
@@ -85,7 +85,7 @@ function Initialize-MergeTogether(
             $success += $current
             if ($current -eq $initialSuccessfulBranch) { continue }
             if ($current -notin $skipRevParse) {
-                Invoke-MockGit "rev-parse --verify $current" -MockWith $commitish[$current]
+                Initialize-GetBranchCommit $current $commitish[$current]
             }
 
             Invoke-MockGit "rev-list --count ^$currentCommit $($commitish[$current])" -MockWith "0"
@@ -93,7 +93,7 @@ function Initialize-MergeTogether(
             $success += $current
             if ($current -eq $initialSuccessfulBranch) { continue }
             if ($current -notin $skipRevParse) {
-                Invoke-MockGit "rev-parse --verify $current" -MockWith $commitish[$current]
+                Initialize-GetBranchCommit $current $commitish[$current]
             }
 
             Invoke-MockGit "rev-list --count ^$currentCommit $($commitish[$current])" -MockWith "1"
@@ -112,10 +112,10 @@ function Initialize-MergeTogether(
         } else {
             if ($success.Count -eq 0) {
                 # If everything fails, that means we weren't able to resolve a single commitish
-                Invoke-MockGit "rev-parse --verify $current" -MockWith { $global:LASTEXITCODE = 1 }
+                Initialize-GetBranchCommit $current $null
             } else {
                 if ($current -notin $skipRevParse) {
-                    Invoke-MockGit "rev-parse --verify $current" -MockWith $commitish[$current]
+                    Initialize-GetBranchCommit $current $commitish[$current]
                 }
                 Invoke-MockGit "rev-list --count ^$currentCommit $($commitish[$current])" -MockWith "1"
                 $treeish = "$current-tree"

--- a/utils/git/Invoke-MergeTogether.psm1
+++ b/utils/git/Invoke-MergeTogether.psm1
@@ -11,14 +11,7 @@ function Invoke-MergeTogether(
     [switch] $noFailureMessages
 ) {
     function ResolveCommit($commitish) {
-        if ($commitMappingOverride[$commitish]) {
-            return $commitMappingOverride[$commitish]
-        }
-        $result = Invoke-ProcessLogs "git rev-parse --verify $target" {
-            git rev-parse --verify $target
-        } -allowSuccessOutput
-        if ($global:LASTEXITCODE -ne 0) { return $null }
-        return $result
+        return Get-BranchCommit $commitish -commitMappingOverride:$commitMappingOverride
     }
 
     [String[]]$remaining = $commitishes

--- a/utils/query-state.mocks.psm1
+++ b/utils/query-state.mocks.psm1
@@ -17,6 +17,9 @@ Export-ModuleMember -Function `
     , Initialize-OtherGitFilesAsBlank, Initialize-GitFile `
     , Initialize-MergeTree `
 
+Import-Module -Scope Local "$PSScriptRoot/query-state/Get-BranchCommit.mocks.psm1"
+Export-ModuleMember -Function Initialize-GetBranchCommit
+    
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-BranchSyncState.mocks.psm1"
 Export-ModuleMember -Function Initialize-RemoteBranchBehind, Initialize-RemoteBranchAhead, Initialize-RemoteBranchNotTracked, Initialize-RemoteBranchInSync, Initialize-RemoteBranchAheadAndBehind
 

--- a/utils/query-state.psm1
+++ b/utils/query-state.psm1
@@ -21,8 +21,14 @@ Export-ModuleMember -Function Get-Configuration `
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-BranchSyncState.psm1"
 Export-ModuleMember -Function Get-BranchSyncState
 
+Import-Module -Scope Local "$PSScriptRoot/query-state/Get-BranchCommit.psm1"
+Export-ModuleMember -Function Get-BranchCommit
+
 Import-Module -Scope Local "$PSScriptRoot/query-state/Get-LocalBranchForRemote.psm1"
 Export-ModuleMember -Function Get-LocalBranchForRemote
+
+Import-Module -Scope Local "$PSScriptRoot/query-state/Get-RemoteBranchRef.psm1"
+Export-ModuleMember -Function Get-RemoteBranchRef
 
 Import-Module -Scope Local "$PSScriptRoot/query-state/Select-AllUpstreamBranches.psm1"
 Export-ModuleMember -Function Select-AllUpstreamBranches

--- a/utils/query-state/Get-BranchCommit.mocks.psm1
+++ b/utils/query-state/Get-BranchCommit.mocks.psm1
@@ -1,4 +1,3 @@
-Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../testing.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Get-BranchCommit.psm1"
 

--- a/utils/query-state/Get-BranchCommit.mocks.psm1
+++ b/utils/query-state/Get-BranchCommit.mocks.psm1
@@ -1,0 +1,16 @@
+Import-Module -Scope Local "$PSScriptRoot/../core.psm1"
+Import-Module -Scope Local "$PSScriptRoot/../testing.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Get-BranchCommit.psm1"
+
+function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
+    return Invoke-MockGitModule -ModuleName 'Get-BranchCommit' @PSBoundParameters
+}
+
+function Initialize-GetBranchCommit([string] $branch, [string][AllowNull()] $result) {
+    Invoke-MockGit "rev-parse --verify $branch" -MockWith {
+        if ($result) { $result }
+        else { $global:LASTEXITCODE = 1 }
+    }.GetNewClosure()
+}
+
+Export-ModuleMember -Function Initialize-GetBranchCommit

--- a/utils/query-state/Get-BranchCommit.psm1
+++ b/utils/query-state/Get-BranchCommit.psm1
@@ -1,0 +1,17 @@
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+
+function Get-BranchCommit(
+    [Parameter()][string] $branch,
+    [Parameter()][hashtable] $commitMappingOverride = @{}
+) {
+    if ($commitMappingOverride[$branch]) {
+        return $commitMappingOverride[$branch]
+    }
+    $result = Invoke-ProcessLogs "git rev-parse --verify $branch" {
+        git rev-parse --verify $branch
+    } -allowSuccessOutput
+    if ($global:LASTEXITCODE -ne 0) { return $null }
+    return $result
+}
+
+Export-ModuleMember -Function Get-BranchCommit

--- a/utils/query-state/Get-BranchCommit.tests.ps1
+++ b/utils/query-state/Get-BranchCommit.tests.ps1
@@ -1,0 +1,29 @@
+BeforeAll {
+    . "$PSScriptRoot/../testing.ps1"
+    Import-Module -Scope Local "$PSScriptRoot/Get-BranchCommit.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Get-BranchCommit.mocks.psm1"
+}
+
+Describe 'Get-BranchCommit' {
+    It 'resolves a commit' {
+        Initialize-GetBranchCommit 'foo' '1234567890'
+
+        $result = Get-BranchCommit 'foo'
+        $result | Should -Be '1234567890'
+    }
+
+    It 'resolve to null when unknown' {
+        Initialize-GetBranchCommit 'foo' $null
+
+        $result = Get-BranchCommit 'foo'
+        $result | Should -Be $null
+    }
+
+    It 'resolves via an override' {
+        $result = Get-BranchCommit 'foo' -commitMappingOverride @{
+            baz = $null
+            'foo' = '1234567890'
+        }
+        $result | Should -Be '1234567890'
+    }
+}

--- a/utils/query-state/Get-RemoteBranchRef.psm1
+++ b/utils/query-state/Get-RemoteBranchRef.psm1
@@ -1,0 +1,14 @@
+Import-Module -Scope Local "$PSScriptRoot/../framework.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
+
+# TODO: use the remote's refspec
+function Get-RemoteBranchRef(
+    [Parameter()][string] $branch,
+    [Parameter()][hashtable][AllowNull()] $configuration
+) {
+    $configuration = $configuration ?? (Get-Configuration)
+    $remote = $configuration.remote
+    return ($remote) ? "$remote/$branch" : $branch
+}
+
+Export-ModuleMember -Function Get-RemoteBranchRef

--- a/utils/query-state/Get-RemoteBranchRef.tests.ps1
+++ b/utils/query-state/Get-RemoteBranchRef.tests.ps1
@@ -1,0 +1,34 @@
+BeforeAll {
+    . "$PSScriptRoot/../testing.ps1"
+    Import-Module -Scope Local "$PSScriptRoot/Configuration.mocks.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Configuration.psm1"
+    Import-Module -Scope Local "$PSScriptRoot/Get-RemoteBranchRef.psm1"
+}
+
+Describe 'Get-RemoteBranchRef' {
+    It 'resolves a branch with no remote' {
+        Initialize-ToolConfiguration -noRemote
+
+        $result = Get-RemoteBranchRef 'feature/my-branch'
+        $result | Should -Be 'feature/my-branch'
+    }
+
+    It 'resolves a branch with default remote' {
+        Initialize-ToolConfiguration
+
+        $result = Get-RemoteBranchRef 'feature/my-branch'
+        $result | Should -Be 'origin/feature/my-branch'
+    }
+
+    It 'resolves a branch with a custom remote' {
+        Initialize-ToolConfiguration -remote 'azure'
+
+        $result = Get-RemoteBranchRef 'feature/my-branch'
+        $result | Should -Be 'azure/feature/my-branch'
+    }
+
+    It 'allows passing a manual config object' {
+        $result = Get-RemoteBranchRef 'feature/my-branch' -configuration @{ remote = 'azure' }
+        $result | Should -Be 'azure/feature/my-branch'
+    }
+}


### PR DESCRIPTION
- Use new diagnostics framework
- Add checks to ensure all intermediate branches that will be removed were up-to-date
- Simplify upstreams of affected branches so that bad links are not created
- Add `-force` flag to allow cleanup of branches even if not all branches were fully included in the release

Note that this does not use the new JSON script syntax.
- This required several loops, which are not clean in the JSON syntax
- JSON syntax is much more difficult to debug, since breakpoints cannot be set
