### PR TITLE
Refactor action registry

### DIFF
--- a/utils/actions/Invoke-FinalizeAction.psm1
+++ b/utils/actions/Invoke-FinalizeAction.psm1
@@ -4,10 +4,11 @@ Import-Module -Scope Local "$PSScriptRoot/finalize/Register-FinalizeActionChecko
 Import-Module -Scope Local "$PSScriptRoot/finalize/Register-FinalizeActionSetBranches.psm1"
 Import-Module -Scope Local "$PSScriptRoot/finalize/Register-FinalizeActionTrack.psm1"
 
-$finalizeActions = @{}
-Register-FinalizeActionCheckout $finalizeActions
-Register-FinalizeActionSetBranches $finalizeActions
-Register-FinalizeActionTrack $finalizeActions
+$finalizeActions = @{
+    'checkout' = ${function:Invoke-CheckoutFinalizeAction}
+    'set-branches' = ${function:Invoke-SetBranchesFinalizeAction}
+    'track' = ${function:Invoke-TrackFinalizeAction}
+}
 
 function Invoke-FinalizeAction(
     [PSObject] $actionDefinition,

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -16,20 +16,20 @@ Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionValidateBran
 Import-Module -Scope Local "$PSScriptRoot/local/Register-LocalActionAssertExistence.psm1"
 
 $localActions = Get-LocalActionsRegistry
-Register-LocalActionAddDiagnostic $localActions
-Register-LocalActionAssertPushed $localActions
-Register-LocalActionAssertUpdated $localActions
+$localActions['add-diagnostic'] = ${function:Invoke-AddDiagnosticLocalAction}
+$localActions['assert-existence'] = ${function:Invoke-AssertBranchExistenceLocalAction}
+$localActions['assert-pushed'] = ${function:Invoke-AssertBranchPushedLocalAction}
+$localActions['assert-updated'] = ${function:Invoke-AssertBranchUpToDateLocalAction}
 Register-LocalActionEvaluate $localActions
-Register-LocalActionGetAllUpstreams $localActions
-Register-LocalActionGetUpstream $localActions
-Register-LocalActionGetDownstream $localActions
-Register-LocalActionFilterBranches $localActions
-Register-LocalActionMergeBranches $localActions
-Register-LocalActionRecurse $localActions
-Register-LocalActionSetUpstream $localActions
-Register-LocalActionSimplifyUpstreamBranches $localActions
-Register-LocalActionUpstreamsUpdated $localActions
-Register-LocalActionValidateBranchNames $localActions
-Register-LocalActionAssertExistence $localActions
+$localActions['filter-branches'] = ${function:Invoke-FilterBranchesLocalAction}
+$localActions['get-all-upstreams'] = ${function:Invoke-GetAllUpstreamsLocalAction}
+$localActions['get-downstream'] = ${function:Invoke-GetDownstreamLocalAction}
+$localActions['get-upstream'] = ${function:Invoke-GetUpstreamLocalAction}
+$localActions['merge-branches'] = ${function:Invoke-MergeBranchesLocalAction}
+$localActions['recurse'] = ${function:Invoke-RecursiveScriptLocalAction}
+$localActions['set-upstream'] = ${function:Invoke-SetUpstreamLocalAction}
+$localActions['simplify-upstream'] = ${function:Invoke-SimplifyUpstreamLocalAction}
+$localActions['upstreams-updated'] = ${function:Invoke-UpstreamsUpdatedLocalAction}
+$localActions['validate-branch-names'] = ${function:Invoke-AssertBranchNamesLocalAction}
 
 Export-ModuleMember -Function Invoke-LocalAction

--- a/utils/actions/Invoke-LocalAction.psm1
+++ b/utils/actions/Invoke-LocalAction.psm1
@@ -20,7 +20,7 @@ $localActions['add-diagnostic'] = ${function:Invoke-AddDiagnosticLocalAction}
 $localActions['assert-existence'] = ${function:Invoke-AssertBranchExistenceLocalAction}
 $localActions['assert-pushed'] = ${function:Invoke-AssertBranchPushedLocalAction}
 $localActions['assert-updated'] = ${function:Invoke-AssertBranchUpToDateLocalAction}
-Register-LocalActionEvaluate $localActions
+$localActions['evaluate'] = ${function:Invoke-EvaluateLocalAction}
 $localActions['filter-branches'] = ${function:Invoke-FilterBranchesLocalAction}
 $localActions['get-all-upstreams'] = ${function:Invoke-GetAllUpstreamsLocalAction}
 $localActions['get-downstream'] = ${function:Invoke-GetDownstreamLocalAction}

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
@@ -3,10 +3,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 # TODO: should check out the branch from remote as a local tracking branch
-function Register-FinalizeActionCheckout([PSObject] $finalizeActions) {
-    $finalizeActions['checkout'] = ${function:Invoke-CheckoutFinalizeAction}
-}
-
 function Invoke-CheckoutFinalizeAction{
         param(
             [string] $HEAD,
@@ -24,4 +20,4 @@ function Invoke-CheckoutFinalizeAction{
         }
 }
 
-Export-ModuleMember -Function Register-FinalizeActionCheckout
+Export-ModuleMember -Function Invoke-CheckoutFinalizeAction

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
@@ -4,20 +4,20 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 # TODO: should check out the branch from remote as a local tracking branch
 function Invoke-CheckoutFinalizeAction{
-        param(
-            [string] $HEAD,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
-            [switch] $dryRun
-        )
+    param(
+        [string] $HEAD,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
+        [switch] $dryRun
+    )
 
-        if ($dryRun) {
-            "git checkout $HEAD"
-            return
-        }
-        Assert-CleanWorkingDirectory -diagnostics $diagnostics
-        if (-not (Get-HasErrorDiagnostic $diagnostics)) {
-            Invoke-CheckoutBranch $HEAD -diagnostics $diagnostics
-        }
+    if ($dryRun) {
+        "git checkout $HEAD"
+        return
+    }
+    Assert-CleanWorkingDirectory -diagnostics $diagnostics
+    if (-not (Get-HasErrorDiagnostic $diagnostics)) {
+        Invoke-CheckoutBranch $HEAD -diagnostics $diagnostics
+    }
 }
 
 Export-ModuleMember -Function Invoke-CheckoutFinalizeAction

--- a/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionCheckout.psm1
@@ -4,7 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 # TODO: should check out the branch from remote as a local tracking branch
 function Register-FinalizeActionCheckout([PSObject] $finalizeActions) {
-    $finalizeActions['checkout'] = {
+    $finalizeActions['checkout'] = ${function:Invoke-CheckoutFinalizeAction}
+}
+
+function Invoke-CheckoutFinalizeAction{
         param(
             [string] $HEAD,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
@@ -19,7 +22,6 @@ function Register-FinalizeActionCheckout([PSObject] $finalizeActions) {
         if (-not (Get-HasErrorDiagnostic $diagnostics)) {
             Invoke-CheckoutBranch $HEAD -diagnostics $diagnostics
         }
-    }
 }
 
 Export-ModuleMember -Function Register-FinalizeActionCheckout

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.helpers.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.helpers.psm1
@@ -1,0 +1,9 @@
+function ConvertTo-PushBranchList([Parameter(Mandatory)][Hashtable] $branches) {
+    $result = $branches.Keys | Sort-Object | Foreach-Object {
+        "$($branches[$_]):refs/heads/$($_)"
+    }
+    return $result
+}
+
+# Not to be re-exported; used for testing
+Export-ModuleMember -Function ConvertTo-PushBranchList

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.mocks.psm1
@@ -3,6 +3,7 @@ Import-Module -Scope Local "$PSScriptRoot/../../input.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.mocks.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Register-FinalizeActionSetBranches.psm1"
+Import-Module -Scope Local "$PSScriptRoot/Register-FinalizeActionSetBranches.helpers.psm1"
 
 function Invoke-MockGit([string] $gitCli, [object] $MockWith) {
     return Invoke-MockGitModule -ModuleName 'Register-FinalizeActionSetBranches' @PSBoundParameters

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -15,7 +15,9 @@ function ConvertTo-PushBranchList([Parameter(Mandatory)][Hashtable] $branches) {
 Export-ModuleMember -Function ConvertTo-PushBranchList
 
 function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
-    $finalizeActions['set-branches'] = {
+    $finalizeActions['set-branches'] = ${function:Invoke-SetBranchesFinalizeAction}
+}
+function Invoke-SetBranchesFinalizeAction {
         param(
             [Parameter()] $branches,
             [Parameter()] $force = $false,
@@ -73,7 +75,6 @@ function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
                 }
             }
         }
-    }
 }
 
 Export-ModuleMember -Function Register-FinalizeActionSetBranches

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -6,63 +6,63 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 Import-Module -Scope Local "$PSScriptRoot/Register-FinalizeActionSetBranches.helpers.psm1"
 
 function Invoke-SetBranchesFinalizeAction {
-        param(
-            [Parameter()] $branches,
-            [Parameter()] $force = $false,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
-            [switch] $dryRun
-        )
+    param(
+        [Parameter()] $branches,
+        [Parameter()] $force = $false,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
+        [switch] $dryRun
+    )
 
-        $branches = ConvertTo-Hashtable $branches
-        $config = Get-Configuration
+    $branches = ConvertTo-Hashtable $branches
+    $config = Get-Configuration
 
-        $branches.Keys | Assert-ValidBranchName -diagnostics $diagnostics
+    $branches.Keys | Assert-ValidBranchName -diagnostics $diagnostics
 
-        if ($null -ne $config.remote) {
-            $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
-            $forcePart = $force ? @("--force") : @()
-            [string[]]$branchList = ConvertTo-PushBranchList $branches
-            if ($dryRun) {
-                "git push $($config.remote) $atomicPart $forcePart $branchList"
-                return
-            }
-            Invoke-ProcessLogs "git push $($config.remote) $atomicPart $forcePart $branchList" {
-                git push $config.remote @atomicPart @forcePart @branchList
+    if ($null -ne $config.remote) {
+        $atomicPart = $config.atomicPushEnabled ? @("--atomic") : @()
+        $forcePart = $force ? @("--force") : @()
+        [string[]]$branchList = ConvertTo-PushBranchList $branches
+        if ($dryRun) {
+            "git push $($config.remote) $atomicPart $forcePart $branchList"
+            return
+        }
+        Invoke-ProcessLogs "git push $($config.remote) $atomicPart $forcePart $branchList" {
+            git push $config.remote @atomicPart @forcePart @branchList
+        }
+        if ($global:LASTEXITCODE -ne 0) {
+            Add-ErrorDiagnostic $diagnostics "Unable to push updates to $($config.remote)"
+        }
+    } else {
+        $currentBranch = Get-CurrentBranch
+
+        foreach ($key in $branches.Keys) {
+            if ($currentBranch -eq $key) {
+                Assert-CleanWorkingDirectory -diagnostics $diagnostics
+                if (Get-HasErrorDiagnostic $diagnostics) { continue }
+
+                # update head, since it matches the branch to be "pushed"
+                if ($dryRun) {
+                    "git reset --hard `"$($branches[$key])`""
+                    continue
+                }
+                Invoke-ProcessLogs "git reset --hard $($branches[$key])" {
+                    git reset --hard "$($branches[$key])"
+                }
+            } else {
+                # just update the branch
+                if ($dryRun) {
+                    "git branch $key `"$($branches[$key])`" -f"
+                    continue
+                }
+                Invoke-ProcessLogs "git branch $key $($branches[$key])" {
+                    git branch $key "$($branches[$key])" -f
+                }
             }
             if ($global:LASTEXITCODE -ne 0) {
-                Add-ErrorDiagnostic $diagnostics "Unable to push updates to $($config.remote)"
-            }
-        } else {
-            $currentBranch = Get-CurrentBranch
-
-            foreach ($key in $branches.Keys) {
-                if ($currentBranch -eq $key) {
-                    Assert-CleanWorkingDirectory -diagnostics $diagnostics
-                    if (Get-HasErrorDiagnostic $diagnostics) { continue }
-
-                    # update head, since it matches the branch to be "pushed"
-                    if ($dryRun) {
-                        "git reset --hard `"$($branches[$key])`""
-                        continue
-                    }
-                    Invoke-ProcessLogs "git reset --hard $($branches[$key])" {
-                        git reset --hard "$($branches[$key])"
-                    }
-                } else {
-                    # just update the branch
-                    if ($dryRun) {
-                        "git branch $key `"$($branches[$key])`" -f"
-                        continue
-                    }
-                    Invoke-ProcessLogs "git branch $key $($branches[$key])" {
-                        git branch $key "$($branches[$key])" -f
-                    }
-                }
-                if ($global:LASTEXITCODE -ne 0) {
-                    Add-ErrorDiagnostic $diagnostics "Unable to update local branches"
-                }
+                Add-ErrorDiagnostic $diagnostics "Unable to update local branches"
             }
         }
+    }
 }
 
 Export-ModuleMember -Function Invoke-SetBranchesFinalizeAction

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -3,16 +3,7 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
-
-function ConvertTo-PushBranchList([Parameter(Mandatory)][Hashtable] $branches) {
-    $result = $branches.Keys | Sort-Object | Foreach-Object {
-        "$($branches[$_]):refs/heads/$($_)"
-    }
-    return $result
-}
-
-# Not to be re-exported; used for testing
-Export-ModuleMember -Function ConvertTo-PushBranchList
+Import-Module -Scope Local "$PSScriptRoot/Register-FinalizeActionSetBranches.helpers.psm1"
 
 function Invoke-SetBranchesFinalizeAction {
         param(

--- a/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionSetBranches.psm1
@@ -14,9 +14,6 @@ function ConvertTo-PushBranchList([Parameter(Mandatory)][Hashtable] $branches) {
 # Not to be re-exported; used for testing
 Export-ModuleMember -Function ConvertTo-PushBranchList
 
-function Register-FinalizeActionSetBranches([PSObject] $finalizeActions) {
-    $finalizeActions['set-branches'] = ${function:Invoke-SetBranchesFinalizeAction}
-}
 function Invoke-SetBranchesFinalizeAction {
         param(
             [Parameter()] $branches,
@@ -77,4 +74,4 @@ function Invoke-SetBranchesFinalizeAction {
         }
 }
 
-Export-ModuleMember -Function Register-FinalizeActionSetBranches
+Export-ModuleMember -Function Invoke-SetBranchesFinalizeAction

--- a/utils/actions/finalize/Register-FinalizeActionTrack.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.psm1
@@ -5,66 +5,66 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 function Invoke-TrackFinalizeAction {
-        param(
-            [Parameter()][AllowEmptyCollection()][string[]] $branches,
-            [Parameter()][bool] $createIfNotTracked,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
-            [switch] $dryRun
-        )
-        [string[]] $tracked = @()
-        $config = Get-Configuration
-        if ($null -eq $config.remote) {
+    param(
+        [Parameter()][AllowEmptyCollection()][string[]] $branches,
+        [Parameter()][bool] $createIfNotTracked,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics,
+        [switch] $dryRun
+    )
+    [string[]] $tracked = @()
+    $config = Get-Configuration
+    if ($null -eq $config.remote) {
+        if ($dryRun) {
+            return
+        }
+        return $tracked
+    }
+
+    $currentBranch = Get-CurrentBranch
+    foreach ($branch in $branches) {
+        $localBranch = Get-LocalBranchForRemote $branch
+        if (-not $localBranch -AND $currentBranch -eq $branch) {
+            # current branch matches tracked one, but doesn't currently track the remote
+            $localBranch = $currentBranch
             if ($dryRun) {
-                return
-            }
-            return $tracked
-        }
-
-        $currentBranch = Get-CurrentBranch
-        foreach ($branch in $branches) {
-            $localBranch = Get-LocalBranchForRemote $branch
-            if (-not $localBranch -AND $currentBranch -eq $branch) {
-                # current branch matches tracked one, but doesn't currently track the remote
-                $localBranch = $currentBranch
-                if ($dryRun) {
-                    "git branch $localBranch --set-upstream-to `"refs/remotes/$($config.remote)/$branch`""
-                } else {
-                    Invoke-ProcessLogs "git branch $localBranch --set-upstream-to refs/remotes/$($config.remote)/$branch" {
-                        git branch $localBranch --set-upstream-to "refs/remotes/$($config.remote)/$branch"
-                    }
-                }
-            }
-            
-            if ($currentBranch -eq $localBranch) {
-                # update head
-                Assert-CleanWorkingDirectory -diagnostics $diagnostics
-                if (Get-HasErrorDiagnostic $diagnostics) { continue }
-                if ($dryRun) {
-                    "git reset --hard `"refs/remotes/$($config.remote)/$branch`""
-                } else {
-                    Invoke-ProcessLogs "git reset --hard refs/remotes/$($config.remote)/$branch" {
-                        git reset --hard "refs/remotes/$($config.remote)/$branch"
-                    }
-                }
-            } elseif ($localBranch -OR $createIfNotTracked) {
-                $localBranch = $localBranch ? $localBranch : $branch
-                # update
-                if ($dryRun) {
-                    "git branch $localBranch `"refs/remotes/$($config.remote)/$branch`" -f"
-                } else {
-                    Invoke-ProcessLogs "git branch $localBranch refs/remotes/$($config.remote)/$branch -f" {
-                        git branch $localBranch "refs/remotes/$($config.remote)/$branch" -f
-                    }
-                }
+                "git branch $localBranch --set-upstream-to `"refs/remotes/$($config.remote)/$branch`""
             } else {
-                continue
+                Invoke-ProcessLogs "git branch $localBranch --set-upstream-to refs/remotes/$($config.remote)/$branch" {
+                    git branch $localBranch --set-upstream-to "refs/remotes/$($config.remote)/$branch"
+                }
             }
-            $tracked += $branch
         }
+        
+        if ($currentBranch -eq $localBranch) {
+            # update head
+            Assert-CleanWorkingDirectory -diagnostics $diagnostics
+            if (Get-HasErrorDiagnostic $diagnostics) { continue }
+            if ($dryRun) {
+                "git reset --hard `"refs/remotes/$($config.remote)/$branch`""
+            } else {
+                Invoke-ProcessLogs "git reset --hard refs/remotes/$($config.remote)/$branch" {
+                    git reset --hard "refs/remotes/$($config.remote)/$branch"
+                }
+            }
+        } elseif ($localBranch -OR $createIfNotTracked) {
+            $localBranch = $localBranch ? $localBranch : $branch
+            # update
+            if ($dryRun) {
+                "git branch $localBranch `"refs/remotes/$($config.remote)/$branch`" -f"
+            } else {
+                Invoke-ProcessLogs "git branch $localBranch refs/remotes/$($config.remote)/$branch -f" {
+                    git branch $localBranch "refs/remotes/$($config.remote)/$branch" -f
+                }
+            }
+        } else {
+            continue
+        }
+        $tracked += $branch
+    }
 
-        if (-not $dryRun) {
-            return $tracked
-        }
+    if (-not $dryRun) {
+        return $tracked
+    }
 }
 
 Export-ModuleMember -Function Invoke-TrackFinalizeAction

--- a/utils/actions/finalize/Register-FinalizeActionTrack.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.psm1
@@ -4,10 +4,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
-function Register-FinalizeActionTrack([PSObject] $finalizeActions) {
-    $finalizeActions['track'] = ${function:Invoke-TrackFinalizeAction}
-}
-
 function Invoke-TrackFinalizeAction {
         param(
             [Parameter()][AllowEmptyCollection()][string[]] $branches,
@@ -71,4 +67,4 @@ function Invoke-TrackFinalizeAction {
         }
 }
 
-Export-ModuleMember -Function Register-FinalizeActionTrack
+Export-ModuleMember -Function Invoke-TrackFinalizeAction

--- a/utils/actions/finalize/Register-FinalizeActionTrack.psm1
+++ b/utils/actions/finalize/Register-FinalizeActionTrack.psm1
@@ -5,7 +5,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 function Register-FinalizeActionTrack([PSObject] $finalizeActions) {
-    $finalizeActions['track'] = {
+    $finalizeActions['track'] = ${function:Invoke-TrackFinalizeAction}
+}
+
+function Invoke-TrackFinalizeAction {
         param(
             [Parameter()][AllowEmptyCollection()][string[]] $branches,
             [Parameter()][bool] $createIfNotTracked,
@@ -66,7 +69,6 @@ function Register-FinalizeActionTrack([PSObject] $finalizeActions) {
         if (-not $dryRun) {
             return $tracked
         }
-    }
 }
 
 Export-ModuleMember -Function Register-FinalizeActionTrack

--- a/utils/actions/local/Register-LocalActionAddDiagnostic.psm1
+++ b/utils/actions/local/Register-LocalActionAddDiagnostic.psm1
@@ -2,10 +2,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 
 function Register-LocalActionAddDiagnostic([PSObject] $localActions) {
-    $localActions['add-diagnostic'] = ${function:Add-DiagnosticAction}
+    $localActions['add-diagnostic'] = ${function:Invoke-AddDiagnosticLocalAction}
 }
 
-function Add-DiagnosticAction {
+function Invoke-AddDiagnosticLocalAction {
     param(
         [Parameter()][string] $message,
         [switch] $isWarning,

--- a/utils/actions/local/Register-LocalActionAddDiagnostic.psm1
+++ b/utils/actions/local/Register-LocalActionAddDiagnostic.psm1
@@ -2,21 +2,23 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 
 function Register-LocalActionAddDiagnostic([PSObject] $localActions) {
-    $localActions['add-diagnostic'] = {
-        param(
-            [Parameter()][string] $message,
-            [switch] $isWarning,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
-        
-        if ($isWarning) {
-            Add-WarningDiagnostic $diagnostics $message
-        } else {
-            Add-ErrorDiagnostic $diagnostics $message
-        }
+    $localActions['add-diagnostic'] = ${function:Add-DiagnosticAction}
+}
 
-        return @{}
+function Add-DiagnosticAction {
+    param(
+        [Parameter()][string] $message,
+        [switch] $isWarning,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
+
+    if ($isWarning) {
+        Add-WarningDiagnostic $diagnostics $message
+    } else {
+        Add-ErrorDiagnostic $diagnostics $message
     }
+
+    return @{}
 }
 
 Export-ModuleMember -Function Register-LocalActionAddDiagnostic

--- a/utils/actions/local/Register-LocalActionAddDiagnostic.psm1
+++ b/utils/actions/local/Register-LocalActionAddDiagnostic.psm1
@@ -1,10 +1,6 @@
 Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 
-function Register-LocalActionAddDiagnostic([PSObject] $localActions) {
-    $localActions['add-diagnostic'] = ${function:Invoke-AddDiagnosticLocalAction}
-}
-
 function Invoke-AddDiagnosticLocalAction {
     param(
         [Parameter()][string] $message,
@@ -21,4 +17,4 @@ function Invoke-AddDiagnosticLocalAction {
     return @{}
 }
 
-Export-ModuleMember -Function Register-LocalActionAddDiagnostic
+Export-ModuleMember -Function Invoke-AddDiagnosticLocalAction

--- a/utils/actions/local/Register-LocalActionAssertExistence.psm1
+++ b/utils/actions/local/Register-LocalActionAssertExistence.psm1
@@ -10,7 +10,7 @@ function Invoke-AssertBranchExistenceLocalAction {
     )
 
     $remote = $(Get-Configuration).remote
-    
+
     foreach ($branch in $branches) {
         $actualBranch = ($remote) ? "$remote/$branch" : $branch
         Invoke-ProcessLogs "git rev-parse --verify $actualBranch" {

--- a/utils/actions/local/Register-LocalActionAssertExistence.psm1
+++ b/utils/actions/local/Register-LocalActionAssertExistence.psm1
@@ -3,29 +3,31 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionAssertExistence([PSObject] $localActions) {
-    $localActions['assert-existence'] = {
-        param(
-            [Parameter(Mandatory)][AllowEmptyCollection()] $branches,
-            [Parameter(Mandatory)][bool] $shouldExist,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+    $localActions['assert-existence'] = ${function:Assert-BranchExistence}
+}
 
-        $remote = $(Get-Configuration).remote
-        
-        foreach ($branch in $branches) {
-            $actualBranch = ($remote) ? "$remote/$branch" : $branch
-            Invoke-ProcessLogs "git rev-parse --verify $actualBranch" {
-                git rev-parse --verify $actualBranch
-            }
-            if ($global:LASTEXITCODE -ne 0 -AND $shouldExist) {
-                Add-ErrorDiagnostic $diagnostics "Branch $branch did not exist$($remote ? " on remote $remote" : '')."
-            } elseif ($global:LASTEXITCODE -eq 0 -AND -not $shouldExist) {
-                Add-ErrorDiagnostic $diagnostics "Branch $branch already exists$($remote ? " on remote $remote" : '')."
-            }
+function Assert-BranchExistence {
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()] $branches,
+        [Parameter(Mandatory)][bool] $shouldExist,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
+
+    $remote = $(Get-Configuration).remote
+    
+    foreach ($branch in $branches) {
+        $actualBranch = ($remote) ? "$remote/$branch" : $branch
+        Invoke-ProcessLogs "git rev-parse --verify $actualBranch" {
+            git rev-parse --verify $actualBranch
         }
-
-        return @{}
+        if ($global:LASTEXITCODE -ne 0 -AND $shouldExist) {
+            Add-ErrorDiagnostic $diagnostics "Branch $branch did not exist$($remote ? " on remote $remote" : '')."
+        } elseif ($global:LASTEXITCODE -eq 0 -AND -not $shouldExist) {
+            Add-ErrorDiagnostic $diagnostics "Branch $branch already exists$($remote ? " on remote $remote" : '')."
+        }
     }
+
+    return @{}
 }
 
 Export-ModuleMember -Function Register-LocalActionAssertExistence

--- a/utils/actions/local/Register-LocalActionAssertExistence.psm1
+++ b/utils/actions/local/Register-LocalActionAssertExistence.psm1
@@ -2,10 +2,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionAssertExistence([PSObject] $localActions) {
-    $localActions['assert-existence'] = ${function:Invoke-AssertBranchExistenceLocalAction}
-}
-
 function Invoke-AssertBranchExistenceLocalAction {
     param(
         [Parameter(Mandatory)][AllowEmptyCollection()] $branches,
@@ -30,4 +26,4 @@ function Invoke-AssertBranchExistenceLocalAction {
     return @{}
 }
 
-Export-ModuleMember -Function Register-LocalActionAssertExistence
+Export-ModuleMember -Function Invoke-AssertBranchExistenceLocalAction

--- a/utils/actions/local/Register-LocalActionAssertExistence.psm1
+++ b/utils/actions/local/Register-LocalActionAssertExistence.psm1
@@ -3,10 +3,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionAssertExistence([PSObject] $localActions) {
-    $localActions['assert-existence'] = ${function:Assert-BranchExistence}
+    $localActions['assert-existence'] = ${function:Invoke-AssertBranchExistenceLocalAction}
 }
 
-function Assert-BranchExistence {
+function Invoke-AssertBranchExistenceLocalAction {
     param(
         [Parameter(Mandatory)][AllowEmptyCollection()] $branches,
         [Parameter(Mandatory)][bool] $shouldExist,

--- a/utils/actions/local/Register-LocalActionAssertPushed.psm1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.psm1
@@ -2,10 +2,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionAssertPushed([PSObject] $localActions) {
-    $localActions['assert-pushed'] = ${function:Invoke-AssertBranchPushedLocalAction}
-}
-
 function Invoke-AssertBranchPushedLocalAction {
     param(
         [Parameter()][string] $target,
@@ -25,4 +21,4 @@ function Invoke-AssertBranchPushedLocalAction {
     return @{}
 }
 
-Export-ModuleMember -Function Register-LocalActionAssertPushed
+Export-ModuleMember -Function Invoke-AssertBranchPushedLocalAction

--- a/utils/actions/local/Register-LocalActionAssertPushed.psm1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.psm1
@@ -17,7 +17,7 @@ function Invoke-AssertBranchPushedLocalAction {
     } elseif ($remoteMustExist -AND -not $state) {
         Add-ErrorDiagnostic $diagnostics "The local branch for $target does not exist on the remote"
     }
-    
+
     return @{}
 }
 

--- a/utils/actions/local/Register-LocalActionAssertPushed.psm1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.psm1
@@ -3,24 +3,26 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionAssertPushed([PSObject] $localActions) {
-    $localActions['assert-pushed'] = {
-        param(
-            [Parameter()][string] $target,
-            [Switch] $remoteMustExist,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+    $localActions['assert-pushed'] = ${function:Assert-BranchPushed}
+}
 
-        $state = Get-BranchSyncState $target
+function Assert-BranchPushed {
+    param(
+        [Parameter()][string] $target,
+        [Switch] $remoteMustExist,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
 
-        $disallowed = @('>', '<>')
-        if ($disallowed -contains $state) {
-            Add-ErrorDiagnostic $diagnostics "The local branch for $target has changes that are not pushed to the remote"
-        } elseif ($remoteMustExist -AND -not $state) {
-            Add-ErrorDiagnostic $diagnostics "The local branch for $target does not exist on the remote"
-        }
-        
-        return @{}
+    $state = Get-BranchSyncState $target
+
+    $disallowed = @('>', '<>')
+    if ($disallowed -contains $state) {
+        Add-ErrorDiagnostic $diagnostics "The local branch for $target has changes that are not pushed to the remote"
+    } elseif ($remoteMustExist -AND -not $state) {
+        Add-ErrorDiagnostic $diagnostics "The local branch for $target does not exist on the remote"
     }
+    
+    return @{}
 }
 
 Export-ModuleMember -Function Register-LocalActionAssertPushed

--- a/utils/actions/local/Register-LocalActionAssertPushed.psm1
+++ b/utils/actions/local/Register-LocalActionAssertPushed.psm1
@@ -3,10 +3,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionAssertPushed([PSObject] $localActions) {
-    $localActions['assert-pushed'] = ${function:Assert-BranchPushed}
+    $localActions['assert-pushed'] = ${function:Invoke-AssertBranchPushedLocalAction}
 }
 
-function Assert-BranchPushed {
+function Invoke-AssertBranchPushedLocalAction {
     param(
         [Parameter()][string] $target,
         [Switch] $remoteMustExist,

--- a/utils/actions/local/Register-LocalActionAssertUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.psm1
@@ -4,31 +4,33 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 function Register-LocalActionAssertUpdated([PSObject] $localActions) {
-    $localActions['assert-updated'] = {
-        param(
-            [Parameter()][string] $downstream,
-            [Parameter()][string] $upstream,
-            [hashtable] $commitMappingOverride = @{},
+    $localActions['assert-updated'] = ${function:Assert-BranchUpToDate}
+}
 
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+function Assert-BranchUpToDate {
+    param(
+        [Parameter()][string] $downstream,
+        [Parameter()][string] $upstream,
+        [hashtable] $commitMappingOverride = @{},
 
-        # Verifies that everything in "upstream" is in "downstream". Asserts if not.
-        $mergeResult = Invoke-MergeTogether `
-            -source (Get-RemoteBranchRef $downstream) `
-            -commitishes @(Get-RemoteBranchRef $upstream) `
-            -messageTemplate 'Verification Only' `
-            -commitMappingOverride $commitMappingOverride `
-            -diagnostics $diagnostics `
-            -noFailureMessages
-        if ($mergeResult.failed) {
-            Add-ErrorDiagnostic $diagnostics "The branch $upstream conflicts with $downstream"
-        } elseif ($mergeResult.hasChanges) {
-            Add-ErrorDiagnostic $diagnostics "The branch $upstream has changes that are not in $downstream"
-        }
-        
-        return @{}
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
+
+    # Verifies that everything in "upstream" is in "downstream". Asserts if not.
+    $mergeResult = Invoke-MergeTogether `
+        -source (Get-RemoteBranchRef $downstream) `
+        -commitishes @(Get-RemoteBranchRef $upstream) `
+        -messageTemplate 'Verification Only' `
+        -commitMappingOverride $commitMappingOverride `
+        -diagnostics $diagnostics `
+        -noFailureMessages
+    if ($mergeResult.failed) {
+        Add-ErrorDiagnostic $diagnostics "The branch $upstream conflicts with $downstream"
+    } elseif ($mergeResult.hasChanges) {
+        Add-ErrorDiagnostic $diagnostics "The branch $upstream has changes that are not in $downstream"
     }
+    
+    return @{}
 }
 
 Export-ModuleMember -Function Register-LocalActionAssertUpdated

--- a/utils/actions/local/Register-LocalActionAssertUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.psm1
@@ -4,10 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 function Register-LocalActionAssertUpdated([PSObject] $localActions) {
-    $localActions['assert-updated'] = ${function:Assert-BranchUpToDate}
+    $localActions['assert-updated'] = ${function:Invoke-AssertBranchUpToDateLocalAction}
 }
 
-function Assert-BranchUpToDate {
+function Invoke-AssertBranchUpToDateLocalAction {
     param(
         [Parameter()][string] $downstream,
         [Parameter()][string] $upstream,

--- a/utils/actions/local/Register-LocalActionAssertUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.psm1
@@ -25,7 +25,7 @@ function Invoke-AssertBranchUpToDateLocalAction {
     } elseif ($mergeResult.hasChanges) {
         Add-ErrorDiagnostic $diagnostics "The branch $upstream has changes that are not in $downstream"
     }
-    
+
     return @{}
 }
 

--- a/utils/actions/local/Register-LocalActionAssertUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionAssertUpdated.psm1
@@ -3,10 +3,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
-function Register-LocalActionAssertUpdated([PSObject] $localActions) {
-    $localActions['assert-updated'] = ${function:Invoke-AssertBranchUpToDateLocalAction}
-}
-
 function Invoke-AssertBranchUpToDateLocalAction {
     param(
         [Parameter()][string] $downstream,
@@ -33,4 +29,4 @@ function Invoke-AssertBranchUpToDateLocalAction {
     return @{}
 }
 
-Export-ModuleMember -Function Register-LocalActionAssertUpdated
+Export-ModuleMember -Function Invoke-AssertBranchUpToDateLocalAction

--- a/utils/actions/local/Register-LocalActionEvaluate.psm1
+++ b/utils/actions/local/Register-LocalActionEvaluate.psm1
@@ -8,7 +8,7 @@ function Register-LocalActionEvaluate([PSObject] $localActions) {
             [Parameter(Mandatory)][AllowNull()][object] $result,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
         )
-        
+
         return $result
     }
 }

--- a/utils/actions/local/Register-LocalActionEvaluate.psm1
+++ b/utils/actions/local/Register-LocalActionEvaluate.psm1
@@ -2,15 +2,13 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionEvaluate([PSObject] $localActions) {
-    $localActions['evaluate'] = {
-        param(
-            [Parameter(Mandatory)][AllowNull()][object] $result,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+function Invoke-EvaluateLocalAction {
+    param(
+        [Parameter(Mandatory)][AllowNull()][object] $result,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
 
-        return $result
-    }
+    return $result
 }
 
-Export-ModuleMember -Function Register-LocalActionEvaluate
+Export-ModuleMember -Function Invoke-EvaluateLocalAction

--- a/utils/actions/local/Register-LocalActionFilterBranches.psm1
+++ b/utils/actions/local/Register-LocalActionFilterBranches.psm1
@@ -3,19 +3,20 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionFilterBranches([PSObject] $localActions) {
-    $localActions['filter-branches'] = {
-        param(
-            [Parameter()][AllowEmptyCollection()][string[]] $include,
-            [Parameter()][AllowEmptyCollection()][string[]] $exclude,
-            
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+    $localActions['filter-branches'] = ${function:Invoke-FilterBranches}
+}
 
+function Invoke-FilterBranches {
+    param(
+        [Parameter()][AllowEmptyCollection()][string[]] $include,
+        [Parameter()][AllowEmptyCollection()][string[]] $exclude,
         
-        [string[]]$result = $include | Where-Object { $_ } | Where-Object { $_ -notin $exclude } | Get-Unique
-        
-        return $result
-    }
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
+
+    [string[]]$result = $include | Where-Object { $_ } | Where-Object { $_ -notin $exclude } | Get-Unique
+    
+    return $result
 }
 
 Export-ModuleMember -Function Register-LocalActionFilterBranches

--- a/utils/actions/local/Register-LocalActionFilterBranches.psm1
+++ b/utils/actions/local/Register-LocalActionFilterBranches.psm1
@@ -6,12 +6,12 @@ function Invoke-FilterBranchesLocalAction {
     param(
         [Parameter()][AllowEmptyCollection()][string[]] $include,
         [Parameter()][AllowEmptyCollection()][string[]] $exclude,
-        
+
         [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
     )
 
     [string[]]$result = $include | Where-Object { $_ } | Where-Object { $_ -notin $exclude } | Get-Unique
-    
+
     return $result
 }
 

--- a/utils/actions/local/Register-LocalActionFilterBranches.psm1
+++ b/utils/actions/local/Register-LocalActionFilterBranches.psm1
@@ -3,10 +3,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionFilterBranches([PSObject] $localActions) {
-    $localActions['filter-branches'] = ${function:Invoke-FilterBranches}
+    $localActions['filter-branches'] = ${function:Invoke-FilterBranchesLocalAction}
 }
 
-function Invoke-FilterBranches {
+function Invoke-FilterBranchesLocalAction {
     param(
         [Parameter()][AllowEmptyCollection()][string[]] $include,
         [Parameter()][AllowEmptyCollection()][string[]] $exclude,

--- a/utils/actions/local/Register-LocalActionFilterBranches.psm1
+++ b/utils/actions/local/Register-LocalActionFilterBranches.psm1
@@ -2,10 +2,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionFilterBranches([PSObject] $localActions) {
-    $localActions['filter-branches'] = ${function:Invoke-FilterBranchesLocalAction}
-}
-
 function Invoke-FilterBranchesLocalAction {
     param(
         [Parameter()][AllowEmptyCollection()][string[]] $include,
@@ -19,4 +15,4 @@ function Invoke-FilterBranchesLocalAction {
     return $result
 }
 
-Export-ModuleMember -Function Register-LocalActionFilterBranches
+Export-ModuleMember -Function Invoke-FilterBranchesLocalAction

--- a/utils/actions/local/Register-LocalActionGetAllUpstreams.psm1
+++ b/utils/actions/local/Register-LocalActionGetAllUpstreams.psm1
@@ -3,14 +3,16 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionGetAllUpstreams([PSObject] $localActions) {
-    $localActions['get-all-upstreams'] = {
-        param(
-            [Parameter()][AllowNull()] $overrideUpstreams,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
-        
-        return Select-AllUpstreamBranches -overrideUpstreams:$overrideUpstreams
-    }
+    $localActions['get-all-upstreams'] = ${function:Get-AllUpstreams}
+}
+
+function Get-AllUpstreams {
+    param(
+        [Parameter()][AllowNull()] $overrideUpstreams,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
+
+    return Select-AllUpstreamBranches -overrideUpstreams:$overrideUpstreams
 }
 
 Export-ModuleMember -Function Register-LocalActionGetAllUpstreams

--- a/utils/actions/local/Register-LocalActionGetAllUpstreams.psm1
+++ b/utils/actions/local/Register-LocalActionGetAllUpstreams.psm1
@@ -2,10 +2,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionGetAllUpstreams([PSObject] $localActions) {
-    $localActions['get-all-upstreams'] = ${function:Invoke-GetAllUpstreamsLocalAction}
-}
-
 function Invoke-GetAllUpstreamsLocalAction {
     param(
         [Parameter()][AllowNull()] $overrideUpstreams,
@@ -15,4 +11,4 @@ function Invoke-GetAllUpstreamsLocalAction {
     return Select-AllUpstreamBranches -overrideUpstreams:$overrideUpstreams
 }
 
-Export-ModuleMember -Function Register-LocalActionGetAllUpstreams
+Export-ModuleMember -Function Invoke-GetAllUpstreamsLocalAction

--- a/utils/actions/local/Register-LocalActionGetAllUpstreams.psm1
+++ b/utils/actions/local/Register-LocalActionGetAllUpstreams.psm1
@@ -3,10 +3,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionGetAllUpstreams([PSObject] $localActions) {
-    $localActions['get-all-upstreams'] = ${function:Get-AllUpstreams}
+    $localActions['get-all-upstreams'] = ${function:Invoke-GetAllUpstreamsLocalAction}
 }
 
-function Get-AllUpstreams {
+function Invoke-GetAllUpstreamsLocalAction {
     param(
         [Parameter()][AllowNull()] $overrideUpstreams,
         [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics

--- a/utils/actions/local/Register-LocalActionGetDownstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetDownstream.psm1
@@ -2,10 +2,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionGetDownstream([PSObject] $localActions) {
-    $localActions['get-downstream'] = ${function:Invoke-GetDownstreamLocalAction}
-}
-
 function Invoke-GetDownstreamLocalAction {
     param(
         [Parameter(Mandatory)][string] $target,
@@ -19,4 +15,4 @@ function Invoke-GetDownstreamLocalAction {
     return $result
 }
 
-Export-ModuleMember -Function Register-LocalActionGetDownstream
+Export-ModuleMember -Function Invoke-GetDownstreamLocalAction

--- a/utils/actions/local/Register-LocalActionGetDownstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetDownstream.psm1
@@ -3,10 +3,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionGetDownstream([PSObject] $localActions) {
-    $localActions['get-downstream'] = ${function:Get-Downstream}
+    $localActions['get-downstream'] = ${function:Invoke-GetDownstreamLocalAction}
 }
 
-function Get-Downstream {
+function Invoke-GetDownstreamLocalAction {
     param(
         [Parameter(Mandatory)][string] $target,
         [Parameter()][AllowNull()] $overrideUpstreams,

--- a/utils/actions/local/Register-LocalActionGetDownstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetDownstream.psm1
@@ -3,18 +3,20 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionGetDownstream([PSObject] $localActions) {
-    $localActions['get-downstream'] = {
-        param(
-            [Parameter(Mandatory)][string] $target,
-            [Parameter()][AllowNull()] $overrideUpstreams,
-            [switch] $recurse,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+    $localActions['get-downstream'] = ${function:Get-Downstream}
+}
 
-        [string[]]$result = Select-DownstreamBranches -branchName $target -recurse:$recurse -overrideUpstreams:$overrideUpstreams
+function Get-Downstream {
+    param(
+        [Parameter(Mandatory)][string] $target,
+        [Parameter()][AllowNull()] $overrideUpstreams,
+        [switch] $recurse,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
 
-        return $result
-    }
+    [string[]]$result = Select-DownstreamBranches -branchName $target -recurse:$recurse -overrideUpstreams:$overrideUpstreams
+
+    return $result
 }
 
 Export-ModuleMember -Function Register-LocalActionGetDownstream

--- a/utils/actions/local/Register-LocalActionGetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.psm1
@@ -12,7 +12,7 @@ function Invoke-GetUpstreamLocalAction {
     )
 
     [string[]]$result = Select-UpstreamBranches -branchName $target -recurse:$recurse -includeRemote:$includeRemote -overrideUpstreams:$overrideUpstreams
-    
+
     return $result
 }
 

--- a/utils/actions/local/Register-LocalActionGetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.psm1
@@ -3,19 +3,21 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionGetUpstream([PSObject] $localActions) {
-    $localActions['get-upstream'] = {
-        param(
-            [Parameter(Mandatory)][string] $target,
-            [Parameter()][AllowNull()] $overrideUpstreams,
-            [switch] $recurse,
-            [switch] $includeRemote,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+    $localActions['get-upstream'] = ${function:Get-Upstream}
+}
 
-        [string[]]$result = Select-UpstreamBranches -branchName $target -recurse:$recurse -includeRemote:$includeRemote -overrideUpstreams:$overrideUpstreams
-        
-        return $result
-    }
+function Get-Upstream {
+    param(
+        [Parameter(Mandatory)][string] $target,
+        [Parameter()][AllowNull()] $overrideUpstreams,
+        [switch] $recurse,
+        [switch] $includeRemote,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
+
+    [string[]]$result = Select-UpstreamBranches -branchName $target -recurse:$recurse -includeRemote:$includeRemote -overrideUpstreams:$overrideUpstreams
+    
+    return $result
 }
 
 Export-ModuleMember -Function Register-LocalActionGetUpstream

--- a/utils/actions/local/Register-LocalActionGetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.psm1
@@ -2,10 +2,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionGetUpstream([PSObject] $localActions) {
-    $localActions['get-upstream'] = ${function:Invoke-GetUpstreamLocalAction}
-}
-
 function Invoke-GetUpstreamLocalAction {
     param(
         [Parameter(Mandatory)][string] $target,
@@ -20,4 +16,4 @@ function Invoke-GetUpstreamLocalAction {
     return $result
 }
 
-Export-ModuleMember -Function Register-LocalActionGetUpstream
+Export-ModuleMember -Function Invoke-GetUpstreamLocalAction

--- a/utils/actions/local/Register-LocalActionGetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionGetUpstream.psm1
@@ -3,10 +3,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionGetUpstream([PSObject] $localActions) {
-    $localActions['get-upstream'] = ${function:Get-Upstream}
+    $localActions['get-upstream'] = ${function:Invoke-GetUpstreamLocalAction}
 }
 
-function Get-Upstream {
+function Invoke-GetUpstreamLocalAction {
     param(
         [Parameter(Mandatory)][string] $target,
         [Parameter()][AllowNull()] $overrideUpstreams,

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -4,10 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 # TODO: this assumes all branches are remotes (if remote is specified)
 function Register-LocalActionMergeBranches([PSObject] $localActions) {
-    $localActions['merge-branches'] = ${function:Invoke-MergeBranches}
+    $localActions['merge-branches'] = ${function:Invoke-MergeBranchesLocalAction}
 }
 
-function Invoke-MergeBranches
+function Invoke-MergeBranchesLocalAction
 {
         param(
             [string] $source,

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -5,69 +5,69 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 # TODO: this assumes all branches are remotes (if remote is specified)
 function Invoke-MergeBranchesLocalAction
 {
-        param(
-            [string] $source,
-            [string[]] $upstreamBranches,
-            [string] $mergeMessageTemplate = "Merge {}",
-            [hashtable] $commitMappingOverride = @{},
+    param(
+        [string] $source,
+        [string[]] $upstreamBranches,
+        [string] $mergeMessageTemplate = "Merge {}",
+        [hashtable] $commitMappingOverride = @{},
 
-            [Parameter()][bool] $errorOnFailure = $false,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+        [Parameter()][bool] $errorOnFailure = $false,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
 
-        $config = Get-Configuration
-        if ($null -ne $config.remote) {
-            $upstreamBranches = [string[]]$upstreamBranches | Where-Object { $_ } | Foreach-Object { "$($config.remote)/$_" }
-            if ($null -ne $source -AND '' -ne $source) {
-                $source = "$($config.remote)/$source"
-            }
+    $config = Get-Configuration
+    if ($null -ne $config.remote) {
+        $upstreamBranches = [string[]]$upstreamBranches | Where-Object { $_ } | Foreach-Object { "$($config.remote)/$_" }
+        if ($null -ne $source -AND '' -ne $source) {
+            $source = "$($config.remote)/$source"
         }
+    }
 
-        if ($null -eq $upstreamBranches) {
-            # Nothing to merge
-            return @{
-                commit = $null;
-                hasChanges = $false;
-                failed = @();
-                successful = $();
-            }
-        }
-
-        $mergeResult = Invoke-MergeTogether `
-            -source $source `
-            -commitishes $upstreamBranches `
-            -messageTemplate $mergeMessageTemplate `
-            -commitMappingOverride $commitMappingOverride `
-            -diagnostics $diagnostics `
-            -noFailureMessages:$(-not $errorOnFailure)
-        $commit = $mergeResult.result
-        if ($null -eq $commit) {
-            if ($source -notin $mergeResult.failed) {
-                Add-ErrorDiagnostic $diagnostics "No branches could be resolved to merge"
-            }
-        }
-
-        $failed = $mergeResult.failed
-        $successful = $mergeResult.successful
-        if ($null -ne $config.remote) {
-            $prefix = "$($config.remote)/"
-            $failed = [string[]]$failed | Foreach-Object { $_.StartsWith($prefix) ? $_.Substring($prefix.Length) : $_ }
-            $successful = [string[]]$successful | Foreach-Object { $_.StartsWith($prefix) ? $_.Substring($prefix.Length) : $_ }
-        }
-
+    if ($null -eq $upstreamBranches) {
+        # Nothing to merge
         return @{
-            # [string] new commit hash, or null if everything failed
-            commit = $mergeResult.result
-            
-            # [boolean] false if the commit is null or if it matches the source
-            hasChanges = $mergeResult.hasChanges
-            
-            # [string[]] list of branches that could not merge due to conflicts
-            failed = $failed
-            
-            # [string[]] list of branches that would merge without errors (but may have no changes)
-            successful = $successful
+            commit = $null;
+            hasChanges = $false;
+            failed = @();
+            successful = $();
         }
+    }
+
+    $mergeResult = Invoke-MergeTogether `
+        -source $source `
+        -commitishes $upstreamBranches `
+        -messageTemplate $mergeMessageTemplate `
+        -commitMappingOverride $commitMappingOverride `
+        -diagnostics $diagnostics `
+        -noFailureMessages:$(-not $errorOnFailure)
+    $commit = $mergeResult.result
+    if ($null -eq $commit) {
+        if ($source -notin $mergeResult.failed) {
+            Add-ErrorDiagnostic $diagnostics "No branches could be resolved to merge"
+        }
+    }
+
+    $failed = $mergeResult.failed
+    $successful = $mergeResult.successful
+    if ($null -ne $config.remote) {
+        $prefix = "$($config.remote)/"
+        $failed = [string[]]$failed | Foreach-Object { $_.StartsWith($prefix) ? $_.Substring($prefix.Length) : $_ }
+        $successful = [string[]]$successful | Foreach-Object { $_.StartsWith($prefix) ? $_.Substring($prefix.Length) : $_ }
+    }
+
+    return @{
+        # [string] new commit hash, or null if everything failed
+        commit = $mergeResult.result
+
+        # [boolean] false if the commit is null or if it matches the source
+        hasChanges = $mergeResult.hasChanges
+
+        # [string[]] list of branches that could not merge due to conflicts
+        failed = $failed
+
+        # [string[]] list of branches that would merge without errors (but may have no changes)
+        successful = $successful
+    }
 }
 
 Export-ModuleMember -Function Invoke-MergeBranchesLocalAction

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -4,7 +4,11 @@ Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 # TODO: this assumes all branches are remotes (if remote is specified)
 function Register-LocalActionMergeBranches([PSObject] $localActions) {
-    $localActions['merge-branches'] = {
+    $localActions['merge-branches'] = ${function:Invoke-MergeBranches}
+}
+
+function Invoke-MergeBranches
+{
         param(
             [string] $source,
             [string[]] $upstreamBranches,
@@ -68,7 +72,6 @@ function Register-LocalActionMergeBranches([PSObject] $localActions) {
             # [string[]] list of branches that would merge without errors (but may have no changes)
             successful = $successful
         }
-    }
 }
 
 Export-ModuleMember -Function Register-LocalActionMergeBranches

--- a/utils/actions/local/Register-LocalActionMergeBranches.psm1
+++ b/utils/actions/local/Register-LocalActionMergeBranches.psm1
@@ -3,10 +3,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 # TODO: this assumes all branches are remotes (if remote is specified)
-function Register-LocalActionMergeBranches([PSObject] $localActions) {
-    $localActions['merge-branches'] = ${function:Invoke-MergeBranchesLocalAction}
-}
-
 function Invoke-MergeBranchesLocalAction
 {
         param(
@@ -74,4 +70,4 @@ function Invoke-MergeBranchesLocalAction
         }
 }
 
-Export-ModuleMember -Function Register-LocalActionMergeBranches
+Export-ModuleMember -Function Invoke-MergeBranchesLocalAction

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -16,7 +16,10 @@ function New-SafeScript([string] $header, [string[]] $script) {
 }
 
 function Register-LocalActionRecurse([PSObject] $localActions) {
-    $localActions['recurse'] = {
+    $localActions['recurse'] = ${function:Invoke-RecursiveScript}
+}
+
+function Invoke-RecursiveScript {
         param(
             [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $inputParameters,
             [Parameter(Mandatory)][string] $path,
@@ -118,7 +121,6 @@ function Register-LocalActionRecurse([PSObject] $localActions) {
         }
 
         return & $reduceToOutput -mapped $mapped -recursionContext $recursionContext
-    }
 }
 
 function Invoke-Prepare(

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -15,10 +15,6 @@ function New-SafeScript([string] $header, [string[]] $script) {
     ")
 }
 
-function Register-LocalActionRecurse([PSObject] $localActions) {
-    $localActions['recurse'] = ${function:Invoke-RecursiveScriptLocalAction}
-}
-
 function Invoke-RecursiveScriptLocalAction {
         param(
             [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $inputParameters,
@@ -209,4 +205,4 @@ function Invoke-Act(
     return $actions
 }
 
-Export-ModuleMember -Function Register-LocalActionRecurse
+Export-ModuleMember -Function Invoke-RecursiveScriptLocalAction

--- a/utils/actions/local/Register-LocalActionRecurse.psm1
+++ b/utils/actions/local/Register-LocalActionRecurse.psm1
@@ -16,10 +16,10 @@ function New-SafeScript([string] $header, [string[]] $script) {
 }
 
 function Register-LocalActionRecurse([PSObject] $localActions) {
-    $localActions['recurse'] = ${function:Invoke-RecursiveScript}
+    $localActions['recurse'] = ${function:Invoke-RecursiveScriptLocalAction}
 }
 
-function Invoke-RecursiveScript {
+function Invoke-RecursiveScriptLocalAction {
         param(
             [Parameter(Mandatory)][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $inputParameters,
             [Parameter(Mandatory)][string] $path,

--- a/utils/actions/local/Register-LocalActionSetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.psm1
@@ -3,10 +3,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
-function Register-LocalActionSetUpstream([PSObject] $localActions) {
-    $localActions['set-upstream'] = ${function:Invoke-SetUpstreamLocalAction}
-}
-
 function Invoke-SetUpstreamLocalAction {
         param(
             [PSObject] $upstreamBranches,
@@ -29,4 +25,4 @@ function Invoke-SetUpstreamLocalAction {
         }
 }
 
-Export-ModuleMember -Function Register-LocalActionSetUpstream
+Export-ModuleMember -Function Invoke-SetUpstreamLocalAction

--- a/utils/actions/local/Register-LocalActionSetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.psm1
@@ -4,10 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 function Register-LocalActionSetUpstream([PSObject] $localActions) {
-    $localActions['set-upstream'] = ${function:Invoke-SetUpstream}
+    $localActions['set-upstream'] = ${function:Invoke-SetUpstreamLocalAction}
 }
 
-function Invoke-SetUpstream {
+function Invoke-SetUpstreamLocalAction {
         param(
             [PSObject] $upstreamBranches,
             [string] $message,

--- a/utils/actions/local/Register-LocalActionSetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.psm1
@@ -4,7 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 function Register-LocalActionSetUpstream([PSObject] $localActions) {
-    $localActions['set-upstream'] = {
+    $localActions['set-upstream'] = ${function:Invoke-SetUpstream}
+}
+
+function Invoke-SetUpstream {
         param(
             [PSObject] $upstreamBranches,
             [string] $message,
@@ -24,7 +27,6 @@ function Register-LocalActionSetUpstream([PSObject] $localActions) {
         return @{
             commit = $commit
         }
-    }
 }
 
 Export-ModuleMember -Function Register-LocalActionSetUpstream

--- a/utils/actions/local/Register-LocalActionSetUpstream.psm1
+++ b/utils/actions/local/Register-LocalActionSetUpstream.psm1
@@ -4,25 +4,25 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
 function Invoke-SetUpstreamLocalAction {
-        param(
-            [PSObject] $upstreamBranches,
-            [string] $message,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
-        $upstreamBranch = Get-UpstreamBranch
-        $ht = ConvertTo-Hashtable $upstreamBranches
-        $contents = $ht.Keys | ConvertTo-HashMap -getValue {
-            if ($null -eq $ht[$_] -OR $ht[$_].length -eq 0) { return $null }
-            "$(($ht[$_] | Where-Object { $_ }) -join "`n")`n"
-        }
-        
-        $commit = Set-GitFiles $contents -m $message -initialCommitish $upstreamBranch
-        if ($null -eq $commit) {
-            throw "Set-GitFiles was unable to create a new commit."
-        }
-        return @{
-            commit = $commit
-        }
+    param(
+        [PSObject] $upstreamBranches,
+        [string] $message,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
+    $upstreamBranch = Get-UpstreamBranch
+    $ht = ConvertTo-Hashtable $upstreamBranches
+    $contents = $ht.Keys | ConvertTo-HashMap -getValue {
+        if ($null -eq $ht[$_] -OR $ht[$_].length -eq 0) { return $null }
+        "$(($ht[$_] | Where-Object { $_ }) -join "`n")`n"
+    }
+
+    $commit = Set-GitFiles $contents -m $message -initialCommitish $upstreamBranch
+    if ($null -eq $commit) {
+        throw "Set-GitFiles was unable to create a new commit."
+    }
+    return @{
+        commit = $commit
+    }
 }
 
 Export-ModuleMember -Function Invoke-SetUpstreamLocalAction

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -4,10 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) {
-    $localActions['simplify-upstream'] = ${function:Invoke-SimplifyUpstream}
+    $localActions['simplify-upstream'] = ${function:Invoke-SimplifyUpstreamLocalAction}
 }
 
-function Invoke-SimplifyUpstream {
+function Invoke-SimplifyUpstreamLocalAction {
         param(
             [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][string[]] $upstreamBranches,
             [Parameter()][AllowNull()] $overrideUpstreams,

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -4,7 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) {
-    $localActions['simplify-upstream'] = {
+    $localActions['simplify-upstream'] = ${function:Invoke-SimplifyUpstream}
+}
+
+function Invoke-SimplifyUpstream {
         param(
             [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][string[]] $upstreamBranches,
             [Parameter()][AllowNull()] $overrideUpstreams,
@@ -29,7 +32,6 @@ function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) 
 
         $result = Compress-UpstreamBranches $upstreamBranches -diagnostics:$diagnostics -overrideUpstreams:$overrideUpstreams -branchName:$branchName
         return $result
-    }
 }
 
 Export-ModuleMember -Function Register-LocalActionSimplifyUpstreamBranches

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -4,30 +4,30 @@ Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Invoke-SimplifyUpstreamLocalAction {
-        param(
-            [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][string[]] $upstreamBranches,
-            [Parameter()][AllowNull()] $overrideUpstreams,
-            [Parameter()][AllowNull()][string] $branchName,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+    param(
+        [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][string[]] $upstreamBranches,
+        [Parameter()][AllowNull()] $overrideUpstreams,
+        [Parameter()][AllowNull()][string] $branchName,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
 
-        $upstreamBranches = $upstreamBranches | Where-Object { $_ }
-        if ($upstreamBranches.Count -ne 0) {
-            $upstreamBranches | Assert-ValidBranchName -diagnostics $diagnostics
+    $upstreamBranches = $upstreamBranches | Where-Object { $_ }
+    if ($upstreamBranches.Count -ne 0) {
+        $upstreamBranches | Assert-ValidBranchName -diagnostics $diagnostics
+    }
+    if (Get-HasErrorDiagnostic $diagnostics) { return $null }
+
+    if ($upstreamBranches.Count -eq 0) {
+        $config = Get-Configuration
+        if ($null -eq $config.defaultServiceLine) {
+            Add-ErrorDiagnostic $diagnostics 'At least one upstream branch must be specified or the default service line must be set'
         }
-        if (Get-HasErrorDiagnostic $diagnostics) { return $null }
+        # default to service line if none provided and config has a service line
+        return @( $config.defaultServiceLine )
+    }
 
-        if ($upstreamBranches.Count -eq 0) {
-            $config = Get-Configuration
-            if ($null -eq $config.defaultServiceLine) {
-                Add-ErrorDiagnostic $diagnostics 'At least one upstream branch must be specified or the default service line must be set'
-            }
-            # default to service line if none provided and config has a service line
-            return @( $config.defaultServiceLine )
-        }
-
-        $result = Compress-UpstreamBranches $upstreamBranches -diagnostics:$diagnostics -overrideUpstreams:$overrideUpstreams -branchName:$branchName
-        return $result
+    $result = Compress-UpstreamBranches $upstreamBranches -diagnostics:$diagnostics -overrideUpstreams:$overrideUpstreams -branchName:$branchName
+    return $result
 }
 
 Export-ModuleMember -Function Invoke-SimplifyUpstreamLocalAction

--- a/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
+++ b/utils/actions/local/Register-LocalActionSimplifyUpstreamBranches.psm1
@@ -3,10 +3,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionSimplifyUpstreamBranches([PSObject] $localActions) {
-    $localActions['simplify-upstream'] = ${function:Invoke-SimplifyUpstreamLocalAction}
-}
-
 function Invoke-SimplifyUpstreamLocalAction {
         param(
             [Parameter(Mandatory)][AllowEmptyCollection()][AllowEmptyString()][string[]] $upstreamBranches,
@@ -34,4 +30,4 @@ function Invoke-SimplifyUpstreamLocalAction {
         return $result
 }
 
-Export-ModuleMember -Function Register-LocalActionSimplifyUpstreamBranches
+Export-ModuleMember -Function Invoke-SimplifyUpstreamLocalAction

--- a/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
@@ -4,10 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionUpstreamsUpdated([PSObject] $localActions) {
     # Checks to see if the upstreams are up-to-date
-    $localActions['upstreams-updated'] = ${function:Get-UpstreamUpdatedStatus}
+    $localActions['upstreams-updated'] = ${function:Invoke-UpstreamsUpdatedLocalAction}
  }
  
- function Get-UpstreamUpdatedStatus {
+ function Invoke-UpstreamsUpdatedLocalAction {
         param(
             [Parameter()][AllowEmptyCollection()][string[]] $branches,
             [Parameter()][AllowNull()] $overrideUpstreams,

--- a/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
@@ -2,12 +2,7 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionUpstreamsUpdated([PSObject] $localActions) {
-    # Checks to see if the upstreams are up-to-date
-    $localActions['upstreams-updated'] = ${function:Invoke-UpstreamsUpdatedLocalAction}
- }
- 
- function Invoke-UpstreamsUpdatedLocalAction {
+function Invoke-UpstreamsUpdatedLocalAction {
         param(
             [Parameter()][AllowEmptyCollection()][string[]] $branches,
             [Parameter()][AllowNull()] $overrideUpstreams,
@@ -51,4 +46,4 @@ function Register-LocalActionUpstreamsUpdated([PSObject] $localActions) {
         }
 }
 
-Export-ModuleMember -Function Register-LocalActionUpstreamsUpdated
+Export-ModuleMember -Function Invoke-UpstreamsUpdatedLocalAction

--- a/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
@@ -3,47 +3,47 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Invoke-UpstreamsUpdatedLocalAction {
-        param(
-            [Parameter()][AllowEmptyCollection()][string[]] $branches,
-            [Parameter()][AllowNull()] $overrideUpstreams,
-            [Parameter()][bool] $recurse = $false,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+    param(
+        [Parameter()][AllowEmptyCollection()][string[]] $branches,
+        [Parameter()][AllowNull()] $overrideUpstreams,
+        [Parameter()][bool] $recurse = $false,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
 
-        $selectStandardParams = @{
-            recurse = $recurse
-            overrideUpstreams = $overrideUpstreams
-        }
-        $config = Get-Configuration
-        $prefix = $config.remote ? "refs/remotes/$($config.remote)" : "refs/heads/"
+    $selectStandardParams = @{
+        recurse = $recurse
+        overrideUpstreams = $overrideUpstreams
+    }
+    $config = Get-Configuration
+    $prefix = $config.remote ? "refs/remotes/$($config.remote)" : "refs/heads/"
 
-        $needsUpdate = @{}
-        $isUpdated = @()
-        $noUpstreams = @()
-        foreach ($branch in $branches) {
-            $upstreams = Select-UpstreamBranches -branch $branch @selectStandardParams
-            if (-not $upstreams) {
-                $noUpstreams += $branch
-                continue
-            }
-            $target = "$prefix/$branch"
-            [string[]]$fullyQualifiedUpstreams = $upstreams | ForEach-Object { "$prefix/$_" }
-            [string[]]$upstreamResults = Invoke-ProcessLogs "git for-each-ref --format=`"%(refname:lstrip=3) %(ahead-behind:$target)`" $fullyQualifiedUpstreams" {
-                git for-each-ref --format="%(refname:lstrip=3) %(ahead-behind:$target)" @fullyQualifiedUpstreams
-            } -allowSuccessOutput
-            $outOfDate = ($upstreamResults | Where-Object { ($_ -split ' ')[1] -gt 0 } | ForEach-Object { ($_ -split ' ')[0] })
-            if ($outOfDate.Count -gt 0) {
-                $needsUpdate[$branch] = $outOfDate
-            } else {
-                $isUpdated += $branch
-            }
+    $needsUpdate = @{}
+    $isUpdated = @()
+    $noUpstreams = @()
+    foreach ($branch in $branches) {
+        $upstreams = Select-UpstreamBranches -branch $branch @selectStandardParams
+        if (-not $upstreams) {
+            $noUpstreams += $branch
+            continue
         }
-        
-        return @{
-            noUpstreams = $noUpstreams
-            needsUpdate = $needsUpdate
-            isUpdated = $isUpdated
+        $target = "$prefix/$branch"
+        [string[]]$fullyQualifiedUpstreams = $upstreams | ForEach-Object { "$prefix/$_" }
+        [string[]]$upstreamResults = Invoke-ProcessLogs "git for-each-ref --format=`"%(refname:lstrip=3) %(ahead-behind:$target)`" $fullyQualifiedUpstreams" {
+            git for-each-ref --format="%(refname:lstrip=3) %(ahead-behind:$target)" @fullyQualifiedUpstreams
+        } -allowSuccessOutput
+        $outOfDate = ($upstreamResults | Where-Object { ($_ -split ' ')[1] -gt 0 } | ForEach-Object { ($_ -split ' ')[0] })
+        if ($outOfDate.Count -gt 0) {
+            $needsUpdate[$branch] = $outOfDate
+        } else {
+            $isUpdated += $branch
         }
+    }
+
+    return @{
+        noUpstreams = $noUpstreams
+        needsUpdate = $needsUpdate
+        isUpdated = $isUpdated
+    }
 }
 
 Export-ModuleMember -Function Invoke-UpstreamsUpdatedLocalAction

--- a/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
+++ b/utils/actions/local/Register-LocalActionUpstreamsUpdated.psm1
@@ -4,7 +4,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
 function Register-LocalActionUpstreamsUpdated([PSObject] $localActions) {
     # Checks to see if the upstreams are up-to-date
-    $localActions['upstreams-updated'] = {
+    $localActions['upstreams-updated'] = ${function:Get-UpstreamUpdatedStatus}
+ }
+ 
+ function Get-UpstreamUpdatedStatus {
         param(
             [Parameter()][AllowEmptyCollection()][string[]] $branches,
             [Parameter()][AllowNull()] $overrideUpstreams,
@@ -46,7 +49,6 @@ function Register-LocalActionUpstreamsUpdated([PSObject] $localActions) {
             needsUpdate = $needsUpdate
             isUpdated = $isUpdated
         }
-    }
 }
 
 Export-ModuleMember -Function Register-LocalActionUpstreamsUpdated

--- a/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
+++ b/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
@@ -3,10 +3,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 
 function Register-LocalActionValidateBranchNames([PSObject] $localActions) {
-    $localActions['validate-branch-names'] = ${function:Assert-ValidBranchNames}
+    $localActions['validate-branch-names'] = ${function:Invoke-AssertBranchNamesLocalAction}
 }
 
-function Assert-ValidBranchNames {
+function Invoke-AssertBranchNamesLocalAction {
         param(
             [string[]] $branches,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics

--- a/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
+++ b/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
@@ -3,14 +3,14 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 
 function Invoke-AssertBranchNamesLocalAction {
-        param(
-            [string[]] $branches,
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+    param(
+        [string[]] $branches,
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
 
-        $branches | Assert-ValidBranchName -diagnostics $diagnostics
-        
-        return @{}
+    $branches | Assert-ValidBranchName -diagnostics $diagnostics
+
+    return @{}
 }
 
 Export-ModuleMember -Function Invoke-AssertBranchNamesLocalAction

--- a/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
+++ b/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
@@ -3,7 +3,10 @@ Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 
 function Register-LocalActionValidateBranchNames([PSObject] $localActions) {
-    $localActions['validate-branch-names'] = {
+    $localActions['validate-branch-names'] = ${function:Assert-ValidBranchNames}
+}
+
+function Assert-ValidBranchNames {
         param(
             [string[]] $branches,
             [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
@@ -12,7 +15,6 @@ function Register-LocalActionValidateBranchNames([PSObject] $localActions) {
         $branches | Assert-ValidBranchName -diagnostics $diagnostics
         
         return @{}
-    }
 }
 
 Export-ModuleMember -Function Register-LocalActionValidateBranchNames

--- a/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
+++ b/utils/actions/local/Register-LocalActionValidateBranchNames.psm1
@@ -2,10 +2,6 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 
-function Register-LocalActionValidateBranchNames([PSObject] $localActions) {
-    $localActions['validate-branch-names'] = ${function:Invoke-AssertBranchNamesLocalAction}
-}
-
 function Invoke-AssertBranchNamesLocalAction {
         param(
             [string[]] $branches,
@@ -17,4 +13,4 @@ function Invoke-AssertBranchNamesLocalAction {
         return @{}
 }
 
-Export-ModuleMember -Function Register-LocalActionValidateBranchNames
+Export-ModuleMember -Function Invoke-AssertBranchNamesLocalAction

--- a/utils/actions/template/Register-FinalizeActionXxx.psm1
+++ b/utils/actions/template/Register-FinalizeActionXxx.psm1
@@ -4,15 +4,13 @@ Import-Module -Scope Local "$PSScriptRoot/../../input.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../git.psm1"
 
-function Register-FinalizeActionXxx([PSObject] $finalizeActions) {
-    $finalizeActions['xxx'] = {
-        param(
-            # TODO: add parameters
-            [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
-        )
+function Invoke-XxxFinalizeAction {
+    param(
+        # TODO: add parameters
+        [Parameter()][AllowNull()][AllowEmptyCollection()][System.Collections.ArrayList] $diagnostics
+    )
 
-        return @{}
-    }
+    return @{}
 }
 
-Export-ModuleMember -Function Register-FinalizeActionXxx
+Export-ModuleMember -Function Invoke-XxxFinalizeAction

--- a/utils/actions/template/Register-LocalActionXxx.psm1
+++ b/utils/actions/template/Register-LocalActionXxx.psm1
@@ -2,7 +2,7 @@ Import-Module -Scope Local "$PSScriptRoot/../../core.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../framework.psm1"
 Import-Module -Scope Local "$PSScriptRoot/../../query-state.psm1"
 
-function Register-LocalActionXxx([PSObject] $localActions) {
+function Invoke-XxxLocalAction([PSObject] $localActions) {
     $localActions['xxx'] = {
         param(
             # TODO: add parameters
@@ -13,4 +13,4 @@ function Register-LocalActionXxx([PSObject] $localActions) {
     }
 }
 
-Export-ModuleMember -Function Register-LocalActionXxx
+Export-ModuleMember -Function Invoke-XxxLocalAction


### PR DESCRIPTION
This diff is best viewed with "Ignore Whitespace".

Uses standard pwsh functions and registers them via `${function:...}` syntax instead of having specialized `Register` functions. (Did not rename files in this PR to make diff easier to read.)